### PR TITLE
Embed autocapture hook in install.sh, install to all agent dirs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -110,17 +110,91 @@ echo "==> Enabling DeepVista auto-capture..."
 
 echo "==> Installing DeepVista auto-capture hook..."
 
-# Download hook script to a temp location for use across agents
+# Write hook script directly (embedded) so installation works without network access
 HOOK_SRC="$TMP/deepvista-autocapture.sh"
-if [ -f "$SRC/../hooks/deepvista-autocapture.sh" ]; then
-  cp "$SRC/../hooks/deepvista-autocapture.sh" "$HOOK_SRC"
-elif command -v curl >/dev/null 2>&1; then
-  curl -sSL "https://raw.githubusercontent.com/$REPO/main/hooks/deepvista-autocapture.sh" \
-    -o "$HOOK_SRC"
-else
-  echo "    Warning: could not download hook script — skipping hook installation" >&2
-  HOOK_SRC=""
-fi
+cat > "$HOOK_SRC" << 'HOOKEOF'
+#!/usr/bin/env bash
+# DeepVista Auto-Capture — Claude Code Stop Hook
+# Saves notable user statements to DeepVista notes after each conversation turn.
+# Install: referenced in ~/.claude/settings.json under hooks.Stop
+
+# Set up PATH for common tool install locations
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:$PATH"
+
+# Silently exit if deepvista is not installed
+command -v deepvista >/dev/null 2>&1 || exit 0
+
+# Read the hook payload from stdin
+PAYLOAD=$(cat)
+
+# Extract transcript path from payload JSON
+TRANSCRIPT_PATH=$(printf '%s' "$PAYLOAD" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('transcript_path', ''))
+except Exception:
+    print('')
+" 2>/dev/null || true)
+
+[ -z "$TRANSCRIPT_PATH" ] || [ ! -f "$TRANSCRIPT_PATH" ] && exit 0
+
+# Extract the last user message from the JSONL transcript
+LAST_USER=$(TRANSCRIPT_PATH="$TRANSCRIPT_PATH" python3 - <<'PYEOF'
+import sys, json, os
+
+path = os.environ.get("TRANSCRIPT_PATH", "")
+last_text = ""
+try:
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except Exception:
+                continue
+            # Support both flat {role, content} and nested {message: {role, content}} formats
+            role = entry.get("role")
+            content_raw = entry.get("content")
+            if not role:
+                msg = entry.get("message") or {}
+                role = msg.get("role")
+                content_raw = msg.get("content")
+            if role != "user" or not content_raw:
+                continue
+            if isinstance(content_raw, str):
+                last_text = content_raw
+            elif isinstance(content_raw, list):
+                parts = [
+                    b.get("text", "") if isinstance(b, dict) and b.get("type") == "text" else ""
+                    for b in content_raw
+                ]
+                last_text = " ".join(p for p in parts if p).strip()
+except Exception:
+    pass
+
+# Truncate to avoid oversized notes
+print(last_text[:1500] if last_text else "")
+PYEOF
+)
+
+# Skip empty or trivially short messages
+[ -z "$LAST_USER" ] || [ "${#LAST_USER}" -lt 20 ] && exit 0
+
+# Only save messages that contain factual statements about the user, their work,
+# decisions, or plans — skip pure questions and commands
+LOWER=$(printf '%s' "$LAST_USER" | tr '[:upper:]' '[:lower:]')
+printf '%s' "$LOWER" | grep -qE \
+  "(i am|i'm |we are|we're |my |our |i have|we have|i don't|i do not|i like|i love|i hate|i prefer|decided|planning|going to|working on|we built|i built|the tool|the product|the company|we('re| are) building|i want to|we want to|it is |it's )" \
+  || exit 0
+
+# Save to DeepVista in background — non-blocking so Claude isn't delayed
+deepvista notes +quick "$LAST_USER" >/dev/null 2>&1 &
+
+exit 0
+HOOKEOF
 
 install_stop_hook() {
   local settings_file="$1"
@@ -171,18 +245,16 @@ copy_hook() {
   echo "    Hook copied to $dest"
 }
 
-if [ -n "$HOOK_SRC" ]; then
-  # Claude Code: copy hook and register in settings.json
-  copy_hook "$HOME/.claude/hooks"
-  install_stop_hook "$HOME/.claude/settings.json" "$HOME/.claude/hooks/deepvista-autocapture.sh"
+# Claude Code: copy hook and register in settings.json
+copy_hook "$HOME/.claude/hooks"
+install_stop_hook "$HOME/.claude/settings.json" "$HOME/.claude/hooks/deepvista-autocapture.sh"
 
-  # Other detected agent dirs: copy hook so it's available if the agent supports it
-  [ -d "$HOME/.agents" ]   && copy_hook "$HOME/.agents/hooks"
-  [ -d "$HOME/.cursor" ]   && copy_hook "$HOME/.cursor/hooks"
-  [ -d "$HOME/.opencode" ] && copy_hook "$HOME/.opencode/hooks"
+# Other detected agent dirs: copy hook so it's available if the agent supports it
+[ -d "$HOME/.agents" ]   && copy_hook "$HOME/.agents/hooks"
+[ -d "$HOME/.cursor" ]   && copy_hook "$HOME/.cursor/hooks"
+[ -d "$HOME/.opencode" ] && copy_hook "$HOME/.opencode/hooks"
 
-  echo "    Auto-capture hook active — notable facts will be saved to DeepVista after each conversation turn"
-fi
+echo "    Auto-capture hook active — notable facts will be saved to DeepVista after each conversation turn"
 
 echo "==> Checking DeepVista authentication..."
 

--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,7 @@ for dir in "${SKILL_DIRS[@]}"; do
 done
 
 # Auto-capture instruction block (written to each agent's global instructions file)
-read -r -d '' AUTOCAPTURE_BLOCK << 'EOF'
+read -r -d '' AUTOCAPTURE_BLOCK << 'EOF' || true
 
 <!-- deepvista-auto-capture -->
 ## DeepVista Auto-Capture
@@ -208,6 +208,7 @@ install_stop_hook() {
 
   # Idempotent: skip if hook already registered
   if grep -q "deepvista-autocapture" "$settings_file" 2>/dev/null; then
+    echo "    Stop hook already registered in $settings_file"
     return
   fi
 


### PR DESCRIPTION
## Summary

- Embeds `deepvista-autocapture.sh` inline in `install.sh` via heredoc so `~/.claude/hooks/deepvista-autocapture.sh` is always created during installation without a separate network request for the hook
- Installs the hook to all detected agent directories (`.agents`, `.cursor`, `.opencode`) in addition to `.claude`
- Removes the `if [ -n "$HOOK_SRC" ]` guard that could silently skip hook installation on download failure

## Test plan

- [ ] Run `install.sh` and verify `~/.claude/hooks/deepvista-autocapture.sh` is created and executable
- [ ] Verify hook is registered in `~/.claude/settings.json` under `hooks.Stop`
- [ ] Run with no internet after initial clone to confirm hook is written without network access
- [ ] Verify idempotent re-runs don't duplicate hook entries in settings.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)