### PR TITLE
Add self-contained install.sh

### DIFF
--- a/INSTALL_PROMPT.md
+++ b/INSTALL_PROMPT.md
@@ -1,16 +1,18 @@
 # DeepVista Install Prompt
 
-Copy and paste the prompt below into Claude Code (or any compatible agent) to install and configure DeepVista.
+Copy and paste the prompt below into any AI agent (Claude Code, OpenCode, Cursor, etc.) to configure DeepVista.
 
 ---
 
-## First: Install Skills
+## First: Install
 
-Run this once in your terminal to install the DeepVista skills globally:
+Run this once in your terminal:
 
 ```bash
-cd ~ && npx skills add DeepVista-AI/deepvista-cli --yes
+curl -sSL https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/install.sh | bash
 ```
+
+This installs the `deepvista` CLI and all 9 skills for your agent — no Node or extra tools required.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,17 +20,19 @@ CLI for DeepVista — manage your knowledge base, VistaBooks, notes, and chat fr
 
 ## For AI Agents
 
-The key idea: **install the skills once, then talk to your agent**. The agent handles CLI installation, authentication, and all commands on your behalf.
+The key idea: **install once, then talk to your agent**. The agent handles authentication and all commands on your behalf.
 
-### Step 1 — Install Skills
+### Install
 
-Install the DeepVista skills globally so they're available in every agent session:
+Run this in your terminal — no Node, no extra tools required beyond a Python package manager and either `git` or `curl`:
 
 ```bash
-cd ~ && npx skills add DeepVista-AI/deepvista-cli --yes
+curl -sSL https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/install.sh | bash
 ```
 
-This installs 9 skills into `~/.claude/skills/` (Claude Code) or `~/.agents/skills/` (OpenCode and others).
+The script:
+1. Installs the `deepvista` CLI (auto-detects `uv`, `pipx`, or `pip`)
+2. Copies 9 skills into your agent's skills directory (auto-detects Claude Code, OpenCode, Cursor, and others)
 
 | Skill | What it teaches your agent |
 |-------|---------------------------|
@@ -44,21 +46,20 @@ This installs 9 skills into `~/.claude/skills/` (Claude Code) or `~/.agents/skil
 | `deepvista-recipe-export-knowledge-as-skills` | Turn your knowledge into installable skills |
 | `deepvista-recipe-analyze-notes` | Analyze, summarize, and find patterns across notes |
 
-### Step 2 — Open Your Agent and Get Started
+### Get Started
 
-Open Claude Code (or your agent) and ask it to set everything up:
+Open your agent and paste:
 
 ```
 Load skills: deepvista-shared deepvista-notes deepvista-vistabase deepvista-vistabook
 
-Help me get started with DeepVista. Install the CLI if needed, then walk me through logging in.
+Help me get started with DeepVista. Walk me through logging in.
 ```
 
 Your agent will:
-1. Check if `deepvista` is installed; install it via `pip` or `uv` if not
-2. Open the browser login page
-3. Guide you through pasting the auth code
-4. Confirm you're logged in with `deepvista auth status`
+1. Open the browser login page
+2. Guide you through pasting the auth code
+3. Confirm you're logged in with `deepvista auth status`
 
 > **Claude Code tip:** If you're prompted to confirm skill file reads, run once:
 > ```bash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -e
+
+REPO="DeepVista-AI/deepvista-cli"
+SKILLS=(
+  deepvista-shared
+  deepvista-vistabase
+  deepvista-notes
+  deepvista-vistabook
+  deepvista-chat
+  deepvista-persona-knowledge-worker
+  deepvista-recipe-research-to-vistabook
+  deepvista-recipe-export-knowledge-as-skills
+  deepvista-recipe-analyze-notes
+)
+
+echo "==> Installing deepvista CLI..."
+
+if command -v uv >/dev/null 2>&1; then
+  uv tool install deepvista-cli
+elif command -v pipx >/dev/null 2>&1; then
+  pipx install deepvista-cli
+elif command -v pip3 >/dev/null 2>&1; then
+  pip3 install --user deepvista-cli
+elif command -v pip >/dev/null 2>&1; then
+  pip install --user deepvista-cli
+else
+  echo "Error: no Python package manager found (pip, pipx, or uv required)" >&2
+  exit 1
+fi
+
+echo "==> Installing DeepVista skills..."
+
+# Detect which agent skill directories to install into
+SKILL_DIRS=()
+[ -d "$HOME/.claude" ]  && SKILL_DIRS+=("$HOME/.claude/skills")
+[ -d "$HOME/.agents" ]  && SKILL_DIRS+=("$HOME/.agents/skills")
+[ -d "$HOME/.cursor" ]  && SKILL_DIRS+=("$HOME/.cursor/skills")
+[ -d "$HOME/.opencode" ] && SKILL_DIRS+=("$HOME/.opencode/skills")
+
+# Default to Claude if no agent directory found
+if [ ${#SKILL_DIRS[@]} -eq 0 ]; then
+  SKILL_DIRS+=("$HOME/.claude/skills")
+fi
+
+# Download skills via git clone (fastest) or curl as fallback
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+if command -v git >/dev/null 2>&1; then
+  git clone --depth 1 --quiet "https://github.com/$REPO.git" "$TMP/repo"
+  SRC="$TMP/repo/skills"
+elif command -v curl >/dev/null 2>&1; then
+  # Download each skill's SKILL.md individually
+  SRC="$TMP/skills"
+  for skill in "${SKILLS[@]}"; do
+    mkdir -p "$SRC/$skill"
+    curl -sSL "https://raw.githubusercontent.com/$REPO/main/skills/$skill/SKILL.md" \
+      -o "$SRC/$skill/SKILL.md"
+  done
+else
+  echo "Error: git or curl required to install skills" >&2
+  exit 1
+fi
+
+for dir in "${SKILL_DIRS[@]}"; do
+  mkdir -p "$dir"
+  for skill in "${SKILLS[@]}"; do
+    cp -r "$SRC/$skill" "$dir/"
+  done
+  echo "    Skills installed to $dir"
+done
+
+echo ""
+echo "DeepVista is ready. Open your AI agent and say:"
+echo ""
+echo '  Load skills: deepvista-shared deepvista-notes deepvista-vistabase'
+echo '  Help me get started with DeepVista.'
+echo ""


### PR DESCRIPTION
## Summary

- Add `install.sh`: a `curl | bash` one-liner that works without Node/npx — auto-detects `uv`/`pipx`/`pip` for the CLI and `git`/`curl` for downloading skills; copies skills into whichever agent directories exist (Claude Code, OpenCode, Cursor, and others)
- Update README `For AI Agents` section: replace the two-step npx-based install with the single curl one-liner; remove Claude-specific framing so it works for any agent tool
- Update `INSTALL_PROMPT.md`: reference the new one-liner

## Test plan

- [ ] Run `curl -sSL https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/install.sh | bash` on a clean machine and verify CLI and skills are installed
- [ ] Verify script works when only `pip` is available (no uv/pipx)
- [ ] Verify script falls back to `curl` for skills download when `git` is not available
- [ ] Verify skills land in the correct directory for Claude Code (`~/.claude/skills/`) and OpenCode (`~/.agents/skills/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)