### PR TITLE
Add auto-capture notes feature

### DIFF
--- a/hooks/deepvista-autocapture.sh
+++ b/hooks/deepvista-autocapture.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# DeepVista Auto-Capture — Claude Code Stop Hook
+# Saves notable user statements to DeepVista notes after each conversation turn.
+# Install: referenced in ~/.claude/settings.json under hooks.Stop
+
+# Set up PATH for common tool install locations
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:$PATH"
+
+# Silently exit if deepvista is not installed
+command -v deepvista >/dev/null 2>&1 || exit 0
+
+# Read the hook payload from stdin
+PAYLOAD=$(cat)
+
+# Extract transcript path from payload JSON
+TRANSCRIPT_PATH=$(printf '%s' "$PAYLOAD" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('transcript_path', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+[ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ] && exit 0
+
+# Extract the last user message from the JSONL transcript
+LAST_USER=$(TRANSCRIPT_PATH="$TRANSCRIPT_PATH" python3 - <<'PYEOF'
+import sys, json, os
+
+path = os.environ.get("TRANSCRIPT_PATH", "")
+last_text = ""
+try:
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except Exception:
+                continue
+            # Support both flat {role, content} and nested {message: {role, content}} formats
+            role = entry.get("role")
+            content_raw = entry.get("content")
+            if not role:
+                msg = entry.get("message") or {}
+                role = msg.get("role")
+                content_raw = msg.get("content")
+            if role != "user" or not content_raw:
+                continue
+            if isinstance(content_raw, str):
+                last_text = content_raw
+            elif isinstance(content_raw, list):
+                parts = [
+                    b.get("text", "") if isinstance(b, dict) and b.get("type") == "text" else ""
+                    for b in content_raw
+                ]
+                last_text = " ".join(p for p in parts if p).strip()
+except Exception:
+    pass
+
+# Truncate to avoid oversized notes
+print(last_text[:1500] if last_text else "")
+PYEOF
+)
+
+# Skip empty or trivially short messages
+[ -z "$LAST_USER" ] || [ "${#LAST_USER}" -lt 20 ] && exit 0
+
+# Only save messages that contain factual statements about the user, their work,
+# decisions, or plans — skip pure questions and commands
+LOWER=$(printf '%s' "$LAST_USER" | tr '[:upper:]' '[:lower:]')
+printf '%s' "$LOWER" | grep -qE \
+  "(i am|i'm |we are|we're |my |our |i have|we have|i don't|i do not|i like|i love|i hate|i prefer|decided|planning|going to|working on|we built|i built|the tool|the product|the company|we('re| are) building|i want to|we want to|it is |it's )" \
+  || exit 0
+
+# Save to DeepVista in background — non-blocking so Claude isn't delayed
+deepvista notes +quick "$LAST_USER" >/dev/null 2>&1 &
+
+exit 0

--- a/install.sh
+++ b/install.sh
@@ -108,6 +108,59 @@ echo "==> Enabling DeepVista auto-capture..."
 [ -d "$HOME/.cursor" ]   && install_autocapture "$HOME/.cursor/rules"
 [ -d "$HOME/.opencode" ] && install_autocapture "$HOME/.opencode/AGENTS.md"
 
+echo "==> Installing DeepVista auto-capture hook..."
+
+install_stop_hook() {
+  local settings_file="$1"
+  local hook_script="$2"
+  mkdir -p "$(dirname "$settings_file")"
+
+  # Create settings file if missing
+  if [ ! -f "$settings_file" ]; then
+    echo '{}' > "$settings_file"
+  fi
+
+  # Idempotent: skip if hook already registered
+  if grep -q "deepvista-autocapture" "$settings_file" 2>/dev/null; then
+    return
+  fi
+
+  # Merge hook into settings JSON using Python (always available for deepvista)
+  python3 - "$settings_file" "$hook_script" <<'PYEOF'
+import sys, json
+
+settings_path, hook_cmd = sys.argv[1], sys.argv[2]
+try:
+    with open(settings_path) as f:
+        cfg = json.load(f)
+except Exception:
+    cfg = {}
+
+hooks = cfg.setdefault("hooks", {})
+stop_list = hooks.setdefault("Stop", [])
+stop_list.append({
+    "matcher": "",
+    "hooks": [{"type": "command", "command": hook_cmd}]
+})
+
+with open(settings_path, "w") as f:
+    json.dump(cfg, f, indent=2)
+PYEOF
+
+  echo "    Stop hook registered in $settings_file"
+}
+
+# Install hook script and register it for Claude Code
+if [ -d "$HOME/.claude" ]; then
+  mkdir -p "$HOME/.claude/hooks"
+  cp "$SRC/../hooks/deepvista-autocapture.sh" "$HOME/.claude/hooks/deepvista-autocapture.sh" 2>/dev/null || \
+    curl -sSL "https://raw.githubusercontent.com/$REPO/main/hooks/deepvista-autocapture.sh" \
+      -o "$HOME/.claude/hooks/deepvista-autocapture.sh"
+  chmod +x "$HOME/.claude/hooks/deepvista-autocapture.sh"
+  install_stop_hook "$HOME/.claude/settings.json" "$HOME/.claude/hooks/deepvista-autocapture.sh"
+  echo "    Auto-capture hook active — notable facts will be saved to DeepVista after each conversation turn"
+fi
+
 echo ""
 echo "DeepVista is ready. Open your AI agent and say:"
 echo ""

--- a/skills/deepvista-notes/SKILL.md
+++ b/skills/deepvista-notes/SKILL.md
@@ -2,7 +2,7 @@
 name: deepvista-notes
 description: |
   DeepVista Notes: Create, read, update, and delete notes in your knowledge base.
-  TRIGGER when: user wants to create, capture, save, read, list, update, or delete a note; user says "take a note", "jot this down", "save this as a note", "show my notes", or asks about a specific note by title or ID.
+  TRIGGER when: user wants to create, capture, save, read, list, update, or delete a note; user says "take a note", "jot this down", "save this as a note", "show my notes", or asks about a specific note by title or ID. Also trigger for "enable auto-capture", "disable auto-capture", "turn on/off auto-capture", or "auto-capture status".
   DO NOT TRIGGER when: user wants to analyze, summarize, or find patterns across notes (use deepvista-recipe-analyze-notes instead); or when working with non-note knowledge base cards.
 metadata:
   deepvista:
@@ -92,6 +92,214 @@ deepvista notes +quick "Alice mentioned the API migration deadline is April 15"
 # Update a note
 deepvista notes update note_abc --content "Updated content with new findings..."
 ```
+
+### +autocapture
+
+Manage the auto-capture hook that automatically saves notable facts from conversations to DeepVista notes after each turn.
+
+```bash
+# Check current status
+deepvista notes +autocapture status
+
+# Enable auto-capture (hook only)
+deepvista notes +autocapture enable
+
+# Disable auto-capture (hook only)
+deepvista notes +autocapture disable
+
+# Enable everything: hook + Claude instruction in CLAUDE.md
+deepvista notes +autocapture enable-all
+
+# Disable everything: hook + Claude instruction in CLAUDE.md
+deepvista notes +autocapture disable-all
+```
+
+Since `deepvista notes +autocapture` may not exist as a CLI command yet, implement each subcommand as shell steps:
+
+#### status
+```bash
+grep -q "deepvista-autocapture" "$HOME/.claude/settings.json" 2>/dev/null \
+  && echo "Auto-capture is ENABLED" \
+  || echo "Auto-capture is DISABLED"
+```
+
+#### enable
+```bash
+# 1. Ensure hook script is present
+mkdir -p "$HOME/.claude/hooks"
+if [ ! -f "$HOME/.claude/hooks/deepvista-autocapture.sh" ]; then
+  curl -sSL "https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/hooks/deepvista-autocapture.sh" \
+    -o "$HOME/.claude/hooks/deepvista-autocapture.sh"
+  chmod +x "$HOME/.claude/hooks/deepvista-autocapture.sh"
+fi
+
+# 2. Register Stop hook in settings.json (idempotent)
+python3 - <<'PYEOF'
+import json, os
+
+path = os.path.expanduser("~/.claude/settings.json")
+hook_cmd = os.path.expanduser("~/.claude/hooks/deepvista-autocapture.sh")
+
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except Exception:
+    cfg = {}
+
+hooks = cfg.setdefault("hooks", {})
+stop_list = hooks.setdefault("Stop", [])
+already = any(
+    any(h.get("command") == hook_cmd for h in e.get("hooks", []))
+    for e in stop_list
+)
+if not already:
+    stop_list.append({"matcher": "", "hooks": [{"type": "command", "command": hook_cmd}]})
+    with open(path, "w") as f:
+        json.dump(cfg, f, indent=2)
+    print("Auto-capture ENABLED")
+else:
+    print("Auto-capture already enabled")
+PYEOF
+```
+
+#### disable
+```bash
+python3 - <<'PYEOF'
+import json, os
+
+path = os.path.expanduser("~/.claude/settings.json")
+hook_cmd = os.path.expanduser("~/.claude/hooks/deepvista-autocapture.sh")
+
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except Exception:
+    print("No settings.json found")
+    raise SystemExit(0)
+
+hooks = cfg.get("hooks", {})
+stop_list = hooks.get("Stop", [])
+filtered = [
+    e for e in stop_list
+    if not any(h.get("command") == hook_cmd for h in e.get("hooks", []))
+]
+hooks["Stop"] = filtered
+if not filtered:
+    del hooks["Stop"]
+if not hooks:
+    cfg.pop("hooks", None)
+
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+print("Auto-capture DISABLED")
+PYEOF
+```
+
+#### disable-all
+Disables both the Stop hook and the Claude auto-capture instruction in CLAUDE.md:
+
+```bash
+# 1. Disable the Stop hook (same as disable above)
+python3 - <<'PYEOF'
+import json, os
+path = os.path.expanduser("~/.claude/settings.json")
+hook_cmd = os.path.expanduser("~/.claude/hooks/deepvista-autocapture.sh")
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except Exception:
+    cfg = {}
+hooks = cfg.get("hooks", {})
+stop_list = hooks.get("Stop", [])
+filtered = [e for e in stop_list if not any(h.get("command") == hook_cmd for h in e.get("hooks", []))]
+hooks["Stop"] = filtered
+if not filtered:
+    del hooks["Stop"]
+if not hooks:
+    cfg.pop("hooks", None)
+with open(path, "w") as f:
+    json.dump(cfg, f, indent=2)
+PYEOF
+
+# 2. Remove the auto-capture instruction block from CLAUDE.md
+python3 - <<'PYEOF'
+import os, re
+path = os.path.expanduser("~/.claude/CLAUDE.md")
+if not os.path.exists(path):
+    raise SystemExit(0)
+with open(path) as f:
+    content = f.read()
+# Remove marked block
+cleaned = re.sub(r'\n<!-- deepvista-auto-capture -->.*?<!-- /deepvista-auto-capture -->', '', content, flags=re.DOTALL)
+# Also remove unmarked ## DeepVista Auto-Capture section if present
+cleaned = re.sub(r'\n## DeepVista Auto-Capture\n.*?(?=\n## |\Z)', '', cleaned, flags=re.DOTALL)
+with open(path, "w") as f:
+    f.write(cleaned.strip() + "\n")
+print("Auto-capture fully DISABLED (hook + CLAUDE.md instruction)")
+PYEOF
+```
+
+#### enable-all
+Re-enables both the Stop hook and adds the Claude auto-capture instruction to CLAUDE.md:
+
+```bash
+# 1. Enable the Stop hook (same as enable above)
+mkdir -p "$HOME/.claude/hooks"
+if [ ! -f "$HOME/.claude/hooks/deepvista-autocapture.sh" ]; then
+  curl -sSL "https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/hooks/deepvista-autocapture.sh" \
+    -o "$HOME/.claude/hooks/deepvista-autocapture.sh"
+  chmod +x "$HOME/.claude/hooks/deepvista-autocapture.sh"
+fi
+python3 - <<'PYEOF'
+import json, os
+path = os.path.expanduser("~/.claude/settings.json")
+hook_cmd = os.path.expanduser("~/.claude/hooks/deepvista-autocapture.sh")
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except Exception:
+    cfg = {}
+hooks = cfg.setdefault("hooks", {})
+stop_list = hooks.setdefault("Stop", [])
+already = any(any(h.get("command") == hook_cmd for h in e.get("hooks", [])) for e in stop_list)
+if not already:
+    stop_list.append({"matcher": "", "hooks": [{"type": "command", "command": hook_cmd}]})
+    with open(path, "w") as f:
+        json.dump(cfg, f, indent=2)
+PYEOF
+
+# 2. Add auto-capture instruction back to CLAUDE.md (idempotent)
+python3 - <<'PYEOF'
+import os
+path = os.path.expanduser("~/.claude/CLAUDE.md")
+block = """
+<!-- deepvista-auto-capture -->
+## DeepVista Auto-Capture
+
+When the user shares any of the following during a conversation, automatically save it to DeepVista notes using `deepvista notes +quick "<text>"` without asking for confirmation:
+
+- Personal or professional facts (role, company, team, background)
+- Decisions made or conclusions reached
+- Key insights, learnings, or observations
+- Action items or commitments
+- Meeting or conversation highlights
+
+Use `deepvista notes +quick` for single-line facts. For longer structured notes, use `deepvista notes create --title "..." --content "..."`.
+
+If `deepvista` is not authenticated, prompt the user to run `deepvista auth login` before saving.
+<!-- /deepvista-auto-capture -->"""
+
+content = open(path).read() if os.path.exists(path) else "# Claude Code — Global Instructions\n"
+if "deepvista-auto-capture" not in content:
+    with open(path, "a") as f:
+        f.write(block + "\n")
+    print("Auto-capture fully ENABLED (hook + CLAUDE.md instruction)")
+else:
+    print("Auto-capture instruction already present in CLAUDE.md")
+PYEOF
+```
+
+> [!NOTE] Changes to CLAUDE.md take effect in the next conversation. Hook changes also take effect in the next session.
 
 ## See Also
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -73,5 +73,51 @@ remove_autocapture "$HOME/.claude/CLAUDE.md"
 remove_autocapture "$HOME/.cursor/rules"
 remove_autocapture "$HOME/.opencode/AGENTS.md"
 
+# Remove Stop hook from Claude Code settings.json
+echo "==> Removing DeepVista auto-capture hook..."
+
+remove_stop_hook() {
+  local settings_file="$1"
+  local hook_script="$2"
+  [ ! -f "$settings_file" ] && return
+  grep -q "deepvista-autocapture" "$settings_file" 2>/dev/null || return
+
+  python3 - "$settings_file" "$hook_script" <<'PYEOF'
+import sys, json
+
+settings_path, hook_cmd = sys.argv[1], sys.argv[2]
+try:
+    with open(settings_path) as f:
+        cfg = json.load(f)
+except Exception:
+    sys.exit(0)
+
+hooks = cfg.get("hooks", {})
+stop_list = hooks.get("Stop", [])
+hooks["Stop"] = [
+    entry for entry in stop_list
+    if not any(h.get("command") == hook_cmd for h in entry.get("hooks", []))
+]
+if not hooks["Stop"]:
+    del hooks["Stop"]
+if not hooks:
+    cfg.pop("hooks", None)
+
+with open(settings_path, "w") as f:
+    json.dump(cfg, f, indent=2)
+PYEOF
+
+  echo "    Removed Stop hook from $settings_file"
+}
+
+HOOK_SCRIPT="$HOME/.claude/hooks/deepvista-autocapture.sh"
+remove_stop_hook "$HOME/.claude/settings.json" "$HOOK_SCRIPT"
+
+# Remove the hook script itself
+if [ -f "$HOOK_SCRIPT" ]; then
+  rm -f "$HOOK_SCRIPT"
+  echo "    Removed $HOOK_SCRIPT"
+fi
+
 echo ""
 echo "DeepVista has been uninstalled."


### PR DESCRIPTION
## Summary

- Adds `hooks/deepvista-autocapture.sh` — a Claude Code Stop hook that extracts notable facts from each conversation turn and saves them to DeepVista notes automatically
- Extends `deepvista notes +autocapture` skill commands (`enable`, `disable`, `enable-all`, `disable-all`, `status`) for managing the hook and CLAUDE.md instruction
- Adds `install.sh` and `uninstall.sh` scripts that set up/tear down the hook and agent config blocks across Claude Code, Cursor, and OpenCode
- Updates README with auto-capture docs and uninstall section

## Test plan

- [ ] Run `install.sh` and verify hook is registered in `~/.claude/settings.json` and block appears in `~/.claude/CLAUDE.md`
- [ ] Share a fact in a conversation and confirm it is saved to DeepVista notes after the turn
- [ ] Run `deepvista notes +autocapture status` to confirm enabled state
- [ ] Run `deepvista notes +autocapture disable-all` and verify hook and CLAUDE.md block are removed
- [ ] Run `uninstall.sh` and verify clean removal with no leftover config changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)