### PR TITLE
Bump version to 0.1.0a5

### DIFF
--- a/deepvista_cli/__init__.py
+++ b/deepvista_cli/__init__.py
@@ -1,3 +1,3 @@
 """DeepVista CLI — manage your knowledge base, VistaBooks, notes, and chat from the terminal."""
 
-__version__ = "0.1.0a4"
+__version__ = "0.1.0a5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "CLI for DeepVista — chat, notes, recipes, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.0a4"
+version = "0.1.0a5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump version from `0.1.0a4` to `0.1.0a5` in `pyproject.toml`, `__init__.py`, and `uv.lock`

## Test plan
- [ ] Merge and tag `v0.1.0a5` to trigger PyPI publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)