### PR TITLE
Fix install.sh: auto-install uv and use --force to handle broken envs

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,18 @@ SKILLS=(
 
 echo "==> Installing deepvista CLI..."
 
+# Install uv if not present
+if ! command -v uv >/dev/null 2>&1; then
+  echo "    uv not found — installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  # Add uv to PATH for the rest of this script
+  export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+fi
+
 if command -v uv >/dev/null 2>&1; then
-  uv tool install --reinstall deepvista-cli
+  # Remove broken tool environment before reinstalling (e.g. missing Python executable)
+  uv tool uninstall deepvista-cli 2>/dev/null || true
+  uv tool install --force deepvista-cli
 elif command -v pipx >/dev/null 2>&1; then
   pipx install deepvista-cli
 elif command -v pip3 >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Auto-install `uv` via `astral.sh` if not present on the system
- Uninstall existing `deepvista-cli` tool environment before reinstalling to fix broken Python executable scenarios
- Switch from `--reinstall` to `uv tool uninstall + --force` for cleaner installs

## Test plan
- [ ] Run `install.sh` on a machine without `uv` installed — verify uv is installed automatically
- [ ] Run `install.sh` when a broken `deepvista-cli` tool env exists — verify it recovers cleanly
- [ ] Run `install.sh` on a clean machine with `uv` already present — verify normal flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)