### PR TITLE
chore: bump version to 0.1.0a6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.0a5"
+version = "0.1.0a6"
 description = "CLI for DeepVista — chat, notes, recipes, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Version bump for release `v0.1.0a6`.

Merging this PR and the tag push will trigger the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)