### PR TITLE
Remove X-API-Key from CLI auth (DV-141)

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,20 +77,18 @@ deepvista auth logout
 
 ## Profiles
 
-Profiles store `base_url` and `api_key` so you don't need env vars for each environment.
+Profiles store `base_url` so you don't need env vars for each environment.
 
 ### Create a profile
 
 ```bash
 # Local development
 deepvista config set local \
-  --base-url http://localhost:8080 \
-  --api-key <your-local-api-key>
+  --base-url http://localhost:8080
 
 # Staging (Cloud Run)
 deepvista config set staging \
-  --base-url https://deepvista-ai-service-160619978676.us-west1.run.app \
-  --api-key <your-staging-api-key>
+  --base-url https://deepvista-ai-service-160619978676.us-west1.run.app
 ```
 
 ### Use a profile
@@ -113,7 +111,7 @@ deepvista config delete old # delete a profile
 Settings are resolved in this order (first wins):
 
 1. CLI flags (`--base-url`, `--format`, etc.)
-2. Environment variables (`DEEPVISTA_BASE_URL`, `DEEPVISTA_API_KEY`, etc.)
+2. Environment variables (`DEEPVISTA_BASE_URL`, etc.)
 3. Named profile (`--profile local`)
 4. Built-in defaults (staging Cloud Run)
 
@@ -225,7 +223,6 @@ deepvista vistabase list --profile local
 | Variable | Description |
 |----------|-------------|
 | `DEEPVISTA_BASE_URL` | Backend API URL |
-| `DEEPVISTA_API_KEY` | API key for the backend |
 | `DEEPVISTA_SITE_URL` | Web app URL for login (default: `https://app.deepvista.ai`) |
 | `DEEPVISTA_SUPABASE_URL` | Supabase project URL |
 | `DEEPVISTA_CONFIG_DIR` | Config directory (default: `~/.config/deepvista`) |

--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -170,6 +170,28 @@ class DeepVistaClient:
         """HTTP DELETE, returns parsed JSON."""
         return self._request("DELETE", path, params=params)
 
+    def post_long(self, path: str, body: dict | None = None, timeout: int = 300) -> Any:
+        """HTTP POST with a longer timeout for slow agent operations (non-streaming)."""
+        self._log_request("POST (long)", path, body)
+        if self.config.dry_run:
+            click.echo(
+                json.dumps({"dry_run": True, "method": "POST_LONG", "path": path, "body": body}, default=str),
+                err=True,
+            )
+            sys.exit(0)
+
+        try:
+            client = httpx.Client(base_url=self.config.base_url, timeout=timeout)
+            headers = self._auth_headers()
+            resp = client.post(path, headers=headers, json=body or {})
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            self._handle_network_error(exc)
+
+        self._log_response(resp)
+        if resp.status_code >= 400:
+            self._handle_error(resp)
+        return resp.json()
+
     def stream_sse(self, path: str, body: dict | None = None) -> Iterator[dict]:
         """POST with SSE streaming. Yields parsed JSON events as NDJSON."""
         self._log_request("POST (SSE)", path, body)

--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -1,7 +1,6 @@
 """HTTP client that handles auth headers and auto-refresh.
 
 Every request includes:
-  - X-API-Key: <api_key>
   - Authorization: Bearer <jwt>
   - Content-Type: application/json
 
@@ -44,26 +43,9 @@ class DeepVistaClient:
     def _auth_headers(self) -> dict[str, str]:
         """Build auth headers, auto-refreshing token if needed.
 
-        Auth: X-API-Key + Authorization: Bearer <jwt> (from login).
+        Auth: Authorization: Bearer <jwt> (from login).
         """
         headers: dict[str, str] = {"Content-Type": "application/json"}
-
-        # API key is required for all requests
-        if self.config.api_key:
-            headers["X-API-Key"] = self.config.api_key
-        else:
-            click.echo(
-                json.dumps(
-                    {
-                        "error": {
-                            "code": 2,
-                            "message": "No API key. Run: deepvista config set <name> --base-url <url> --api-key <key>",
-                        }
-                    }
-                ),
-                err=True,
-            )
-            sys.exit(EXIT_AUTH_ERROR)
 
         # JWT auth (from credentials file)
         tokens = get_valid_token()

--- a/deepvista_cli/commands/chat.py
+++ b/deepvista_cli/commands/chat.py
@@ -75,20 +75,33 @@ def chat_delete(ctx: click.Context, chat_id: str) -> None:
 @click.argument("message")
 @click.option("--chat-id", default=None, help="Send to existing chat session.")
 @click.option("--new", "new_chat", is_flag=True, default=False, help="Force start a new conversation.")
+@click.option(
+    "--no-stream",
+    "no_stream",
+    is_flag=True,
+    default=False,
+    help="Wait for completion and return a single JSON result instead of streaming.",
+)
 @click.pass_context
-def chat_send(ctx: click.Context, message: str, chat_id: str | None, new_chat: bool) -> None:
+def chat_send(ctx: click.Context, message: str, chat_id: str | None, new_chat: bool, no_stream: bool) -> None:
     """Send a message to the DeepVista AI agent and stream the response.
 
-    Output is NDJSON (one JSON object per line) — each line is an SSE event
-    from the agent's streaming response.
+    By default, output is NDJSON (one JSON object per line) with simplified
+    agent-friendly events: chat_session, tool start/done, text, and done.
+
+    With --no-stream, waits for the full response and prints a single JSON
+    object: {"result": "...", "chat_id": "...", "created_card_id": "..."}.
 
     > [!CAUTION] This is a write command — it creates/updates a chat session
     > and may trigger agent actions (creating cards, searching, etc.).
     """
-    body: dict = {"user_instruction": message}
+    body: dict = {"instruction": message, "stream": not no_stream}
     if chat_id and not new_chat:
         body["chat_id"] = chat_id
-    # If --new is set, we omit chat_id to create a new session
 
-    for event in _client(ctx).stream_sse("/imagine", body):
-        click.echo(json.dumps(event, default=str))
+    if no_stream:
+        data = _client(ctx).post_long("/run", body)
+        click.echo(json.dumps(data, default=str))
+    else:
+        for event in _client(ctx).stream_sse("/run", body):
+            click.echo(json.dumps(event, default=str))

--- a/deepvista_cli/commands/config.py
+++ b/deepvista_cli/commands/config.py
@@ -16,21 +16,20 @@ def config_group() -> None:
 @config_group.command("set")
 @click.argument("profile_name")
 @click.option("--base-url", required=True, help="Backend API URL for this profile.")
-@click.option("--api-key", required=True, help="API key for this profile.")
 @click.option("--site-url", default=None, help="Frontend URL for login (default: https://app.deepvista.ai).")
 @click.pass_context
-def config_set(ctx: click.Context, profile_name: str, base_url: str, api_key: str, site_url: str | None) -> None:
+def config_set(ctx: click.Context, profile_name: str, base_url: str, site_url: str | None) -> None:
     """Create or update a profile.
 
     \b
     Example:
-      deepvista config set local --base-url http://localhost:8080 --api-key dvsa_xxx --site-url http://localhost:3000
+      deepvista config set local --base-url http://localhost:8080 --site-url http://localhost:3000
     """
-    settings: dict = {"base_url": base_url, "api_key": api_key}
+    settings: dict = {"base_url": base_url}
     if site_url:
         settings["site_url"] = site_url
     set_profile(profile_name, settings)
-    output = {"profile": profile_name, "base_url": base_url, "api_key": f"{api_key[:4]}****"}
+    output: dict = {"profile": profile_name, "base_url": base_url}
     if site_url:
         output["site_url"] = site_url
     format_output(output, ctx.obj.output_format)
@@ -44,17 +43,11 @@ def config_list(ctx: click.Context) -> None:
     profiles = list_profiles()
     if not profiles:
         click.echo(
-            "No profiles configured. Create one with: deepvista config set <name> --base-url ... --api-key ...",
+            "No profiles configured. Create one with: deepvista config set <name> --base-url ...",
             err=True,
         )
         return
-    # Mask API keys in output
-    masked = {}
-    for name, settings in profiles.items():
-        masked[name] = {**settings}
-        if "api_key" in masked[name]:
-            masked[name]["api_key"] = masked[name]["api_key"][:4] + "****"
-    format_output(masked, ctx.obj.output_format, title="Profiles")
+    format_output(profiles, ctx.obj.output_format, title="Profiles")
 
 
 @config_group.command("show")
@@ -66,10 +59,7 @@ def config_show(ctx: click.Context, profile_name: str) -> None:
     if not profile:
         click.echo(f"Profile '{profile_name}' not found.", err=True)
         return
-    masked = {**profile}
-    if "api_key" in masked:
-        masked["api_key"] = masked["api_key"][:4] + "****"
-    format_output(masked, ctx.obj.output_format, title=f"Profile: {profile_name}")
+    format_output(profile, ctx.obj.output_format, title=f"Profile: {profile_name}")
 
 
 @config_group.command("delete")

--- a/deepvista_cli/commands/vistabook.py
+++ b/deepvista_cli/commands/vistabook.py
@@ -73,28 +73,40 @@ def vistabook_get(ctx: click.Context, vistabook_id: str) -> None:
 @vistabook_group.command("+run")
 @click.argument("vistabook_id")
 @click.option("--input", "user_input", default=None, help="Context or instructions for the run.")
+@click.option(
+    "--no-stream",
+    "no_stream",
+    is_flag=True,
+    default=False,
+    help="Wait for completion and return a single JSON result instead of streaming.",
+)
 @click.pass_context
-def vistabook_run(ctx: click.Context, vistabook_id: str, user_input: str | None) -> None:
+def vistabook_run(ctx: click.Context, vistabook_id: str, user_input: str | None, no_stream: bool) -> None:
     """Start a VistaBook run — executes the workflow via the chat agent.
 
     > [!CAUTION] This is a write command — it creates a new VistaBook run and sends
     > messages to the chat agent. Confirm with the user before executing.
 
-    Output is NDJSON (one JSON object per line) as the agent streams its response.
+    By default, output is NDJSON (one JSON object per line) with simplified
+    agent-friendly events: chat_session, tool start/done, text, and done.
+
+    With --no-stream, waits for the full response and prints a single JSON
+    object: {"result": "...", "chat_id": "...", "created_card_id": "..."}.
     """
     _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
     if not _UUID_RE.match(vistabook_id):
         output_error(3, "Invalid vistabook ID", f"Expected UUID format, got: {vistabook_id!r}")
 
-    # Note: context_card_id triggers watch mode on /imagine, NOT chat processing.
-    # Pass the vistabook reference in user_instruction instead.
-    instruction = user_input or "Run this vistabook"
-    body: dict = {
-        "user_instruction": f"[vistabook:{vistabook_id}] {instruction}",
-    }
+    # Pass the vistabook reference in the instruction so the agent loads the card.
+    instruction = f"[vistabook:{vistabook_id}] {user_input or 'Run this vistabook'}"
+    body: dict = {"instruction": instruction, "stream": not no_stream}
 
-    for event in _client(ctx).stream_sse("/imagine", body):
-        click.echo(json.dumps(event, default=str))
+    if no_stream:
+        data = _client(ctx).post_long("/run", body)
+        click.echo(json.dumps(data, default=str))
+    else:
+        for event in _client(ctx).stream_sse("/run", body):
+            click.echo(json.dumps(event, default=str))
 
 
 @vistabook_group.command("+status")

--- a/deepvista_cli/config.py
+++ b/deepvista_cli/config.py
@@ -34,9 +34,6 @@ SUPABASE_ANON_KEY = os.environ.get(
     ".Ae6jkDZ4vHBAjFsRxCoiy_QdRTMnTQ6Se6b5iQfFdDU",
 )
 
-# Default API key — loaded from env var or profile. No hardcoded fallback.
-DEFAULT_API_KEY = ""
-
 # ---------------------------------------------------------------------------
 # Exit codes (following GWS pattern)
 # ---------------------------------------------------------------------------
@@ -65,7 +62,7 @@ def _load_profiles() -> dict:
 
 
 def _save_profiles(profiles: dict) -> None:
-    """Save profiles to ~/.config/deepvista/config.json (mode 0600 — contains API keys)."""
+    """Save profiles to ~/.config/deepvista/config.json (mode 0600)."""
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     PROFILES_PATH.write_text(json.dumps(profiles, indent=2))
     PROFILES_PATH.chmod(0o600)
@@ -108,7 +105,6 @@ class CLIConfig:
     """Resolved configuration for a single CLI invocation."""
 
     base_url: str = field(default_factory=lambda: os.environ.get("DEEPVISTA_BASE_URL", DEFAULT_BASE_URL))
-    api_key: str = field(default_factory=lambda: os.environ.get("DEEPVISTA_API_KEY", DEFAULT_API_KEY))
     site_url: str = field(default_factory=lambda: os.environ.get("DEEPVISTA_SITE_URL", "https://app.deepvista.ai"))
     output_format: str = DEFAULT_FORMAT
     verbose: bool = False
@@ -124,8 +120,6 @@ class CLIConfig:
         # Profile values are overridden by env vars
         if not os.environ.get("DEEPVISTA_BASE_URL") and "base_url" in profile:
             self.base_url = profile["base_url"]
-        if not os.environ.get("DEEPVISTA_API_KEY") and "api_key" in profile:
-            self.api_key = profile["api_key"]
         if not os.environ.get("DEEPVISTA_SITE_URL") and "site_url" in profile:
             self.site_url = profile["site_url"]
 


### PR DESCRIPTION
## Summary

- Removes the `X-API-Key` header from all CLI requests — the static API key was a long-lived, non-rotating credential that added setup friction without any security benefit over the existing Supabase JWT
- Drops `api_key` from `CLIConfig`, profile storage, and the `config set` command
- Removes `DEEPVISTA_API_KEY` env var support
- Cleans up README profile examples and env var table

## Security rationale

The Supabase JWT Bearer token already provides strong authentication:
- Cryptographically signed, verifiable without a shared secret
- Contains user identity (`user_id`, `email`)
- Short-lived (~1 hour), auto-rotates via refresh tokens

The static API key by contrast:
- Never rotates — a leaked key in dotfiles stays valid indefinitely
- Stored in plaintext JSON (`~/.config/deepvista/config.json`)
- Required users to manage two separate credentials (login + config set)

Relates to: [DV-141](https://linear.app/deepvista/issue/DV-141/remove-api-key-from-cli-auth)

## Test plan

- [ ] `deepvista auth login` still works (JWT flow unaffected)
- [ ] `deepvista config set <name> --base-url <url>` works without `--api-key`
- [ ] Existing profiles with `api_key` in JSON are silently ignored (field not read)
- [ ] All requests succeed with only `Authorization: Bearer <jwt>` header

> **Note for backend team:** The backend API must also stop requiring `X-API-Key` header validation for this change to take full effect.