### PR TITLE
Use --reinstall flag in uv tool install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ SKILLS=(
 echo "==> Installing deepvista CLI..."
 
 if command -v uv >/dev/null 2>&1; then
-  uv tool install deepvista-cli
+  uv tool install --reinstall deepvista-cli
 elif command -v pipx >/dev/null 2>&1; then
   pipx install deepvista-cli
 elif command -v pip3 >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Changes `uv tool install deepvista-cli` to `uv tool install --reinstall deepvista-cli` so re-running `install.sh` upgrades an existing installation instead of being a no-op.

## Test plan
- [ ] Run `install.sh` on a machine that already has `deepvista-cli` installed and confirm it reinstalls/upgrades successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)