### PR TITLE
Refactor CLI config: api_url/auth_url rename, drop X-API-Key, per-profile credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ deepvista auth login --code <base64_auth_code>
 ### Self-hosted / staging
 
 ```bash
-export DEEPVISTA_SITE_URL=https://staging.deepvista.ai
+export DEEPVISTA_AUTH_URL=https://staging.deepvista.ai
 deepvista auth login
 ```
 
@@ -77,20 +77,16 @@ deepvista auth logout
 
 ## Profiles
 
-Profiles store `base_url` and `api_key` so you don't need env vars for each environment.
+Profiles store `api_url` so you don't need env vars for each environment.
 
 ### Create a profile
 
 ```bash
 # Local development
-deepvista config set local \
-  --base-url http://localhost:8080 \
-  --api-key <your-local-api-key>
+deepvista config set local --api-url http://localhost:8080
 
-# Staging (Cloud Run)
-deepvista config set staging \
-  --base-url https://deepvista-ai-service-160619978676.us-west1.run.app \
-  --api-key <your-staging-api-key>
+# Staging
+deepvista config set staging --api-url https://api-staging.deepvista.ai
 ```
 
 ### Use a profile
@@ -112,10 +108,10 @@ deepvista config delete old # delete a profile
 
 Settings are resolved in this order (first wins):
 
-1. CLI flags (`--base-url`, `--format`, etc.)
-2. Environment variables (`DEEPVISTA_BASE_URL`, `DEEPVISTA_API_KEY`, etc.)
+1. CLI flags (`--api-url`, `--format`, etc.)
+2. Environment variables (`DEEPVISTA_API_URL`, etc.)
 3. Named profile (`--profile local`)
-4. Built-in defaults (staging Cloud Run)
+4. Built-in default (`https://api.deepvista.ai`)
 
 ## Commands
 
@@ -189,7 +185,7 @@ Chat output is NDJSON (one JSON object per line) streamed from the agent.
 | `--format json\|table` | `json` | Output format |
 | `--verbose` | off | Show HTTP request/response details |
 | `--dry-run` | off | Show what would be sent, don't execute |
-| `--base-url URL` | staging | Override backend URL |
+| `--api-url URL` | staging | Override backend URL |
 | `--profile NAME` | `default` | Use a named config profile |
 
 **Global flags must come before the service name:**
@@ -224,9 +220,8 @@ deepvista vistabase list --profile local
 
 | Variable | Description |
 |----------|-------------|
-| `DEEPVISTA_BASE_URL` | Backend API URL |
-| `DEEPVISTA_API_KEY` | API key for the backend |
-| `DEEPVISTA_SITE_URL` | Web app URL for login (default: `https://app.deepvista.ai`) |
+| `DEEPVISTA_API_URL` | Backend API URL (default: `https://api.deepvista.ai`) |
+| `DEEPVISTA_AUTH_URL` | Auth app URL for login (default: `https://app.deepvista.ai`) |
 | `DEEPVISTA_SUPABASE_URL` | Supabase project URL |
 | `DEEPVISTA_CONFIG_DIR` | Config directory (default: `~/.config/deepvista`) |
 

--- a/deepvista_cli/__init__.py
+++ b/deepvista_cli/__init__.py
@@ -1,3 +1,3 @@
 """DeepVista CLI — manage your knowledge base, VistaBooks, notes, and chat from the terminal."""
 
-__version__ = "0.1.0a1"
+__version__ = "0.1.0a2"

--- a/deepvista_cli/auth/login.py
+++ b/deepvista_cli/auth/login.py
@@ -14,19 +14,20 @@ import base64
 import json
 import time
 import webbrowser
+from pathlib import Path
 
 import click
 
 from deepvista_cli.auth.tokens import TokenSet, save_tokens
 
 
-def login_interactive(site_url: str = "https://app.deepvista.ai") -> None:
+def login_interactive(auth_url: str = "https://app.deepvista.ai") -> None:
     """Open browser to the login page and exit.
 
     The browser page will show the full `deepvista auth login --code <b64>`
     command for the user to copy and paste back into the terminal.
     """
-    login_url = f"{site_url}/auth/cli"
+    login_url = f"{auth_url}/auth/cli"
 
     click.echo("", err=True)
     click.echo("  Opening browser to: " + login_url, err=True)
@@ -38,7 +39,7 @@ def login_interactive(site_url: str = "https://app.deepvista.ai") -> None:
     webbrowser.open(login_url)
 
 
-def login_with_code(code: str) -> TokenSet:
+def login_with_code(code: str, credentials_path: Path | None = None) -> TokenSet:
     """Decode and store a base64-encoded auth code from the /auth/cli page.
 
     The code is base64(JSON) containing:
@@ -64,5 +65,5 @@ def login_with_code(code: str) -> TokenSet:
         user_id=user.get("id", ""),
         email=user.get("email", ""),
     )
-    save_tokens(tokens)
+    save_tokens(tokens, credentials_path)
     return tokens

--- a/deepvista_cli/auth/tokens.py
+++ b/deepvista_cli/auth/tokens.py
@@ -13,11 +13,13 @@ import os
 import tempfile
 import time
 from dataclasses import dataclass
+from pathlib import Path
 
 import httpx
 from filelock import FileLock
 
-from deepvista_cli.config import CONFIG_DIR, CREDENTIALS_PATH, SUPABASE_ANON_KEY, SUPABASE_URL
+from deepvista_cli.config import CONFIG_DIR, SUPABASE_ANON_KEY, SUPABASE_URL
+from deepvista_cli.config import credentials_path as _default_creds_path
 
 logger = logging.getLogger(__name__)
 
@@ -61,40 +63,43 @@ class TokenSet:
 # ---------------------------------------------------------------------------
 
 
-def save_tokens(tokens: TokenSet) -> None:
-    """Persist tokens to ~/.config/deepvista/credentials.json (mode 0600).
+def save_tokens(tokens: TokenSet, path: Path | None = None) -> None:
+    """Persist tokens to a per-profile credentials file (mode 0600).
 
     Writes atomically via a temp file so the credentials file is never
     world-readable, even briefly (avoids TOCTOU between write and chmod).
     """
+    creds = path or _default_creds_path()
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(dir=CONFIG_DIR, prefix=".credentials.", suffix=".tmp")
     try:
         os.chmod(tmp_path, 0o600)
         with os.fdopen(fd, "w") as f:
             f.write(json.dumps(tokens.to_dict(), indent=2))
-        os.replace(tmp_path, CREDENTIALS_PATH)
+        os.replace(tmp_path, creds)
     except Exception:
         os.unlink(tmp_path)
         raise
-    logger.debug("Tokens saved to %s", CREDENTIALS_PATH)
+    logger.debug("Tokens saved to %s", creds)
 
 
-def load_tokens() -> TokenSet | None:
-    """Load tokens from credentials file."""
-    if CREDENTIALS_PATH.exists():
+def load_tokens(path: Path | None = None) -> TokenSet | None:
+    """Load tokens from a per-profile credentials file."""
+    creds = path or _default_creds_path()
+    if creds.exists():
         try:
-            data = json.loads(CREDENTIALS_PATH.read_text())
+            data = json.loads(creds.read_text())
             return TokenSet.from_dict(data)
         except (json.JSONDecodeError, KeyError):
-            logger.warning("Corrupt credentials file at %s", CREDENTIALS_PATH)
+            logger.warning("Corrupt credentials file at %s", creds)
     return None
 
 
-def delete_tokens() -> None:
-    """Remove stored tokens."""
-    if CREDENTIALS_PATH.exists():
-        CREDENTIALS_PATH.unlink()
+def delete_tokens(path: Path | None = None) -> None:
+    """Remove stored tokens for a profile."""
+    creds = path or _default_creds_path()
+    if creds.exists():
+        creds.unlink()
 
 
 def refresh_access_token(refresh_token: str) -> TokenSet:
@@ -124,21 +129,22 @@ def refresh_access_token(refresh_token: str) -> TokenSet:
     )
 
 
-def get_valid_token() -> TokenSet | None:
+def get_valid_token(path: Path | None = None) -> TokenSet | None:
     """Load tokens and auto-refresh if expired. Returns None if not authenticated."""
-    tokens = load_tokens()
+    creds = path or _default_creds_path()
+    tokens = load_tokens(creds)
     if tokens is None:
         return None
 
     if tokens.is_expired and tokens.refresh_token:
-        lock_path = CREDENTIALS_PATH.with_suffix(".lock")
+        lock_path = creds.with_suffix(".lock")
         with FileLock(str(lock_path), timeout=10):
             # Re-read inside the lock in case a parallel invocation already refreshed.
-            tokens = load_tokens() or tokens
+            tokens = load_tokens(creds) or tokens
             if tokens.is_expired:
                 try:
                     tokens = refresh_access_token(tokens.refresh_token)
-                    save_tokens(tokens)
+                    save_tokens(tokens, creds)
                 except httpx.HTTPStatusError as e:
                     logger.error("Token refresh failed: HTTP %s", e.response.status_code)
                     return None

--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -1,7 +1,6 @@
 """HTTP client that handles auth headers and auto-refresh.
 
 Every request includes:
-  - X-API-Key: <api_key>
   - Authorization: Bearer <jwt>
   - Content-Type: application/json
 
@@ -21,7 +20,7 @@ import click
 import httpx
 
 from deepvista_cli.auth.tokens import get_valid_token
-from deepvista_cli.config import EXIT_API_ERROR, EXIT_AUTH_ERROR, EXIT_NETWORK_ERROR, CLIConfig
+from deepvista_cli.config import EXIT_API_ERROR, EXIT_AUTH_ERROR, EXIT_NETWORK_ERROR, CLIConfig, credentials_path
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ class DeepVistaClient:
     def _get_client(self) -> httpx.Client:
         if self._client is None:
             self._client = httpx.Client(
-                base_url=self.config.base_url,
+                base_url=self.config.api_url,
                 timeout=30,
             )
         return self._client
@@ -44,29 +43,12 @@ class DeepVistaClient:
     def _auth_headers(self) -> dict[str, str]:
         """Build auth headers, auto-refreshing token if needed.
 
-        Auth: X-API-Key + Authorization: Bearer <jwt> (from login).
+        Auth: Authorization: Bearer <jwt> (from login).
         """
         headers: dict[str, str] = {"Content-Type": "application/json"}
 
-        # API key is required for all requests
-        if self.config.api_key:
-            headers["X-API-Key"] = self.config.api_key
-        else:
-            click.echo(
-                json.dumps(
-                    {
-                        "error": {
-                            "code": 2,
-                            "message": "No API key. Run: deepvista config set <name> --base-url <url> --api-key <key>",
-                        }
-                    }
-                ),
-                err=True,
-            )
-            sys.exit(EXIT_AUTH_ERROR)
-
-        # JWT auth (from credentials file)
-        tokens = get_valid_token()
+        # JWT auth (from per-profile credentials file)
+        tokens = get_valid_token(credentials_path(self.config.profile))
         if tokens is not None and tokens.access_token:
             headers["Authorization"] = f"Bearer {tokens.access_token}"
             return headers
@@ -87,7 +69,7 @@ class DeepVistaClient:
 
     def _log_request(self, method: str, path: str, body: Any = None) -> None:
         if self.config.verbose:
-            click.echo(f">>> {method} {self.config.base_url}{path}", err=True)
+            click.echo(f">>> {method} {self.config.api_url}{path}", err=True)
             if body:
                 click.echo(f">>> Body: {json.dumps(body, default=str)}", err=True)
 
@@ -98,10 +80,10 @@ class DeepVistaClient:
     def _handle_network_error(self, exc: httpx.ConnectError | httpx.TimeoutException) -> NoReturn:
         """Handle network-level errors with structured output."""
         if isinstance(exc, httpx.ConnectError):
-            msg = f"Cannot connect to {self.config.base_url}"
+            msg = f"Cannot connect to {self.config.api_url}"
             detail = str(exc)
         else:
-            msg = f"Request timed out to {self.config.base_url}"
+            msg = f"Request timed out to {self.config.api_url}"
             detail = str(exc)
         err = {"error": {"code": EXIT_NETWORK_ERROR, "message": msg, "detail": detail}}
         click.echo(json.dumps(err, indent=2), err=True)

--- a/deepvista_cli/commands/auth.py
+++ b/deepvista_cli/commands/auth.py
@@ -8,6 +8,7 @@ import click
 
 from deepvista_cli.auth.login import login_interactive, login_with_code
 from deepvista_cli.auth.tokens import delete_tokens, load_tokens
+from deepvista_cli.config import credentials_path
 from deepvista_cli.output.formatter import format_output, output_error
 
 
@@ -31,7 +32,7 @@ def auth_login(ctx: click.Context, code: str | None) -> None:
       deepvista auth login --code <base64_code>
     """
     if code:
-        tokens = login_with_code(code)
+        tokens = login_with_code(code, credentials_path(ctx.obj.profile))
         result = {
             "status": "authenticated",
             "email": tokens.email,
@@ -40,14 +41,14 @@ def auth_login(ctx: click.Context, code: str | None) -> None:
         format_output(result, ctx.obj.output_format)
         click.echo(f"  Logged in as {tokens.email or tokens.user_id}", err=True)
     else:
-        login_interactive(site_url=ctx.obj.site_url)
+        login_interactive(auth_url=ctx.obj.auth_url)
 
 
 @auth_group.command("status")
 @click.pass_context
 def auth_status(ctx: click.Context) -> None:
     """Show current authentication state."""
-    tokens = load_tokens()
+    tokens = load_tokens(credentials_path(ctx.obj.profile))
     if tokens is None:
         output_error(2, "Not authenticated. Run: deepvista auth login")
         return
@@ -67,7 +68,7 @@ def auth_status(ctx: click.Context) -> None:
 @click.pass_context
 def auth_logout(ctx: click.Context) -> None:
     """Clear stored credentials."""
-    delete_tokens()
+    delete_tokens(credentials_path(ctx.obj.profile))
     result = {"status": "logged_out"}
     format_output(result, ctx.obj.output_format)
     click.echo("  Logged out.", err=True)

--- a/deepvista_cli/commands/config.py
+++ b/deepvista_cli/commands/config.py
@@ -15,24 +15,23 @@ def config_group() -> None:
 
 @config_group.command("set")
 @click.argument("profile_name")
-@click.option("--base-url", required=True, help="Backend API URL for this profile.")
-@click.option("--api-key", required=True, help="API key for this profile.")
-@click.option("--site-url", default=None, help="Frontend URL for login (default: https://app.deepvista.ai).")
+@click.option("--api-url", required=True, help="Backend API URL for this profile.")
+@click.option("--auth-url", default=None, help="Frontend URL for login (default: https://app.deepvista.ai).")
 @click.pass_context
-def config_set(ctx: click.Context, profile_name: str, base_url: str, api_key: str, site_url: str | None) -> None:
+def config_set(ctx: click.Context, profile_name: str, api_url: str, auth_url: str | None) -> None:
     """Create or update a profile.
 
     \b
     Example:
-      deepvista config set local --base-url http://localhost:8080 --api-key dvsa_xxx --site-url http://localhost:3000
+      deepvista config set local --api-url http://localhost:8080 --auth-url http://localhost:3000
     """
-    settings: dict = {"base_url": base_url, "api_key": api_key}
-    if site_url:
-        settings["site_url"] = site_url
+    settings: dict = {"api_url": api_url}
+    if auth_url:
+        settings["auth_url"] = auth_url
     set_profile(profile_name, settings)
-    output = {"profile": profile_name, "base_url": base_url, "api_key": f"{api_key[:4]}****"}
-    if site_url:
-        output["site_url"] = site_url
+    output: dict = {"profile": profile_name, "api_url": api_url}
+    if auth_url:
+        output["auth_url"] = auth_url
     format_output(output, ctx.obj.output_format)
     click.echo(f"Profile '{profile_name}' saved.", err=True)
 
@@ -44,17 +43,11 @@ def config_list(ctx: click.Context) -> None:
     profiles = list_profiles()
     if not profiles:
         click.echo(
-            "No profiles configured. Create one with: deepvista config set <name> --base-url ... --api-key ...",
+            "No profiles configured. Create one with: deepvista config set <name> --api-url ...",
             err=True,
         )
         return
-    # Mask API keys in output
-    masked = {}
-    for name, settings in profiles.items():
-        masked[name] = {**settings}
-        if "api_key" in masked[name]:
-            masked[name]["api_key"] = masked[name]["api_key"][:4] + "****"
-    format_output(masked, ctx.obj.output_format, title="Profiles")
+    format_output(profiles, ctx.obj.output_format, title="Profiles")
 
 
 @config_group.command("show")
@@ -66,10 +59,7 @@ def config_show(ctx: click.Context, profile_name: str) -> None:
     if not profile:
         click.echo(f"Profile '{profile_name}' not found.", err=True)
         return
-    masked = {**profile}
-    if "api_key" in masked:
-        masked["api_key"] = masked["api_key"][:4] + "****"
-    format_output(masked, ctx.obj.output_format, title=f"Profile: {profile_name}")
+    format_output(profile, ctx.obj.output_format, title=f"Profile: {profile_name}")
 
 
 @config_group.command("delete")

--- a/deepvista_cli/config.py
+++ b/deepvista_cli/config.py
@@ -18,10 +18,23 @@ from pathlib import Path
 # Defaults
 # ---------------------------------------------------------------------------
 
-DEFAULT_BASE_URL = "https://deepvista-ai-service-160619978676.us-west1.run.app"
+DEFAULT_API_URL = "https://api.deepvista.ai"
+STAGING_API_URL = "https://api-staging.deepvista.ai"
 DEFAULT_FORMAT = "json"
 CONFIG_DIR = Path(os.environ.get("DEEPVISTA_CONFIG_DIR", Path.home() / ".config" / "deepvista"))
-CREDENTIALS_PATH = CONFIG_DIR / "credentials.json"
+
+
+def credentials_path(profile: str = "default") -> Path:
+    """Return the credentials file path for a given profile.
+
+    Each profile gets its own file so staging and production tokens
+    never overwrite each other:
+      default  -> ~/.config/deepvista/credentials.default.json
+      staging  -> ~/.config/deepvista/credentials.staging.json
+    """
+    return CONFIG_DIR / f"credentials.{profile}.json"
+
+
 PROFILES_PATH = CONFIG_DIR / "config.json"
 
 # Supabase project coordinates (needed for PKCE auth + token refresh)
@@ -34,8 +47,6 @@ SUPABASE_ANON_KEY = os.environ.get(
     ".Ae6jkDZ4vHBAjFsRxCoiy_QdRTMnTQ6Se6b5iQfFdDU",
 )
 
-# Default API key — loaded from env var or profile. No hardcoded fallback.
-DEFAULT_API_KEY = ""
 
 # ---------------------------------------------------------------------------
 # Exit codes (following GWS pattern)
@@ -107,9 +118,8 @@ def delete_profile(name: str) -> bool:
 class CLIConfig:
     """Resolved configuration for a single CLI invocation."""
 
-    base_url: str = field(default_factory=lambda: os.environ.get("DEEPVISTA_BASE_URL", DEFAULT_BASE_URL))
-    api_key: str = field(default_factory=lambda: os.environ.get("DEEPVISTA_API_KEY", DEFAULT_API_KEY))
-    site_url: str = field(default_factory=lambda: os.environ.get("DEEPVISTA_SITE_URL", "https://app.deepvista.ai"))
+    api_url: str = field(default_factory=lambda: os.environ.get("DEEPVISTA_API_URL", DEFAULT_API_URL))
+    auth_url: str = field(default_factory=lambda: os.environ.get("DEEPVISTA_AUTH_URL", "https://app.deepvista.ai"))
     output_format: str = DEFAULT_FORMAT
     verbose: bool = False
     dry_run: bool = False
@@ -122,12 +132,10 @@ class CLIConfig:
             return
 
         # Profile values are overridden by env vars
-        if not os.environ.get("DEEPVISTA_BASE_URL") and "base_url" in profile:
-            self.base_url = profile["base_url"]
-        if not os.environ.get("DEEPVISTA_API_KEY") and "api_key" in profile:
-            self.api_key = profile["api_key"]
-        if not os.environ.get("DEEPVISTA_SITE_URL") and "site_url" in profile:
-            self.site_url = profile["site_url"]
+        if not os.environ.get("DEEPVISTA_API_URL") and "api_url" in profile:
+            self.api_url = profile["api_url"]
+        if not os.environ.get("DEEPVISTA_AUTH_URL") and "auth_url" in profile:
+            self.auth_url = profile["auth_url"]
 
     def ensure_config_dir(self) -> Path:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)

--- a/deepvista_cli/main.py
+++ b/deepvista_cli/main.py
@@ -8,7 +8,7 @@ Global flags:
   --format json|table   Output format (default: json)
   --verbose             Show HTTP request/response details
   --dry-run             Show what would be sent without executing
-  --base-url URL        Override backend URL
+  --api-url URL        Override backend URL
   --profile NAME        Use a named config profile (local, staging, etc.)
   --version             Show version and exit
 """
@@ -25,7 +25,7 @@ from deepvista_cli.commands.config import config_group
 from deepvista_cli.commands.notes import notes_group
 from deepvista_cli.commands.vistabase import vistabase_group
 from deepvista_cli.commands.vistabook import vistabook_group
-from deepvista_cli.config import DEFAULT_BASE_URL, CLIConfig
+from deepvista_cli.config import DEFAULT_API_URL, CLIConfig
 
 
 @click.group()
@@ -33,11 +33,11 @@ from deepvista_cli.config import DEFAULT_BASE_URL, CLIConfig
 @click.option("--format", "output_format", type=click.Choice(["json", "table"]), default="json", help="Output format.")
 @click.option("--verbose", is_flag=True, default=False, help="Show HTTP request/response details.")
 @click.option("--dry-run", is_flag=True, default=False, help="Show what would be sent without executing.")
-@click.option("--base-url", default=None, help=f"Override backend URL (default: {DEFAULT_BASE_URL}).")
+@click.option("--api-url", default=None, help=f"Override backend URL (default: {DEFAULT_API_URL}).")
 @click.option("--profile", default="default", help="Use a named config profile (e.g. local, staging).")
 @click.pass_context
 def cli(
-    ctx: click.Context, output_format: str, verbose: bool, dry_run: bool, base_url: str | None, profile: str
+    ctx: click.Context, output_format: str, verbose: bool, dry_run: bool, api_url: str | None, profile: str
 ) -> None:
     """DeepVista CLI — manage your knowledge base, VistaBooks, notes, and chat."""
     config = CLIConfig(
@@ -51,8 +51,8 @@ def cli(
     config.apply_profile(profile)
 
     # CLI flag overrides everything
-    if base_url:
-        config.base_url = base_url
+    if api_url:
+        config.api_url = api_url
 
     # Attach config + lazy client to context
     ctx.ensure_object(CLIConfig)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "CLI for DeepVista — manage your knowledge base, VistaBooks, notes, and chat from the terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/skills/deepvista-shared/SKILL.md
+++ b/skills/deepvista-shared/SKILL.md
@@ -106,7 +106,7 @@ Global flags go BEFORE the service name.
 | `--format json\|table` | `json` | Output format. JSON is default (agent-friendly). |
 | `--verbose` | off | Show HTTP request/response details on stderr. |
 | `--dry-run` | off | Show what would be sent without executing. |
-| `--base-url URL` | — | Override backend URL. |
+| `--api-url URL` | — | Override backend URL. |
 | `--version` | — | Show version and exit. |
 | `--help` | — | Show help for any command. |
 

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.0a1"
+version = "0.1.0a2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Rename `base_url` → `api_url` and `site_url` → `auth_url` throughout CLI, README, and skills
- Remove `X-API-Key` header — backend now uses JWT-only auth
- Per-profile credentials storage: `~/.config/deepvista/credentials.{profile}.json` so staging and production sessions never overwrite each other
- Update `DEFAULT_API_URL` to `https://api.deepvista.ai` (Cloudflare custom domain backed by Cloud Run domain mapping)
- Bump version to `0.1.0a2`

## Test plan
- [ ] `deepvista auth login` stores tokens in `credentials.default.json`
- [ ] `deepvista --profile staging auth login` stores tokens in `credentials.staging.json`
- [ ] `deepvista --api-url http://localhost:8080 config set local` works without `--api-key`
- [ ] Requests only send `Authorization: Bearer <jwt>`, no `X-API-Key`