### PR TITLE
Set up PyPI packaging and automated publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,68 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Publish target"
+        required: true
+        default: "testpypi"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-caching: true
+
+      - name: Build distributions
+        run: uv build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish-testpypi:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'testpypi'
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'pypi')
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -4,17 +4,41 @@ CLI for DeepVista — manage your knowledge base, VistaBooks, notes, and chat fr
 
 ## Install
 
+### From PyPI (once published)
+
+```bash
+pip install deepvista-cli
+```
+
 ```bash
 uv tool install deepvista-cli
 ```
-
-Or with pipx:
 
 ```bash
 pipx install deepvista-cli
 ```
 
-For development (from this repo):
+### Directly from GitHub (available now)
+
+```bash
+pip install git+https://github.com/DeepVista-AI/deepvista-cli.git
+```
+
+Pin to a specific tag or branch:
+
+```bash
+pip install git+https://github.com/DeepVista-AI/deepvista-cli.git@v0.1.0
+pip install git+https://github.com/DeepVista-AI/deepvista-cli.git@main
+```
+
+Or with uv / pipx:
+
+```bash
+uv tool install git+https://github.com/DeepVista-AI/deepvista-cli.git
+pipx install git+https://github.com/DeepVista-AI/deepvista-cli.git
+```
+
+### For development (from this repo)
 
 ```bash
 uv sync

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,31 @@ name = "deepvista-cli"
 version = "0.1.0"
 description = "CLI for DeepVista — manage your knowledge base, VistaBooks, notes, and chat from the terminal."
 readme = "README.md"
+license = { text = "Apache-2.0" }
 requires-python = ">=3.12"
+authors = [{ name = "DeepVista AI", email = "crew@deepvista.ai" }]
+keywords = ["deepvista", "cli", "knowledge-base", "ai", "notes"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Utilities",
+]
 dependencies = [
     "click>=8.1",
     "filelock>=3.12",
     "httpx>=0.27",
     "rich>=13.0",
 ]
+
+[project.urls]
+Homepage = "https://deepvista.ai"
+Repository = "https://github.com/DeepVista-AI/deepvista-cli"
+Issues = "https://github.com/DeepVista-AI/deepvista-cli/issues"
 
 [project.scripts]
 deepvista = "deepvista_cli.main:cli"

--- a/skills/deepvista-shared/SKILL.md
+++ b/skills/deepvista-shared/SKILL.md
@@ -6,13 +6,38 @@ metadata:
     category: "shared"
     requires:
       bins:
-        - uv
+        - deepvista
     cliHelp: "deepvista --help"
 ---
 
 # DeepVista CLI — Shared Reference
 
 This skill documents authentication, global flags, and security conventions for all DeepVista CLI commands.
+
+## Installation
+
+If `deepvista` is not already installed, install it with any of:
+
+```bash
+# From PyPI
+pip install deepvista-cli
+
+# From GitHub (latest)
+pip install git+https://github.com/DeepVista-AI/deepvista-cli.git
+```
+
+With uv or pipx:
+
+```bash
+uv tool install deepvista-cli
+pipx install deepvista-cli
+```
+
+Verify:
+
+```bash
+deepvista --version
+```
 
 ## Running Commands
 


### PR DESCRIPTION
## Summary

- Add PyPI metadata to `pyproject.toml` (license, authors, classifiers, project URLs)
- Add `.github/workflows/publish.yml` with OIDC Trusted Publisher support — no API tokens needed
- Support both PyPI (on `v*` tag push) and Test PyPI (manual `workflow_dispatch`) targets
- Update README with install instructions for GitHub, PyPI, uv, and pipx

## Test plan

- [x] Verify `uv build` produces valid wheel and sdist
- [x] Trigger workflow manually targeting `testpypi` once Jing sets up environments (DV-155)
- [x] Install from Test PyPI and confirm `deepvista --help` works
- [x] Push a `v*` tag to trigger production publish once Test PyPI validates