### PR TITLE
Show agent icons in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ CLI for DeepVista — manage your knowledge base, VistaBooks, notes, and chat fr
 
 ## For AI Agents
 
+<p>
+  <img src="https://cdn.simpleicons.org/anthropic/000000" width="18" alt="Claude Code" />&nbsp; <strong>Claude Code</strong> &nbsp;&nbsp;
+  <img src="https://cdn.simpleicons.org/cursor/000000" width="18" alt="Cursor" />&nbsp; <strong>Cursor</strong> &nbsp;&nbsp;
+  <strong>OpenCode</strong> &nbsp;&nbsp;
+  and any agent that supports skills
+</p>
+
 The key idea: **install once, then talk to your agent**. The agent handles authentication and all commands on your behalf.
 
 ### Install


### PR DESCRIPTION
## Summary

- Add Claude Code and Cursor logos to the `For AI Agents` section using the Simple Icons CDN
- OpenCode listed by name only (no entry in Simple Icons yet)
- Makes supported agents immediately recognizable at a glance

## Test plan

- [ ] View README on GitHub and confirm Claude Code and Cursor icons render correctly
- [ ] Confirm icons display in both light and dark mode (black icons — may need separate check for dark mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)