### PR TITLE
Add auto-trigger notes analysis recipe and INSTALL_PROMPT.md

### DIFF
--- a/INSTALL_PROMPT.md
+++ b/INSTALL_PROMPT.md
@@ -1,0 +1,110 @@
+# DeepVista Install Prompt
+
+Copy and paste the prompt below into Claude Code (or any compatible agent) to install and configure DeepVista.
+
+---
+
+## First: Install Skills
+
+Run this once in your terminal to install the DeepVista skills globally:
+
+```bash
+cd ~ && npx skills add DeepVista-AI/deepvista-cli --yes
+```
+
+---
+
+## Then: Paste This Prompt Into Your Agent
+
+```
+Load skills: deepvista-shared deepvista-notes deepvista-vistabase deepvista-vistabook deepvista-chat deepvista-persona-knowledge-worker deepvista-recipe-research-to-vistabook deepvista-recipe-export-knowledge-as-skills deepvista-recipe-analyze-notes
+
+Help me get started with DeepVista:
+
+1. Check if the `deepvista` CLI is installed. If not, install it:
+   - Preferred: `uv tool install deepvista-cli`
+   - Fallback: `pip install deepvista-cli`
+
+2. Run `deepvista auth status` to check if I'm already logged in.
+
+3. If not logged in, run `deepvista auth login` to open the browser login page.
+   Guide me through pasting the auth code when I'm ready.
+
+4. Once logged in, confirm with `deepvista auth status` and show me the result.
+
+5. Give me a quick summary of what I can do now — note capture, knowledge base search, VistaBook workflows, and note analysis.
+```
+
+---
+
+## What Gets Installed
+
+| Skill | What it teaches your agent |
+|-------|---------------------------|
+| `deepvista-shared` | Auth, profiles, global flags, security rules |
+| `deepvista-vistabase` | Knowledge base — search, read, create, update cards |
+| `deepvista-notes` | Note capture and management |
+| `deepvista-vistabook` | Run structured AI workflows |
+| `deepvista-chat` | Conversational AI agent |
+| `deepvista-persona-knowledge-worker` | Daily knowledge workflow patterns |
+| `deepvista-recipe-research-to-vistabook` | Search → synthesize → run workflow |
+| `deepvista-recipe-export-knowledge-as-skills` | Turn your knowledge into installable skills |
+| `deepvista-recipe-analyze-notes` | Analyze, summarize, and find patterns across notes |
+
+---
+
+## Quick Start Prompts
+
+Once installed and authenticated, try these:
+
+### Capture a note
+```
+Load skills: deepvista-shared deepvista-notes
+
+Take a note: "Key insight from today's meeting — prioritize async workflows over sync for scale."
+```
+
+### Analyze your notes
+```
+Load skills: deepvista-shared deepvista-notes deepvista-vistabase deepvista-recipe-analyze-notes
+
+Analyze my recent notes and tell me what themes keep coming up.
+```
+
+### Search your knowledge base
+```
+Load skills: deepvista-shared deepvista-vistabase
+
+Search my knowledge base for everything I've captured about product strategy.
+Show me the top 5 results.
+```
+
+### Run a VistaBook workflow
+```
+Load skills: deepvista-shared deepvista-vistabase deepvista-vistabook deepvista-recipe-research-to-vistabook
+
+I want to synthesize patterns from my knowledge base. Find my Research Synthesis VistaBook
+and run it — but show me what you find before running so I can confirm.
+```
+
+---
+
+## Troubleshooting
+
+**Skill reads require confirmation?**
+Run once to allow it globally:
+```bash
+claude config set allowedPaths "~/.claude/skills" --global
+```
+
+**Skills not found?**
+Re-run the install command:
+```bash
+cd ~ && npx skills add DeepVista-AI/deepvista-cli --yes
+```
+
+**Auth issues?**
+```bash
+deepvista auth logout
+deepvista auth login
+```

--- a/README.md
+++ b/README.md
@@ -30,18 +30,19 @@ Install the DeepVista skills globally so they're available in every agent sessio
 cd ~ && npx skills add DeepVista-AI/deepvista-cli --yes
 ```
 
-This installs 8 skills into `~/.claude/skills/` (Claude Code) or `~/.agents/skills/` (OpenCode and others).
+This installs 9 skills into `~/.claude/skills/` (Claude Code) or `~/.agents/skills/` (OpenCode and others).
 
 | Skill | What it teaches your agent |
 |-------|---------------------------|
 | `deepvista-shared` | Auth, profiles, global flags, security rules |
 | `deepvista-vistabase` | Knowledge base — search, read, create, update cards |
-| `deepvista-notes` | Quick note capture |
+| `deepvista-notes` | Note capture and management |
 | `deepvista-vistabook` | Run structured AI workflows |
 | `deepvista-chat` | Conversational AI agent |
 | `deepvista-persona-knowledge-worker` | Daily knowledge workflow patterns |
 | `deepvista-recipe-research-to-vistabook` | Search → synthesize → run workflow |
 | `deepvista-recipe-export-knowledge-as-skills` | Turn your knowledge into installable skills |
+| `deepvista-recipe-analyze-notes` | Analyze, summarize, and find patterns across notes |
 
 ### Step 2 — Open Your Agent and Get Started
 
@@ -408,6 +409,7 @@ deepvista-cli/
     ├── deepvista-notes/        # Notes management
     ├── deepvista-chat/         # Chat with AI agent
     ├── deepvista-persona-knowledge-worker/
+    ├── deepvista-recipe-analyze-notes/
     ├── deepvista-recipe-export-knowledge-as-skills/
     └── deepvista-recipe-research-to-vistabook/
 ```

--- a/skills/deepvista-chat/SKILL.md
+++ b/skills/deepvista-chat/SKILL.md
@@ -23,7 +23,7 @@ Chat with the DeepVista AI agent. The agent can search your knowledge base, crea
 ### sessions
 
 ```bash
-deepvista --profile local chat sessions [--limit N] [--offset N] [--search "query"]
+deepvista chat sessions [--limit N] [--offset N] [--search "query"]
 ```
 
 Read-only — list chat sessions.
@@ -31,7 +31,7 @@ Read-only — list chat sessions.
 ### get
 
 ```bash
-deepvista --profile local chat get <chat_id>
+deepvista chat get <chat_id>
 ```
 
 Read-only — get a chat session with all pages.
@@ -39,7 +39,7 @@ Read-only — get a chat session with all pages.
 ### delete
 
 ```bash
-deepvista --profile local chat delete <chat_id>
+deepvista chat delete <chat_id>
 ```
 
 > [!CAUTION] Destructive command — confirm with user before executing.
@@ -47,7 +47,7 @@ deepvista --profile local chat delete <chat_id>
 ### +send
 
 ```bash
-deepvista --profile local chat +send "your message" [--chat-id ID] [--new]
+deepvista chat +send "your message" [--chat-id ID] [--new]
 ```
 
 > [!CAUTION]
@@ -69,19 +69,19 @@ Output is NDJSON (one JSON object per line) — each line is an SSE event from t
 
 ```bash
 # Send a message (new conversation)
-deepvista --profile local chat +send "What are my open tasks?" --new
+deepvista chat +send "What are my open tasks?" --new
 
 # Continue an existing conversation
-deepvista --profile local chat +send "Tell me more about the first one" --chat-id chat_abc
+deepvista chat +send "Tell me more about the first one" --chat-id chat_abc
 
 # Ask the agent to create a note
-deepvista --profile local chat +send "Create a note summarizing our ML strategy discussion"
+deepvista chat +send "Create a note summarizing our ML strategy discussion"
 
 # List recent sessions
-deepvista --profile local chat sessions --limit 5
+deepvista chat sessions --limit 5
 
 # Search sessions
-deepvista --profile local chat sessions --search "roadmap"
+deepvista chat sessions --search "roadmap"
 ```
 
 ## See Also

--- a/skills/deepvista-notes/SKILL.md
+++ b/skills/deepvista-notes/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: deepvista-notes
-description: "DeepVista Notes: Create, read, update, and delete notes in your knowledge base."
+description: |
+  DeepVista Notes: Create, read, update, and delete notes in your knowledge base.
+  TRIGGER when: user wants to create, capture, save, read, list, update, or delete a note; user says "take a note", "jot this down", "save this as a note", "show my notes", or asks about a specific note by title or ID.
+  DO NOT TRIGGER when: user wants to analyze, summarize, or find patterns across notes (use deepvista-recipe-analyze-notes instead); or when working with non-note knowledge base cards.
 metadata:
   deepvista:
     category: "service"

--- a/skills/deepvista-notes/SKILL.md
+++ b/skills/deepvista-notes/SKILL.md
@@ -26,19 +26,19 @@ Notes are context cards with `type=note`. They support rich markdown content and
 ### list
 
 ```bash
-deepvista --profile local notes list [--limit N] [--page N]
+deepvista notes list [--limit N] [--page N]
 ```
 
 ### get
 
 ```bash
-deepvista --profile local notes get <note_id>
+deepvista notes get <note_id>
 ```
 
 ### create
 
 ```bash
-deepvista --profile local notes create --title "Title" [--content "Markdown content"] [--tags '["t1"]']
+deepvista notes create --title "Title" [--content "Markdown content"] [--tags '["t1"]']
 ```
 
 > [!CAUTION] Write command — confirm with user before executing.
@@ -46,7 +46,7 @@ deepvista --profile local notes create --title "Title" [--content "Markdown cont
 ### update
 
 ```bash
-deepvista --profile local notes update <note_id> [--title "..."] [--content "..."] [--tags '["t1"]']
+deepvista notes update <note_id> [--title "..."] [--content "..."] [--tags '["t1"]']
 ```
 
 > [!CAUTION] Write command — confirm with user before executing.
@@ -54,7 +54,7 @@ deepvista --profile local notes update <note_id> [--title "..."] [--content "...
 ### delete
 
 ```bash
-deepvista --profile local notes delete <note_id>
+deepvista notes delete <note_id>
 ```
 
 > [!CAUTION] Destructive command — confirm with user before executing.
@@ -62,7 +62,7 @@ deepvista --profile local notes delete <note_id>
 ### +quick
 
 ```bash
-deepvista --profile local notes +quick "your text here"
+deepvista notes +quick "your text here"
 ```
 
 Quick-create a note from a single line of text. The first ~50 characters become the title; the full text is the content. Entity enrichment runs automatically.
@@ -81,16 +81,16 @@ Quick-create a note from a single line of text. The first ~50 characters become 
 
 ```bash
 # List recent notes
-deepvista --profile local notes list --limit 5
+deepvista notes list --limit 5
 
 # Create a meeting note
-deepvista --profile local notes create --title "Standup 2026-03-26" --content "## Discussed\n- Roadmap priorities\n- CLI release"
+deepvista notes create --title "Standup 2026-03-26" --content "## Discussed\n- Roadmap priorities\n- CLI release"
 
 # Quick note from a single line
-deepvista --profile local notes +quick "Alice mentioned the API migration deadline is April 15"
+deepvista notes +quick "Alice mentioned the API migration deadline is April 15"
 
 # Update a note
-deepvista --profile local notes update note_abc --content "Updated content with new findings..."
+deepvista notes update note_abc --content "Updated content with new findings..."
 ```
 
 ## See Also

--- a/skills/deepvista-persona-knowledge-worker/SKILL.md
+++ b/skills/deepvista-persona-knowledge-worker/SKILL.md
@@ -24,28 +24,28 @@ You are a knowledge worker using DeepVista to manage information, track tasks, a
 
 1. **Check pinned cards** for high-priority items:
    ```bash
-   deepvista --profile local vistabase list --status pinned --limit 10
+   deepvista vistabase list --status pinned --limit 10
    ```
 
 2. **Search for relevant context** before starting work:
    ```bash
-   deepvista --profile local vistabase +search "today's focus area"
+   deepvista vistabase +search "today's focus area"
    ```
 
 3. **Capture notes** during meetings or research:
    ```bash
-   deepvista --profile local notes +quick "Key insight from morning standup: ..."
+   deepvista notes +quick "Key insight from morning standup: ..."
    ```
 
 4. **Run VistaBook workflows** for structured tasks:
    ```bash
-   deepvista --profile local vistabook list
-   deepvista --profile local vistabook +run <vistabook_id> --input "context for today"
+   deepvista vistabook list
+   deepvista vistabook +run <vistabook_id> --input "context for today"
    ```
 
 5. **Ask the AI agent** for help synthesizing information:
    ```bash
-   deepvista --profile local chat +send "Summarize what I've learned about X this week"
+   deepvista chat +send "Summarize what I've learned about X this week"
    ```
 
 ## Instructions
@@ -58,6 +58,6 @@ You are a knowledge worker using DeepVista to manage information, track tasks, a
 
 ## Tips
 
-- `deepvista --profile local vistabase list --order-by updated_at --order desc --limit 5` shows recently touched cards.
-- `deepvista --profile local vistabase +search "query" --type person` is great for finding who knows what.
+- `deepvista vistabase list --order-by updated_at --order desc --limit 5` shows recently touched cards.
+- `deepvista vistabase +search "query" --type person` is great for finding who knows what.
 - VistaBook runs create linked chat sessions — continue the conversation with `chat +send`.

--- a/skills/deepvista-recipe-analyze-notes/SKILL.md
+++ b/skills/deepvista-recipe-analyze-notes/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: deepvista-recipe-analyze-notes
+description: |
+  Recipe: Analyze, summarize, and find patterns across notes in your DeepVista knowledge base.
+  TRIGGER when: user asks to analyze notes, summarize notes, find patterns or themes in notes, review notes, get insights from notes, "what have I been thinking about", "what are common topics in my notes", "synthesize my notes", or any request to make sense of multiple notes at once.
+  DO NOT TRIGGER when: user wants to create, update, or delete a single note (use deepvista-notes instead); or when the request is about a specific known note by ID.
+metadata:
+  deepvista:
+    category: "recipe"
+    requires:
+      bins:
+        - uv
+      skills:
+        - deepvista-shared
+        - deepvista-vistabase
+        - deepvista-notes
+    cliHelp: "deepvista vistabase +search --help"
+---
+
+# Analyze Notes
+
+> **PREREQUISITE:** Read [deepvista-shared](../deepvista-shared/SKILL.md), [deepvista-vistabase](../deepvista-vistabase/SKILL.md), and [deepvista-notes](../deepvista-notes/SKILL.md).
+
+Search, retrieve, and analyze notes from the knowledge base to surface insights, patterns, and summaries.
+
+## Steps
+
+1. **Search for relevant notes** using a query derived from the user's request:
+   ```bash
+   deepvista --profile local vistabase +search "<topic or keyword>" --type note --limit 20
+   ```
+
+2. **List recent notes** if no specific topic was given, to get a broad view:
+   ```bash
+   deepvista --profile local notes list --limit 20
+   ```
+
+3. **Fetch full content** for the most relevant notes (pick IDs from search/list results):
+   ```bash
+   deepvista --profile local notes get <note_id>
+   ```
+   Repeat for each note you need to read in full.
+
+4. **Analyze and synthesize** — read the content and identify:
+   - Recurring themes or topics
+   - Key decisions or action items
+   - Open questions or unresolved threads
+   - Timeline of ideas if dates are present
+
+5. **Present findings** to the user as a structured summary.
+
+6. **Optionally save the analysis** back as a new note (confirm with user first):
+   ```bash
+   deepvista --profile local notes create --title "Analysis: <topic> — <date>" --content "<synthesis>"
+   ```
+   > [!CAUTION] Write command — confirm with user before saving.
+
+## Tips
+
+- Use `vistabase +search` with specific keywords rather than listing everything — it uses hybrid vector+keyword search and returns the most relevant results.
+- Filter by tag if the user's notes are tagged: `vistabase +search "<query>" --type note` (tags are part of the card metadata returned in results).
+- For time-bounded analysis ("notes from this week"), use `notes list` and filter by `created_at` in the JSON output.
+- Use `chat +send` to ask the AI agent to synthesize across a large set of notes:
+  ```bash
+  deepvista --profile local chat +send "Here are my recent notes: <paste content>. What are the key themes?"
+  ```
+
+## Examples
+
+```bash
+# Find all notes about a project
+deepvista --profile local vistabase +search "project alpha" --type note --limit 15
+
+# Get full content of a note
+deepvista --profile local notes get note_abc123
+
+# Save analysis as a new note
+deepvista --profile local notes create \
+  --title "Weekly Themes — 2026-04-02" \
+  --content "## Key Themes\n- Theme 1\n- Theme 2\n\n## Open Questions\n- ..."
+```
+
+## See Also
+
+- [deepvista-notes](../deepvista-notes/SKILL.md) — CRUD operations on individual notes
+- [deepvista-vistabase](../deepvista-vistabase/SKILL.md) — Full knowledge base search and management
+- [deepvista-recipe-research-to-vistabook](../deepvista-recipe-research-to-vistabook/SKILL.md) — Run a VistaBook workflow with research findings

--- a/skills/deepvista-recipe-analyze-notes/SKILL.md
+++ b/skills/deepvista-recipe-analyze-notes/SKILL.md
@@ -27,17 +27,17 @@ Search, retrieve, and analyze notes from the knowledge base to surface insights,
 
 1. **Search for relevant notes** using a query derived from the user's request:
    ```bash
-   deepvista --profile local vistabase +search "<topic or keyword>" --type note --limit 20
+   deepvista vistabase +search "<topic or keyword>" --type note --limit 20
    ```
 
 2. **List recent notes** if no specific topic was given, to get a broad view:
    ```bash
-   deepvista --profile local notes list --limit 20
+   deepvista notes list --limit 20
    ```
 
 3. **Fetch full content** for the most relevant notes (pick IDs from search/list results):
    ```bash
-   deepvista --profile local notes get <note_id>
+   deepvista notes get <note_id>
    ```
    Repeat for each note you need to read in full.
 
@@ -51,7 +51,7 @@ Search, retrieve, and analyze notes from the knowledge base to surface insights,
 
 6. **Optionally save the analysis** back as a new note (confirm with user first):
    ```bash
-   deepvista --profile local notes create --title "Analysis: <topic> — <date>" --content "<synthesis>"
+   deepvista notes create --title "Analysis: <topic> — <date>" --content "<synthesis>"
    ```
    > [!CAUTION] Write command — confirm with user before saving.
 
@@ -62,20 +62,20 @@ Search, retrieve, and analyze notes from the knowledge base to surface insights,
 - For time-bounded analysis ("notes from this week"), use `notes list` and filter by `created_at` in the JSON output.
 - Use `chat +send` to ask the AI agent to synthesize across a large set of notes:
   ```bash
-  deepvista --profile local chat +send "Here are my recent notes: <paste content>. What are the key themes?"
+  deepvista chat +send "Here are my recent notes: <paste content>. What are the key themes?"
   ```
 
 ## Examples
 
 ```bash
 # Find all notes about a project
-deepvista --profile local vistabase +search "project alpha" --type note --limit 15
+deepvista vistabase +search "project alpha" --type note --limit 15
 
 # Get full content of a note
-deepvista --profile local notes get note_abc123
+deepvista notes get note_abc123
 
 # Save analysis as a new note
-deepvista --profile local notes create \
+deepvista notes create \
   --title "Weekly Themes — 2026-04-02" \
   --content "## Key Themes\n- Theme 1\n- Theme 2\n\n## Open Questions\n- ..."
 ```

--- a/skills/deepvista-recipe-export-knowledge-as-skills/SKILL.md
+++ b/skills/deepvista-recipe-export-knowledge-as-skills/SKILL.md
@@ -22,13 +22,13 @@ Export multiple VistaBooks as SKILL.md files that can be installed in any AI age
 
 1. **List all VistaBooks:**
    ```bash
-   deepvista --profile local vistabook list
+   deepvista vistabook list
    ```
 
 2. **For each VistaBook to export**, generate the SKILL.md:
    ```bash
-   deepvista --profile local vistabook +export <vistabook_id_1> --format skill
-   deepvista --profile local vistabook +export <vistabook_id_2> --format skill
+   deepvista vistabook +export <vistabook_id_1> --format skill
+   deepvista vistabook +export <vistabook_id_2> --format skill
    ```
 
 3. **Save each skill** to the agent's skills directory:

--- a/skills/deepvista-recipe-research-to-vistabook/SKILL.md
+++ b/skills/deepvista-recipe-research-to-vistabook/SKILL.md
@@ -23,30 +23,30 @@ Search your knowledge base for relevant context, then run a VistaBook workflow w
 
 1. **Search for relevant cards:**
    ```bash
-   deepvista --profile local vistabase +search "your research topic" --limit 10
+   deepvista vistabase +search "your research topic" --limit 10
    ```
 
 2. **Read the most relevant cards** (pick IDs from search results):
    ```bash
-   deepvista --profile local vistabase get <card_id_1>
-   deepvista --profile local vistabase get <card_id_2>
+   deepvista vistabase get <card_id_1>
+   deepvista vistabase get <card_id_2>
    ```
 
 3. **Summarize findings** into a context string for the VistaBook.
 
 4. **List available VistaBooks** to find the right workflow:
    ```bash
-   deepvista --profile local vistabook list
+   deepvista vistabook list
    ```
 
 5. **Run the VistaBook** with your research context:
    ```bash
-   deepvista --profile local vistabook +run <vistabook_id> --input "Based on my research: <summary of findings>"
+   deepvista vistabook +run <vistabook_id> --input "Based on my research: <summary of findings>"
    ```
 
 6. **Check run status:**
    ```bash
-   deepvista --profile local vistabook +status <run_chat_id>
+   deepvista vistabook +status <run_chat_id>
    ```
 
 ## Tips

--- a/skills/deepvista-shared/SKILL.md
+++ b/skills/deepvista-shared/SKILL.md
@@ -51,7 +51,7 @@ If running from the cloned repo without installing, prefix commands with `uv run
 
 ```bash
 # Correct:
-deepvista --profile local notes list
+deepvista notes list
 
 # WRONG — will fail:
 deepvista notes list --profile local
@@ -59,10 +59,10 @@ deepvista notes list --profile local
 
 ## Profiles
 
-The CLI uses profiles to connect to different backends. Use `--profile local` for local development:
+Commands use the `default` profile unless you specify one. To target a specific backend, pass `--profile NAME` before the service name:
 
 ```bash
-deepvista --profile local <service> <command>
+deepvista --profile staging vistabase list
 ```
 
 List available profiles:
@@ -142,7 +142,7 @@ deepvista vistabase +search --help
 
 1. **Write commands** are marked with `> [!CAUTION]` — always confirm with the user before executing write/delete operations.
 2. **Read-only commands** are safe to run without confirmation.
-3. **Never output tokens or secrets** — use `deepvista --profile local auth status` to check auth state.
+3. **Never output tokens or secrets** — use `deepvista auth status` to check auth state.
 4. **Use `--dry-run`** to preview destructive operations before executing.
 5. **Tokens are sensitive** — stored in `~/.config/deepvista/credentials.json` (mode 0600).
 

--- a/skills/deepvista-vistabase/SKILL.md
+++ b/skills/deepvista-vistabase/SKILL.md
@@ -23,7 +23,7 @@ VistaBase is DeepVista's knowledge base — a collection of context cards that r
 ### list
 
 ```bash
-deepvista --profile local vistabase list [--type TYPE] [--status STATUS] [--limit N] [--page N] [--order-by FIELD] [--order DIR]
+deepvista vistabase list [--type TYPE] [--status STATUS] [--limit N] [--page N] [--order-by FIELD] [--order DIR]
 ```
 
 | Flag | Required | Default | Description |
@@ -38,13 +38,13 @@ deepvista --profile local vistabase list [--type TYPE] [--status STATUS] [--limi
 ### get
 
 ```bash
-deepvista --profile local vistabase get <card_id>
+deepvista vistabase get <card_id>
 ```
 
 ### create
 
 ```bash
-deepvista --profile local vistabase create --type TYPE --title "Title" [--content "Description"] [--tags '["t1","t2"]'] [--no-enrich]
+deepvista vistabase create --type TYPE --title "Title" [--content "Description"] [--tags '["t1","t2"]'] [--no-enrich]
 ```
 
 > [!CAUTION] Write command — confirm with user before executing.
@@ -52,7 +52,7 @@ deepvista --profile local vistabase create --type TYPE --title "Title" [--conten
 ### update
 
 ```bash
-deepvista --profile local vistabase update <card_id> [--title "..."] [--content "..."] [--type TYPE] [--tags '["t1"]'] [--status pinned|archived]
+deepvista vistabase update <card_id> [--title "..."] [--content "..."] [--type TYPE] [--tags '["t1"]'] [--status pinned|archived]
 ```
 
 > [!CAUTION] Write command — confirm with user before executing.
@@ -60,7 +60,7 @@ deepvista --profile local vistabase update <card_id> [--title "..."] [--content 
 ### delete
 
 ```bash
-deepvista --profile local vistabase delete <card_id> [--type TYPE]
+deepvista vistabase delete <card_id> [--type TYPE]
 ```
 
 > [!CAUTION] Destructive command — confirm with user before executing.
@@ -70,7 +70,7 @@ deepvista --profile local vistabase delete <card_id> [--type TYPE]
 ### +search
 
 ```bash
-deepvista --profile local vistabase +search "query text" [--type TYPE] [--limit N]
+deepvista vistabase +search "query text" [--type TYPE] [--limit N]
 ```
 
 Search across all context cards using hybrid vector + keyword search.
@@ -86,7 +86,7 @@ Read-only. Results include relevance scores from hybrid search (vector similarit
 ### +similar
 
 ```bash
-deepvista --profile local vistabase +similar <card_id> [--limit N]
+deepvista vistabase +similar <card_id> [--limit N]
 ```
 
 Find context cards semantically similar to a given card. Uses the source card's content as a search query.
@@ -101,7 +101,7 @@ Read-only. The source card is excluded from results. Useful for discovering rela
 ### +pin
 
 ```bash
-deepvista --profile local vistabase +pin <card_id>
+deepvista vistabase +pin <card_id>
 ```
 
 > [!CAUTION] Write command.
@@ -109,7 +109,7 @@ deepvista --profile local vistabase +pin <card_id>
 ### +archive
 
 ```bash
-deepvista --profile local vistabase +archive <card_id>
+deepvista vistabase +archive <card_id>
 ```
 
 > [!CAUTION] Write command.
@@ -122,25 +122,25 @@ deepvista --profile local vistabase +archive <card_id>
 
 ```bash
 # Search for anything about quarterly metrics
-deepvista --profile local vistabase +search "quarterly metrics"
+deepvista vistabase +search "quarterly metrics"
 
 # Find people related to a topic
-deepvista --profile local vistabase +search "machine learning team" --type person
+deepvista vistabase +search "machine learning team" --type person
 
 # Find cards similar to a specific card
-deepvista --profile local vistabase +similar card_abc123 --limit 10
+deepvista vistabase +similar card_abc123 --limit 10
 
 # List all people cards
-deepvista --profile local vistabase list --type person
+deepvista vistabase list --type person
 
 # Create a topic card
-deepvista --profile local vistabase create --type topic --title "Machine Learning Strategy" --content "Our approach to ML..."
+deepvista vistabase create --type topic --title "Machine Learning Strategy" --content "Our approach to ML..."
 
 # Pin an important card
-deepvista --profile local vistabase +pin abc123
+deepvista vistabase +pin abc123
 
 # Get full details of a card
-deepvista --profile local vistabase get abc123
+deepvista vistabase get abc123
 ```
 
 ## See Also

--- a/skills/deepvista-vistabook/SKILL.md
+++ b/skills/deepvista-vistabook/SKILL.md
@@ -23,7 +23,7 @@ VistaBooks are structured checklist workflows stored as context cards. Each Vist
 ### list
 
 ```bash
-deepvista --profile local vistabook list [--limit N] [--page N]
+deepvista vistabook list [--limit N] [--page N]
 ```
 
 Read-only -- lists all VistaBook templates.
@@ -31,7 +31,7 @@ Read-only -- lists all VistaBook templates.
 ### get
 
 ```bash
-deepvista --profile local vistabook get <vistabook_id>
+deepvista vistabook get <vistabook_id>
 ```
 
 Read-only -- returns full VistaBook content including checklist phases.
@@ -39,7 +39,7 @@ Read-only -- returns full VistaBook content including checklist phases.
 ### +run
 
 ```bash
-deepvista --profile local vistabook +run <vistabook_id> [--input "context text"]
+deepvista vistabook +run <vistabook_id> [--input "context text"]
 ```
 
 Start a VistaBook run -- the AI agent executes the workflow checklist step by step.
@@ -61,7 +61,7 @@ Output is NDJSON (one JSON object per line) as the agent streams its response.
 ### +status
 
 ```bash
-deepvista --profile local vistabook +status <run_chat_id>
+deepvista vistabook +status <run_chat_id>
 ```
 
 Read-only -- shows run state (running, awaiting_input, completed, failed, paused).
@@ -69,7 +69,7 @@ Read-only -- shows run state (running, awaiting_input, completed, failed, paused
 ### +export
 
 ```bash
-deepvista --profile local vistabook +export <vistabook_id> --format skill
+deepvista vistabook +export <vistabook_id> --format skill
 ```
 
 Export a VistaBook as a SKILL.md file -- the VistaBook-as-Skill pipeline. Author workflows in DeepVista's GUI, then export them as installable agent skills.
@@ -85,16 +85,16 @@ Read-only -- generates output but does not modify the VistaBook. The exported SK
 
 ```bash
 # List all vistabooks
-deepvista --profile local vistabook list
+deepvista vistabook list
 
 # Run a vistabook
-deepvista --profile local vistabook +run vb_abc123 --input "Focus on Q4 objectives"
+deepvista vistabook +run vb_abc123 --input "Focus on Q4 objectives"
 
 # Check if a run is complete
-deepvista --profile local vistabook +status chat_xyz789
+deepvista vistabook +status chat_xyz789
 
 # Export as a skill for other agents
-deepvista --profile local vistabook +export vb_abc123 --format skill
+deepvista vistabook +export vb_abc123 --format skill
 ```
 
 ## See Also


### PR DESCRIPTION
## Summary

- Add `deepvista-recipe-analyze-notes` skill: search, retrieve, and analyze notes to surface themes, patterns, and summaries with optional save-back
- Update `deepvista-notes` SKILL.md: trigger conditions now exclude analysis requests (route to analyze-notes recipe instead)
- Add `INSTALL_PROMPT.md`: standalone copy-pasteable agent prompt for bootstrapping DeepVista — installs CLI, authenticates, loads all 9 skills, and includes quick-start examples for note capture, analysis, search, and VistaBook workflows
- Update README: bump skill count 8→9, add `deepvista-recipe-analyze-notes` to skill table and files section

## Test plan

- [ ] Install skills with `npx skills add DeepVista-AI/deepvista-cli --yes` and verify 9 skills land in `~/.claude/skills/`
- [ ] Paste the prompt from `INSTALL_PROMPT.md` into Claude Code and verify the agent installs the CLI and walks through auth
- [ ] Ask agent "analyze my recent notes" and confirm it loads `deepvista-recipe-analyze-notes` (not `deepvista-notes`)
- [ ] Ask agent "take a note" and confirm it loads `deepvista-notes` (not `deepvista-recipe-analyze-notes`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)