### PR TITLE
Fix CI workflow warnings: setup-uv v6 and enable-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
         with:
-          enable-caching: true
+          enable-cache: true
 
       - name: Install dependencies
         run: uv sync --frozen

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
         with:
-          enable-caching: true
+          enable-cache: true
 
       - name: Build distributions
         run: uv build


### PR DESCRIPTION
## Summary

- Update `astral-sh/setup-uv` from `v5` → `v6` in both `ci.yml` and `publish.yml`
- Rename deprecated `enable-caching` input to `enable-cache`

## Why

Both changes surfaced as warnings in the `v0.1.0a1` publish run:
- `enable-caching` is not a valid input in setup-uv v5+ (correct key is `enable-cache`)
- setup-uv v6 adds Node.js 24 support ahead of the June 2026 GitHub Actions deprecation deadline

## Test plan

- [ ] Verify CI passes on this PR with no `enable-caching` warnings