### PR TITLE
Fix install.sh: include [ui] extras in all package manager install commands

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -27,13 +27,13 @@ fi
 if command -v uv >/dev/null 2>&1; then
   # Remove broken tool environment before reinstalling (e.g. missing Python executable)
   uv tool uninstall deepvista-cli 2>/dev/null || true
-  uv tool install --force deepvista-cli
+  uv tool install --force "deepvista-cli[ui]"
 elif command -v pipx >/dev/null 2>&1; then
-  pipx install deepvista-cli
+  pipx install "deepvista-cli[ui]"
 elif command -v pip3 >/dev/null 2>&1; then
-  pip3 install --user deepvista-cli
+  pip3 install --user "deepvista-cli[ui]"
 elif command -v pip >/dev/null 2>&1; then
-  pip install --user deepvista-cli
+  pip install --user "deepvista-cli[ui]"
 else
   echo "Error: no Python package manager found (pip, pipx, or uv required)" >&2
   exit 1


### PR DESCRIPTION
## Summary
- Updated all four package manager install paths (`uv`, `pipx`, `pip3`, `pip`) to use `deepvista-cli[ui]` instead of `deepvista-cli`
- Ensures the TUI (`deepvista ui`) dependencies are installed by default

## Test plan
- [ ] Run `install.sh` with `uv` available and verify `deepvista ui` launches without missing-dependency errors
- [ ] Run `install.sh` with `pipx` available and verify the same
- [ ] Run `install.sh` with only `pip3`/`pip` available and verify the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)