### PR TITLE
Fix pagination: use offset instead of page_number for list commands

### DIFF
--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -39,11 +39,11 @@ def notes_list(ctx: click.Context, limit: int, page_number: int) -> None:
         {
             "card_type": "note",
             "limit": limit,
-            "page_number": page_number,
+            "offset": (page_number - 1) * limit,
         },
     )
     cards = data.get("cards", [])
-    result = {"notes": cards, "count": len(cards), "has_more": data.get("has_more", False)}
+    result = {"notes": cards, "count": len(cards), "page": page_number, "has_more": data.get("has_more", False)}
     format_output(result, ctx.obj.output_format, columns=NOTE_COLUMNS, title="Notes")
 
 

--- a/deepvista_cli/commands/vistabase.py
+++ b/deepvista_cli/commands/vistabase.py
@@ -75,7 +75,7 @@ def vistabase_list(
     order_direction: str | None,
 ) -> None:
     """List context cards with optional filtering."""
-    body: dict = {"limit": limit, "page_number": page_number}
+    body: dict = {"limit": limit, "offset": (page_number - 1) * limit}
     if card_type:
         body["card_type"] = card_type
     if display_status:
@@ -89,7 +89,7 @@ def vistabase_list(
     cards = data.get("cards", [])
     result = {
         "cards": cards,
-        "page": data.get("page_number", page_number),
+        "page": page_number,
         "has_more": data.get("has_more", False),
         "count": len(cards),
     }

--- a/deepvista_cli/commands/vistabook.py
+++ b/deepvista_cli/commands/vistabook.py
@@ -45,11 +45,11 @@ def vistabook_list(ctx: click.Context, limit: int, page_number: int) -> None:
         {
             "card_type": "vistabook",
             "limit": limit,
-            "page_number": page_number,
+            "offset": (page_number - 1) * limit,
         },
     )
     cards = data.get("cards", [])
-    result = {"vistabooks": cards, "count": len(cards), "has_more": data.get("has_more", False)}
+    result = {"vistabooks": cards, "count": len(cards), "page": page_number, "has_more": data.get("has_more", False)}
     format_output(result, ctx.obj.output_format, columns=VISTABOOK_COLUMNS, title="VistaBooks")
 
 


### PR DESCRIPTION
## Summary
- `notes list`, `vistabase list`, `vistabook list` were sending `page_number` to the API, which the API ignores — causing `--page 2` to return the same results as `--page 1`
- Fixed by computing `offset = (page_number - 1) * limit` and sending `offset` instead, matching how `chat sessions` already works
- Added `page` field to `notes list` and `vistabook list` output for consistency with `vistabase list`

Closes DV-209

## Test plan
- [ ] `deepvista notes list --limit 10 --page 1` returns first 10 notes
- [ ] `deepvista notes list --limit 10 --page 2` returns the next 10 (different results)
- [ ] Same for `vistabase list` and `vistabook list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)