### PR TITLE
[DV-247] Add multi-account support to auth commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,3 +38,33 @@ Fix any validation errors before committing.
 | ruff-format | formatting | yes — `ruff format` |
 | pyright | type checking | no — fix type errors manually |
 | skills-ref-validate | skill YAML/schema | no — fix schema errors manually |
+
+## Releasing a new version
+
+The `main` branch is protected. Follow this workflow:
+
+1. **Create release branch and bump version**
+   ```bash
+   git checkout main && git pull
+   git checkout -b release/vX.Y.Z
+   # Edit pyproject.toml: version = "X.Y.Z"
+   git add pyproject.toml
+   git commit -m "release: vX.Y.Z"
+   git push -u origin release/vX.Y.Z
+   ```
+
+2. **Create PR and merge**
+   ```bash
+   gh pr create --title "release: vX.Y.Z" --body "Bump version for release"
+   ```
+
+3. **After PR merged, tag and push**
+   ```bash
+   git checkout main && git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+
+CI publishes to PyPI automatically on `v*` tags.
+
+**Version scheme:** `0.1.0aN` (alpha) → `0.1.0bN` (beta) → `0.1.0rcN` (rc) → `0.1.0` (stable)

--- a/deepvista_cli/auth/tokens.py
+++ b/deepvista_cli/auth/tokens.py
@@ -1,6 +1,17 @@
 """Token load / save / refresh logic.
 
-Storage: ~/.config/deepvista/credentials.json (mode 0600)
+Storage: ~/.config/deepvista/credentials.{profile}.json (mode 0600)
+
+Each credentials file supports multiple accounts:
+  {
+    "active": "user@example.com",
+    "accounts": {
+      "user@example.com": { ...token_set... },
+      "other@example.com": { ...token_set... }
+    }
+  }
+
+Legacy single-token files are auto-migrated on first read.
 
 Token refresh uses the issuer URL from the JWT itself, so the CLI always
 refreshes against the correct Supabase instance (production vs staging).
@@ -59,6 +70,11 @@ class TokenSet:
     def is_expired(self) -> bool:
         return time.time() >= (self.expires_at - REFRESH_BUFFER_SECONDS)
 
+    @property
+    def account_key(self) -> str:
+        """Stable key for this account: email if available, else user_id."""
+        return self.email or self.user_id
+
     def to_dict(self) -> dict:
         return {
             "access_token": self.access_token,
@@ -84,44 +100,175 @@ class TokenSet:
 
 
 # ---------------------------------------------------------------------------
-# File storage
+# Multi-account file storage
 # ---------------------------------------------------------------------------
 
 
-def save_tokens(tokens: TokenSet, path: Path | None = None) -> None:
-    """Persist tokens to a per-profile credentials file (mode 0600).
-
-    Writes atomically via a temp file so the credentials file is never
-    world-readable, even briefly (avoids TOCTOU between write and chmod).
-    """
-    creds = path or _default_creds_path()
+def _write_credentials_file(data: dict, path: Path) -> None:
+    """Atomically write credentials JSON to *path* (mode 0600)."""
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(dir=CONFIG_DIR, prefix=".credentials.", suffix=".tmp")
     try:
         os.chmod(tmp_path, 0o600)
         with os.fdopen(fd, "w") as f:
-            f.write(json.dumps(tokens.to_dict(), indent=2))
-        os.replace(tmp_path, creds)
+            f.write(json.dumps(data, indent=2))
+        os.replace(tmp_path, path)
     except Exception:
         os.unlink(tmp_path)
         raise
-    logger.debug("Tokens saved to %s", creds)
+
+
+def _load_credentials_file(path: Path) -> dict | None:
+    """Load and return the raw credentials JSON, or None."""
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        logger.warning("Corrupt credentials file at %s", path)
+        return None
+
+
+def _is_legacy_format(data: dict) -> bool:
+    """True if *data* is a legacy single-token file (has access_token at top level)."""
+    return "access_token" in data and "accounts" not in data
+
+
+def _migrate_legacy(data: dict, path: Path) -> dict:
+    """Migrate a legacy single-token file to multi-account format in place."""
+    tokens = TokenSet.from_dict(data)
+    key = tokens.account_key or "default"
+    migrated = {
+        "active": key,
+        "accounts": {key: tokens.to_dict()},
+    }
+    _write_credentials_file(migrated, path)
+    logger.debug("Migrated legacy credentials to multi-account format at %s", path)
+    return migrated
+
+
+# ---------------------------------------------------------------------------
+# Public multi-account helpers
+# ---------------------------------------------------------------------------
+
+
+def load_all_accounts(path: Path | None = None) -> tuple[str | None, dict[str, TokenSet]]:
+    """Load all accounts from a credentials file.
+
+    Returns (active_key, {key: TokenSet}).  If the file doesn't exist or is
+    empty, returns (None, {}).
+    """
+    creds = path or _default_creds_path()
+    data = _load_credentials_file(creds)
+    if data is None:
+        return None, {}
+
+    if _is_legacy_format(data):
+        data = _migrate_legacy(data, creds)
+
+    accounts: dict[str, TokenSet] = {}
+    for key, token_data in data.get("accounts", {}).items():
+        try:
+            accounts[key] = TokenSet.from_dict(token_data)
+        except (KeyError, TypeError):
+            logger.warning("Skipping corrupt account entry: %s", key)
+
+    active = data.get("active")
+    if active and active not in accounts:
+        active = next(iter(accounts), None)
+
+    return active, accounts
+
+
+def save_account(tokens: TokenSet, path: Path | None = None, *, make_active: bool = True) -> None:
+    """Add or update an account in the credentials file.
+
+    If *make_active* is True (the default), this account becomes the active one.
+    """
+    creds = path or _default_creds_path()
+    active, accounts = load_all_accounts(creds)
+    key = tokens.account_key
+    if not key:
+        key = "default"
+    accounts[key] = tokens
+
+    if make_active or active is None:
+        active = key
+
+    data = {
+        "active": active,
+        "accounts": {k: v.to_dict() for k, v in accounts.items()},
+    }
+    _write_credentials_file(data, creds)
+    logger.debug("Account %s saved to %s", key, creds)
+
+
+def switch_active_account(account_key: str, path: Path | None = None) -> TokenSet:
+    """Set a different account as active. Raises KeyError if not found."""
+    creds = path or _default_creds_path()
+    _active, accounts = load_all_accounts(creds)
+    if account_key not in accounts:
+        raise KeyError(account_key)
+
+    data = {
+        "active": account_key,
+        "accounts": {k: v.to_dict() for k, v in accounts.items()},
+    }
+    _write_credentials_file(data, creds)
+    return accounts[account_key]
+
+
+def remove_account(account_key: str, path: Path | None = None) -> bool:
+    """Remove a specific account. Returns True if it existed.
+
+    If the removed account was active, the first remaining account becomes active.
+    """
+    creds = path or _default_creds_path()
+    active, accounts = load_all_accounts(creds)
+    if account_key not in accounts:
+        return False
+
+    del accounts[account_key]
+
+    if not accounts:
+        # Last account removed — delete the file entirely.
+        if creds.exists():
+            creds.unlink()
+        return True
+
+    if active == account_key:
+        active = next(iter(accounts))
+
+    data = {
+        "active": active,
+        "accounts": {k: v.to_dict() for k, v in accounts.items()},
+    }
+    _write_credentials_file(data, creds)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible single-token API (used by HTTP client & auth commands)
+# ---------------------------------------------------------------------------
+
+
+def save_tokens(tokens: TokenSet, path: Path | None = None) -> None:
+    """Persist tokens as the active account (multi-account aware)."""
+    save_account(tokens, path, make_active=True)
 
 
 def load_tokens(path: Path | None = None) -> TokenSet | None:
-    """Load tokens from a per-profile credentials file."""
-    creds = path or _default_creds_path()
-    if creds.exists():
-        try:
-            data = json.loads(creds.read_text())
-            return TokenSet.from_dict(data)
-        except (json.JSONDecodeError, KeyError):
-            logger.warning("Corrupt credentials file at %s", creds)
+    """Load the *active* account's tokens from a credentials file."""
+    active, accounts = load_all_accounts(path)
+    if active and active in accounts:
+        return accounts[active]
+    if accounts:
+        return next(iter(accounts.values()))
     return None
 
 
 def delete_tokens(path: Path | None = None) -> None:
-    """Remove stored tokens for a profile."""
+    """Remove all stored credentials for a profile."""
     creds = path or _default_creds_path()
     if creds.exists():
         creds.unlink()
@@ -164,7 +311,7 @@ def refresh_access_token(tokens: TokenSet) -> TokenSet:
 
 
 def get_valid_token(path: Path | None = None) -> TokenSet | None:
-    """Load tokens and auto-refresh if expired. Returns None if not authenticated."""
+    """Load the active account's tokens and auto-refresh if expired."""
     creds = path or _default_creds_path()
     tokens = load_tokens(creds)
     if tokens is None:
@@ -177,8 +324,9 @@ def get_valid_token(path: Path | None = None) -> TokenSet | None:
             tokens = load_tokens(creds) or tokens
             if tokens.is_expired:
                 try:
-                    tokens = refresh_access_token(tokens)
-                    save_tokens(tokens, creds)
+                    refreshed = refresh_access_token(tokens)
+                    save_account(refreshed, creds, make_active=True)
+                    tokens = refreshed
                 except httpx.HTTPStatusError as e:
                     logger.error("Token refresh failed: HTTP %s", e.response.status_code)
                     return None

--- a/deepvista_cli/commands/auth.py
+++ b/deepvista_cli/commands/auth.py
@@ -1,4 +1,4 @@
-"""deepvista auth — login, status, logout."""
+"""deepvista auth — login, status, logout, and multi-account management."""
 
 from __future__ import annotations
 
@@ -7,7 +7,13 @@ import time
 import click
 
 from deepvista_cli.auth.login import login_auto, login_with_code
-from deepvista_cli.auth.tokens import delete_tokens, load_tokens
+from deepvista_cli.auth.tokens import (
+    delete_tokens,
+    load_all_accounts,
+    load_tokens,
+    remove_account,
+    switch_active_account,
+)
 from deepvista_cli.config import credentials_path
 from deepvista_cli.output.formatter import format_output, output_error
 
@@ -21,7 +27,7 @@ def auth_group() -> None:
 @click.option("--code", default=None, help="One-time auth code from the browser.")
 @click.pass_context
 def auth_login(ctx: click.Context, code: str | None) -> None:
-    """Login to DeepVista.
+    """Login to DeepVista (adds account alongside existing ones).
 
     \b
     Interactive (opens browser, automatic):
@@ -30,6 +36,10 @@ def auth_login(ctx: click.Context, code: str | None) -> None:
     \b
     Non-interactive (paste code from browser):
       deepvista auth login --code XXXX-XXXX
+
+    \b
+    You can login with multiple accounts. The most recent login
+    becomes active. Switch with: deepvista auth switch <email>
     """
     creds_path = credentials_path(ctx.obj.profile)
 
@@ -57,21 +67,103 @@ def auth_status(ctx: click.Context) -> None:
         return
 
     remaining = max(0, tokens.expires_at - time.time())
+    active_key, accounts = load_all_accounts(credentials_path(ctx.obj.profile))
     result = {
         "authenticated": True,
+        "active_account": active_key,
         "email": tokens.email,
         "user_id": tokens.user_id,
         "token_expires_in_seconds": int(remaining),
         "token_expired": tokens.is_expired,
+        "total_accounts": len(accounts),
     }
     format_output(result, ctx.obj.output_format)
+
+
+@auth_group.command("list")
+@click.pass_context
+def auth_list(ctx: click.Context) -> None:
+    """List all authenticated accounts on this profile."""
+    creds_path = credentials_path(ctx.obj.profile)
+    active, accounts = load_all_accounts(creds_path)
+
+    if not accounts:
+        click.echo("No accounts. Run: deepvista auth login", err=True)
+        return
+
+    rows = []
+    for key, tokens in accounts.items():
+        remaining = max(0, tokens.expires_at - time.time())
+        rows.append(
+            {
+                "account": key,
+                "active": key == active,
+                "email": tokens.email,
+                "user_id": tokens.user_id,
+                "token_expires_in_seconds": int(remaining),
+                "token_expired": tokens.is_expired,
+            }
+        )
+
+    format_output(rows, ctx.obj.output_format, title="Accounts")
+
+
+@auth_group.command("switch")
+@click.argument("account")
+@click.pass_context
+def auth_switch(ctx: click.Context, account: str) -> None:
+    """Switch the active account.
+
+    \b
+    ACCOUNT is the email (or user ID) shown by `deepvista auth list`.
+
+    \b
+    Example:
+      deepvista auth switch alice@example.com
+    """
+    creds_path = credentials_path(ctx.obj.profile)
+    try:
+        tokens = switch_active_account(account, creds_path)
+    except KeyError:
+        # Show available accounts to help the user
+        _active, accounts = load_all_accounts(creds_path)
+        available = ", ".join(accounts.keys()) if accounts else "(none)"
+        raise click.ClickException(f"Account '{account}' not found. Available: {available}")
+
+    result = {"active_account": account, "email": tokens.email, "user_id": tokens.user_id}
+    format_output(result, ctx.obj.output_format)
+    click.echo(f"  Switched to {tokens.email or tokens.user_id}", err=True)
+
+
+@auth_group.command("remove")
+@click.argument("account")
+@click.pass_context
+def auth_remove(ctx: click.Context, account: str) -> None:
+    """Remove a specific account from this profile.
+
+    \b
+    ACCOUNT is the email (or user ID) shown by `deepvista auth list`.
+
+    \b
+    Example:
+      deepvista auth remove old@example.com
+    """
+    creds_path = credentials_path(ctx.obj.profile)
+    if not remove_account(account, creds_path):
+        _active, accounts = load_all_accounts(creds_path)
+        available = ", ".join(accounts.keys()) if accounts else "(none)"
+        raise click.ClickException(f"Account '{account}' not found. Available: {available}")
+
+    result = {"removed": account}
+    format_output(result, ctx.obj.output_format)
+    click.echo(f"  Removed {account}", err=True)
 
 
 @auth_group.command("logout")
 @click.pass_context
 def auth_logout(ctx: click.Context) -> None:
-    """Clear stored credentials."""
+    """Clear all stored credentials for this profile."""
     delete_tokens(credentials_path(ctx.obj.profile))
     result = {"status": "logged_out"}
     format_output(result, ctx.obj.output_format)
-    click.echo("  Logged out.", err=True)
+    click.echo("  Logged out (all accounts removed).", err=True)


### PR DESCRIPTION

https://app.visla.us/clip/1491042235909710451


## Summary
- Support multiple authenticated accounts per profile with ability to switch between them
- New commands: `auth list`, `auth switch <email>`, `auth remove <email>`
- `auth login` now adds accounts alongside existing ones (most recent becomes active)
- Credentials file auto-migrates from legacy single-token format to multi-account format

## Linear
https://linear.app/deepvista/issue/DV-247/update-the-deepvista-cli-to-be-able-to-support-multiple-account-login

## Test plan
- [ ] `deepvista auth login` with first account → credentials file created
- [ ] `deepvista auth login` with second account → both stored, second is active
- [ ] `deepvista auth list` → shows both accounts with active indicator
- [ ] `deepvista auth switch <email>` → switches active account
- [ ] `deepvista auth remove <email>` → removes specific account
- [ ] `deepvista auth logout` → clears all accounts
- [ ] Existing single-token credentials file auto-migrates on first read
- [ ] All other commands (card, notes, chat, recipe) use the active account transparently