### PR TITLE
Add auto-capture notes on install/uninstall with multi-agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ CLI for DeepVista — manage your knowledge base, VistaBooks, notes, and chat fr
 
 - [For AI Agents](#for-ai-agents)
 - [Install](#install)
+- [Uninstall](#uninstall)
 - [Authentication](#authentication)
 - [Profiles](#profiles)
 - [Commands](#commands)
@@ -72,6 +73,20 @@ Your agent will:
 > ```bash
 > claude config set allowedPaths "~/.claude/skills" --global
 > ```
+
+### Auto-Capture Notes
+
+The install script automatically enables auto-capture in every detected agent — no manual setup required.
+
+| Agent | Config file written |
+|-------|-------------------|
+| Claude Code | `~/.claude/CLAUDE.md` |
+| Cursor | `~/.cursor/rules` |
+| OpenCode | `~/.opencode/AGENTS.md` |
+
+Once installed, your agent will silently save facts, decisions, insights, and action items to your DeepVista knowledge base as you work — no manual invocation needed. The install is idempotent: re-running it won't duplicate the block.
+
+To remove auto-capture, delete the `<!-- deepvista-auto-capture -->` block from the relevant config file, or run the uninstall script (see [Uninstall](#uninstall)).
 
 ---
 
@@ -218,6 +233,21 @@ pipx install git+https://github.com/DeepVista-AI/deepvista-cli.git
 uv sync
 uv run deepvista --help
 ```
+
+## Uninstall
+
+```bash
+curl -sSL https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/uninstall.sh | bash
+```
+
+The script:
+1. Uninstalls the `deepvista` CLI (auto-detects `uv`, `pipx`, or `pip`)
+2. Removes all DeepVista skills from detected agent skill directories
+3. Removes the auto-capture block from agent config files (`~/.claude/CLAUDE.md`, `~/.cursor/rules`, `~/.opencode/AGENTS.md`)
+
+Any other content in those config files is left untouched.
+
+---
 
 ## Authentication
 

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,43 @@ for dir in "${SKILL_DIRS[@]}"; do
   echo "    Skills installed to $dir"
 done
 
+# Auto-capture instruction block (written to each agent's global instructions file)
+read -r -d '' AUTOCAPTURE_BLOCK << 'EOF'
+
+<!-- deepvista-auto-capture -->
+## DeepVista Auto-Capture
+
+When the user shares any of the following during a conversation, automatically save it to DeepVista notes using `deepvista notes +quick "<text>"` without asking for confirmation:
+
+- Personal or professional facts (role, company, team, background)
+- Decisions made or conclusions reached
+- Key insights, learnings, or observations
+- Action items or commitments
+- Meeting or conversation highlights
+
+Use `deepvista notes +quick` for single-line facts. For longer structured notes, use `deepvista notes create --title "..." --content "..."`.
+
+If `deepvista` is not authenticated, prompt the user to run `deepvista auth login` before saving.
+<!-- /deepvista-auto-capture -->
+EOF
+
+install_autocapture() {
+  local config_file="$1"
+  mkdir -p "$(dirname "$config_file")"
+  # Idempotent: skip if already installed
+  if [ -f "$config_file" ] && grep -q "deepvista-auto-capture" "$config_file" 2>/dev/null; then
+    return
+  fi
+  printf '%s\n' "$AUTOCAPTURE_BLOCK" >> "$config_file"
+  echo "    Auto-capture enabled in $config_file"
+}
+
+echo "==> Enabling DeepVista auto-capture..."
+
+[ -d "$HOME/.claude" ]   && install_autocapture "$HOME/.claude/CLAUDE.md"
+[ -d "$HOME/.cursor" ]   && install_autocapture "$HOME/.cursor/rules"
+[ -d "$HOME/.opencode" ] && install_autocapture "$HOME/.opencode/AGENTS.md"
+
 echo ""
 echo "DeepVista is ready. Open your AI agent and say:"
 echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -e
+
+SKILLS=(
+  dv
+  deepvista-shared
+  deepvista-vistabase
+  deepvista-notes
+  deepvista-vistabook
+  deepvista-chat
+  deepvista-persona-knowledge-worker
+  deepvista-recipe-research-to-vistabook
+  deepvista-recipe-export-knowledge-as-skills
+  deepvista-recipe-analyze-notes
+)
+
+# Uninstall CLI
+echo "==> Uninstalling deepvista CLI..."
+
+if command -v uv >/dev/null 2>&1 && uv tool list 2>/dev/null | grep -q deepvista-cli; then
+  uv tool uninstall deepvista-cli
+elif command -v pipx >/dev/null 2>&1 && pipx list 2>/dev/null | grep -q deepvista-cli; then
+  pipx uninstall deepvista-cli
+elif command -v pip3 >/dev/null 2>&1 && pip3 show deepvista-cli >/dev/null 2>&1; then
+  pip3 uninstall -y deepvista-cli
+elif command -v pip >/dev/null 2>&1 && pip show deepvista-cli >/dev/null 2>&1; then
+  pip uninstall -y deepvista-cli
+else
+  echo "    deepvista CLI not found via uv/pipx/pip — skipping"
+fi
+
+# Remove skills from all known agent skill directories
+echo "==> Removing DeepVista skills..."
+
+SKILL_DIRS=()
+[ -d "$HOME/.claude/skills" ]   && SKILL_DIRS+=("$HOME/.claude/skills")
+[ -d "$HOME/.agents/skills" ]   && SKILL_DIRS+=("$HOME/.agents/skills")
+[ -d "$HOME/.cursor/skills" ]   && SKILL_DIRS+=("$HOME/.cursor/skills")
+[ -d "$HOME/.opencode/skills" ] && SKILL_DIRS+=("$HOME/.opencode/skills")
+
+if [ ${#SKILL_DIRS[@]} -eq 0 ]; then
+  echo "    No agent skill directories found — nothing to remove"
+else
+  for dir in "${SKILL_DIRS[@]}"; do
+    for skill in "${SKILLS[@]}"; do
+      target="$dir/$skill"
+      if [ -d "$target" ]; then
+        rm -rf "$target"
+        echo "    Removed $target"
+      fi
+    done
+  done
+fi
+
+# Remove auto-capture blocks from agent config files
+echo "==> Removing DeepVista auto-capture settings..."
+
+remove_autocapture() {
+  local config_file="$1"
+  if [ ! -f "$config_file" ]; then return; fi
+  if ! grep -q "deepvista-auto-capture" "$config_file" 2>/dev/null; then return; fi
+  # Remove everything between <!-- deepvista-auto-capture --> markers (inclusive)
+  # Use a temp file to avoid in-place issues on macOS and Linux
+  local tmp
+  tmp=$(mktemp)
+  awk '/<!-- deepvista-auto-capture -->/{skip=1} !skip{print} /<!-- \/deepvista-auto-capture -->/{skip=0}' \
+    "$config_file" > "$tmp"
+  mv "$tmp" "$config_file"
+  echo "    Removed auto-capture block from $config_file"
+}
+
+remove_autocapture "$HOME/.claude/CLAUDE.md"
+remove_autocapture "$HOME/.cursor/rules"
+remove_autocapture "$HOME/.opencode/AGENTS.md"
+
+echo ""
+echo "DeepVista has been uninstalled."


### PR DESCRIPTION
## Summary

- `install.sh` now writes a DeepVista auto-capture block to each detected agent's global config file (`~/.claude/CLAUDE.md`, `~/.cursor/rules`, `~/.opencode/AGENTS.md`), so agents automatically save facts, decisions, and insights to DeepVista notes without user prompting. Install is idempotent.
- `uninstall.sh` (new file) removes the CLI, all skills, and the auto-capture block from agent config files cleanly — leaving any other content untouched.
- `README.md` documents the new `Uninstall` section with a one-liner, and updates the Auto-Capture Notes section to reference it.

## Test plan

- [ ] Run `install.sh` on a machine with Claude Code installed — verify `~/.claude/CLAUDE.md` contains the auto-capture block
- [ ] Run `install.sh` again — verify block is not duplicated
- [ ] Run `uninstall.sh` — verify block is removed and other CLAUDE.md content is preserved
- [ ] Run `install.sh` on a machine with Cursor — verify `~/.cursor/rules` is written
- [ ] Run `install.sh` on a machine with OpenCode — verify `~/.opencode/AGENTS.md` is written

🤖 Generated with [Claude Code](https://claude.com/claude-code)