### PR TITLE
release: v0.1.0a8

### DIFF
--- a/deepvista_cli/__init__.py
+++ b/deepvista_cli/__init__.py
@@ -1,3 +1,5 @@
 """DeepVista CLI — manage your knowledge base, VistaBooks, notes, and chat from the terminal."""
 
-__version__ = "0.1.0a5"
+from importlib.metadata import version
+
+__version__ = version("deepvista-cli")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.0a7"
+version = "0.1.0a8"
 description = "CLI for DeepVista — chat, notes, recipes, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.0a6"
+version = "0.1.0a8"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Read `__version__` from package metadata (`importlib.metadata.version`) instead of hardcoding — no more manual sync between `pyproject.toml` and `__init__.py`
- Bump version to 0.1.0a8