### PR TITLE
Add recipe skill: import folder files as context cards

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# deepvista-cli — Claude Code Instructions
+
+## After editing Python files
+
+Run Ruff lint + format on any Python file you create or modify **before committing**:
+
+```bash
+uv run ruff check --fix <file>
+uv run ruff format <file>
+```
+
+If multiple files were changed, pass them all at once:
+
+```bash
+uv run ruff check --fix deepvista_cli/
+uv run ruff format deepvista_cli/
+```
+
+Ruff rules in effect (`pyproject.toml`): `E`, `F`, `I` (isort), `UP` (pyupgrade), line length 120.
+Fix all reported issues before committing — the pre-commit hook runs the same check and will block the commit if lint errors remain.
+
+## After editing skill files
+
+The pre-commit hook validates every `skills/*/SKILL.md`. If you create or modify a skill, validate it manually first:
+
+```bash
+uv run agentskills validate skills/<skill-name>/
+```
+
+Fix any validation errors before committing.
+
+## Pre-commit hooks summary
+
+| Hook | Command | Auto-fix? |
+|------|---------|-----------|
+| gitleaks | secret scanning | no — remove secrets manually |
+| ruff-check | lint | yes — `ruff check --fix` |
+| ruff-format | formatting | yes — `ruff format` |
+| pyright | type checking | no — fix type errors manually |
+| skills-ref-validate | skill YAML/schema | no — fix schema errors manually |

--- a/deepvista_cli/commands/upgrade.py
+++ b/deepvista_cli/commands/upgrade.py
@@ -13,7 +13,6 @@ import click
 
 from deepvista_cli import __version__
 
-
 REPO = "DeepVista-AI/deepvista-cli"
 SKILL_RAW_BASE = f"https://raw.githubusercontent.com/{REPO}/main/skills"
 
@@ -145,7 +144,7 @@ def upgrade_command(check: bool) -> None:
     # --- Upgrade skills ---
     if skill_updates:
         install_sh = f"https://raw.githubusercontent.com/{REPO}/main/install.sh"
-        click.echo(f"\nUpgrading skills...")
+        click.echo("\nUpgrading skills...")
         result = subprocess.run(["bash", "-c", f"curl -sSL {install_sh} | bash"])
         if result.returncode != 0:
             sys.exit(result.returncode)

--- a/skills/deepvista-recipe-import-files/SKILL.md
+++ b/skills/deepvista-recipe-import-files/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: deepvista-recipe-import-files
+version: "0.1.0"
+description: |
+  Recipe: Import files from the current directory (recursively) as context cards in DeepVista.
+  TRIGGER when: user wants to import files as cards, "index this folder", "add files to DeepVista", "import codebase as context", "upload files as knowledge cards", "add all files in this directory to my knowledge base", or any request to bulk-import local files into DeepVista.
+  DO NOT TRIGGER when: user wants to create a single note or card manually; or when working with non-file card types.
+metadata:
+  deepvista:
+    category: "recipe"
+    requires:
+      bins:
+        - uv
+      skills:
+        - deepvista-shared
+    cliHelp: "deepvista card create --help"
+---
+
+# Import Files as Context Cards
+
+> **PREREQUISITE:** Read [deepvista-shared](../deepvista-shared/SKILL.md) for auth, profiles, and global flags.
+
+Walk the current directory recursively, read each file, and create a DeepVista context card with `type=file` for each one. The result is a searchable knowledge base of all files in the project.
+
+> [!CAUTION] Bulk write operation — confirm with the user before starting. Ask whether they want to filter by extension, skip certain directories, or limit the number of files imported.
+
+## Steps
+
+### 1. Clarify scope with the user
+
+Before running, confirm:
+- **Directory**: current working directory (or a subdirectory they specify)
+- **File filter**: all files, or specific extensions (e.g. `*.py`, `*.md`, `*.ts`)?
+- **Exclusions**: skip common noise directories by default (`node_modules`, `.git`, `__pycache__`, `.venv`, `dist`, `build`, `.next`)
+- **Limit**: warn if more than 50 files are matched — ask before proceeding
+
+### 2. Discover files
+
+Use the Glob or Bash tool to list all matching files recursively, excluding noise directories. Example shell command for reference:
+
+```bash
+find . -type f \
+  -not -path '*/.git/*' \
+  -not -path '*/node_modules/*' \
+  -not -path '*/__pycache__/*' \
+  -not -path '*/.venv/*' \
+  -not -path '*/dist/*' \
+  -not -path '*/build/*' \
+  -not -path '*/.next/*' \
+  | sort
+```
+
+For extension filtering, add `-name "*.py"` (or the relevant extension).
+
+### 3. Read and create cards
+
+For each file discovered:
+
+1. **Read the file content** using the Read tool (skip binary files — if content is not valid UTF-8 text, skip with a note to the user).
+
+2. **Create a card** with type `file`, using the relative file path as the title:
+
+```bash
+deepvista card create \
+  --type file \
+  --title "<relative/path/to/file>" \
+  --content "<file content>" \
+  --tags '["imported"]'
+```
+
+- Use the relative path from the root of the scanned directory as the title (e.g. `src/utils/helpers.py`).
+- Set `--content` to the full file text. For large files (>50 KB), truncate to the first 50 KB and append a note: `\n\n[Content truncated at 50 KB]`.
+- Add `--tags '["imported"]'` so the user can find all imported cards with `deepvista card +search "imported"`.
+- If the user wants to tag by language or project name, add those tags too.
+
+3. **Report progress**: after each card is created, print the card ID and title. If creation fails, log the error and continue with the next file — do not abort the whole batch.
+
+### 4. Summarize results
+
+After processing all files, report:
+- Total files found
+- Total cards created successfully
+- Any files skipped (binary, too large, or errors)
+
+Example summary:
+
+```
+Import complete.
+  ✓ 34 cards created
+  - 2 files skipped (binary)
+  - 1 file skipped (error: content too large)
+
+Search your imported files:
+  deepvista card +search "<query>" --type file
+```
+
+### 5. Verify (optional)
+
+The user can search across the newly imported files:
+
+```bash
+deepvista card +search "<keyword>" --type file
+```
+
+## Tips
+
+- **Large repos**: For repos with hundreds of files, import only the most relevant directories (e.g. `src/`) rather than the entire tree.
+- **Re-import / updates**: There is no deduplication — running the recipe twice will create duplicate cards. Warn the user if they are re-importing a directory they may have imported before.
+- **Tags for organization**: Encourage the user to pass a project-specific tag (e.g. `["imported", "my-project"]`) so they can filter cards per project later.
+- **Skip lock files and generated files**: Suggest skipping `*.lock`, `*.min.js`, `*.map`, `package-lock.json`, `yarn.lock` by default.
+
+## Examples
+
+```bash
+# After creating a card, view it in the app:
+# https://app.deepvista.ai/cards/<id>
+
+# Search imported files
+deepvista card +search "authentication" --type file
+
+# List all imported file cards
+deepvista card list --type file
+```
+
+## See Also
+
+- [deepvista-shared](../deepvista-shared/SKILL.md) — Auth and global flags
+- [deepvista-memory](../deepvista-memory/SKILL.md) — Search and manage all card types
+- [deepvista-notes](../deepvista-notes/SKILL.md) — Create notes (type=note) for summaries


### PR DESCRIPTION
## Summary

- Adds a new `deepvista-recipe-import-files` skill that guides the agent to recursively walk the current directory and create a DeepVista `file`-type context card for each file
- Covers scope clarification (filters, exclusions, file count warnings), per-file card creation with `deepvista card create --type file`, progress reporting, and a final summary
- Follows the same recipe skill conventions as `deepvista-recipe-analyze-notes`

## Test plan

- [ ] Trigger the skill with phrases like "import files as cards" or "index this folder" and verify the agent follows the steps
- [ ] Confirm default exclusions skip `.git`, `node_modules`, `__pycache__`, etc.
- [ ] Verify `deepvista card +search "<query>" --type file` returns imported cards after a run
- [ ] Confirm large files (>50 KB) are truncated with a note appended

🤖 Generated with [Claude Code](https://claude.com/claude-code)