### PR TITLE
feat: display URL instead of ID in CLI output

### DIFF
--- a/deepvista_cli/commands/card.py
+++ b/deepvista_cli/commands/card.py
@@ -100,7 +100,14 @@ def card_list(
         "has_more": data.get("has_more", False),
         "count": len(cards),
     }
-    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title="Cards", entity_type="card")
+    format_output(
+        result,
+        ctx.obj.output_format,
+        columns=CARD_COLUMNS,
+        title="Cards",
+        entity_type="card",
+        base_url=ctx.obj.auth_url,
+    )
 
 
 @card_group.command("get")
@@ -109,7 +116,7 @@ def card_list(
 def card_get(ctx: click.Context, card_id: str) -> None:
     """Get a context card by ID."""
     data = _client(ctx).post("/get_context_card", {"card_id": card_id})
-    format_output(data, ctx.obj.output_format, title=f"Card: {card_id}", entity_type="card")
+    format_output(data, ctx.obj.output_format, title=f"Card: {card_id}", entity_type="card", base_url=ctx.obj.auth_url)
 
 
 @card_group.command("create")
@@ -156,7 +163,7 @@ def card_create(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Created Card", entity_type="card")
+    format_output(data, ctx.obj.output_format, title="Created Card", entity_type="card", base_url=ctx.obj.auth_url)
 
 
 @card_group.command("update")
@@ -205,7 +212,9 @@ def card_update(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/update_context_card", body)
-    format_output(data, ctx.obj.output_format, title=f"Updated Card: {card_id}", entity_type="card")
+    format_output(
+        data, ctx.obj.output_format, title=f"Updated Card: {card_id}", entity_type="card", base_url=ctx.obj.auth_url
+    )
 
 
 @card_group.command("edit")
@@ -238,7 +247,9 @@ def card_edit(
         "replace_all": replace_all,
     }
     data = _client(ctx).post("/edit_context_card", body)
-    format_output(data, ctx.obj.output_format, title=f"Edited Card: {card_id}", entity_type="card")
+    format_output(
+        data, ctx.obj.output_format, title=f"Edited Card: {card_id}", entity_type="card", base_url=ctx.obj.auth_url
+    )
 
 
 @card_group.command("delete")
@@ -254,7 +265,7 @@ def card_delete(ctx: click.Context, card_id: str, card_type: str | None) -> None
     if card_type:
         params["card_type"] = card_type
     data = _client(ctx).delete(f"/context_cards/{card_id}", params=params)
-    format_output(data, ctx.obj.output_format, entity_type="card")
+    format_output(data, ctx.obj.output_format, entity_type="card", base_url=ctx.obj.auth_url)
 
 
 # ---------------------------------------------------------------------------
@@ -279,7 +290,14 @@ def card_search(ctx: click.Context, query: str, card_type: str | None, limit: in
     data = _client(ctx).post("/get_context_cards", body)
     cards = data.get("cards", [])
     result = {"query": query, "results": cards, "count": len(cards)}
-    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Search: {query}", entity_type="card")
+    format_output(
+        result,
+        ctx.obj.output_format,
+        columns=CARD_COLUMNS,
+        title=f"Search: {query}",
+        entity_type="card",
+        base_url=ctx.obj.auth_url,
+    )
 
 
 @card_group.command("+similar")
@@ -304,7 +322,12 @@ def card_similar(ctx: click.Context, card_id: str, limit: int) -> None:
     cards = [c for c in data.get("cards", []) if c.get("id") != card_id]
     result = {"source_card_id": card_id, "similar": cards, "count": len(cards)}
     format_output(
-        result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Similar to: {card_id}", entity_type="card"
+        result,
+        ctx.obj.output_format,
+        columns=CARD_COLUMNS,
+        title=f"Similar to: {card_id}",
+        entity_type="card",
+        base_url=ctx.obj.auth_url,
     )
 
 
@@ -317,7 +340,7 @@ def card_pin(ctx: click.Context, card_id: str) -> None:
     > [!CAUTION] This is a write command.
     """
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "pinned"})
-    format_output(data, ctx.obj.output_format, entity_type="card")
+    format_output(data, ctx.obj.output_format, entity_type="card", base_url=ctx.obj.auth_url)
 
 
 @card_group.command("+archive")
@@ -329,7 +352,7 @@ def card_archive(ctx: click.Context, card_id: str) -> None:
     > [!CAUTION] This is a write command.
     """
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "archived"})
-    format_output(data, ctx.obj.output_format, entity_type="card")
+    format_output(data, ctx.obj.output_format, entity_type="card", base_url=ctx.obj.auth_url)
 
 
 @card_group.command("+grep")
@@ -364,4 +387,4 @@ def card_grep(
         body["card_type"] = card_type
 
     data = _client(ctx).post("/grep_context_cards", body)
-    format_output(data, ctx.obj.output_format, title=f"Grep: {pattern}", entity_type="card")
+    format_output(data, ctx.obj.output_format, title=f"Grep: {pattern}", entity_type="card", base_url=ctx.obj.auth_url)

--- a/deepvista_cli/commands/chat.py
+++ b/deepvista_cli/commands/chat.py
@@ -45,6 +45,7 @@ def chat_sessions(ctx: click.Context, limit: int, offset: int, search: str | Non
         columns=["id", "summary", "created_at"],
         title="Chat Sessions",
         entity_type="chat",
+        base_url=ctx.obj.auth_url,
     )
 
 
@@ -57,7 +58,7 @@ def chat_get(ctx: click.Context, chat_id: str) -> None:
     Read-only.
     """
     data = _client(ctx).get(f"/chat_sessions/{chat_id}")
-    format_output(data, ctx.obj.output_format, title=f"Chat: {chat_id}", entity_type="chat")
+    format_output(data, ctx.obj.output_format, title=f"Chat: {chat_id}", entity_type="chat", base_url=ctx.obj.auth_url)
 
 
 @chat_group.command("delete")
@@ -69,7 +70,7 @@ def chat_delete(ctx: click.Context, chat_id: str) -> None:
     > [!CAUTION] This is a destructive write command — confirm with the user before executing.
     """
     data = _client(ctx).delete(f"/chat_sessions/{chat_id}")
-    format_output(data, ctx.obj.output_format, entity_type="chat")
+    format_output(data, ctx.obj.output_format, entity_type="chat", base_url=ctx.obj.auth_url)
 
 
 # ---------------------------------------------------------------------------

--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -45,7 +45,14 @@ def notes_list(ctx: click.Context, limit: int, page_number: int) -> None:
     )
     cards = data.get("cards", [])
     result = {"notes": cards, "count": len(cards), "has_more": data.get("has_more", False)}
-    format_output(result, ctx.obj.output_format, columns=NOTE_COLUMNS, title="Notes", entity_type="note")
+    format_output(
+        result,
+        ctx.obj.output_format,
+        columns=NOTE_COLUMNS,
+        title="Notes",
+        entity_type="note",
+        base_url=ctx.obj.auth_url,
+    )
 
 
 @notes_group.command("get")
@@ -57,7 +64,7 @@ def notes_get(ctx: click.Context, note_id: str) -> None:
     Read-only.
     """
     data = _client(ctx).post("/get_context_card", {"card_id": note_id, "card_type": "note"})
-    format_output(data, ctx.obj.output_format, title=f"Note: {note_id}", entity_type="note")
+    format_output(data, ctx.obj.output_format, title=f"Note: {note_id}", entity_type="note", base_url=ctx.obj.auth_url)
 
 
 @notes_group.command("create")
@@ -88,7 +95,7 @@ def notes_create(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Created Note", entity_type="note")
+    format_output(data, ctx.obj.output_format, title="Created Note", entity_type="note", base_url=ctx.obj.auth_url)
 
 
 @notes_group.command("update")
@@ -127,7 +134,9 @@ def notes_update(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/update_context_card", body)
-    format_output(data, ctx.obj.output_format, title=f"Updated Note: {note_id}", entity_type="note")
+    format_output(
+        data, ctx.obj.output_format, title=f"Updated Note: {note_id}", entity_type="note", base_url=ctx.obj.auth_url
+    )
 
 
 @notes_group.command("delete")
@@ -139,7 +148,7 @@ def notes_delete(ctx: click.Context, note_id: str) -> None:
     > [!CAUTION] This is a destructive write command — confirm with the user before executing.
     """
     data = _client(ctx).delete(f"/context_cards/{note_id}", params={"card_type": "note"})
-    format_output(data, ctx.obj.output_format, entity_type="note")
+    format_output(data, ctx.obj.output_format, entity_type="note", base_url=ctx.obj.auth_url)
 
 
 # ---------------------------------------------------------------------------
@@ -169,4 +178,4 @@ def notes_quick(ctx: click.Context, text: str) -> None:
         "enrich": True,
     }
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Quick Note", entity_type="note")
+    format_output(data, ctx.obj.output_format, title="Quick Note", entity_type="note", base_url=ctx.obj.auth_url)

--- a/deepvista_cli/commands/recipe.py
+++ b/deepvista_cli/commands/recipe.py
@@ -54,7 +54,14 @@ def recipe_list(ctx: click.Context, limit: int, page_number: int) -> None:
     )
     cards = data.get("cards", [])
     result = {"recipes": cards, "count": len(cards), "has_more": data.get("has_more", False)}
-    format_output(result, ctx.obj.output_format, columns=RECIPE_COLUMNS, title="Recipes", entity_type="recipe")
+    format_output(
+        result,
+        ctx.obj.output_format,
+        columns=RECIPE_COLUMNS,
+        title="Recipes",
+        entity_type="recipe",
+        base_url=ctx.obj.auth_url,
+    )
 
 
 @recipe_group.command("get")
@@ -66,7 +73,9 @@ def recipe_get(ctx: click.Context, recipe_id: str) -> None:
     Read-only — never modifies the Recipe.
     """
     data = _client(ctx).post("/get_context_card", {"card_id": recipe_id, "card_type": "vistabook"})
-    format_output(data, ctx.obj.output_format, title=f"Recipe: {recipe_id}", entity_type="recipe")
+    format_output(
+        data, ctx.obj.output_format, title=f"Recipe: {recipe_id}", entity_type="recipe", base_url=ctx.obj.auth_url
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +126,7 @@ def recipe_status(ctx: click.Context, run_id: str) -> None:
         "visibility": session.get("visibility", ""),
         "created_at": session.get("created_at", ""),
     }
-    format_output(result, ctx.obj.output_format, title=f"Run: {run_id}", entity_type="chat")
+    format_output(result, ctx.obj.output_format, title=f"Run: {run_id}", entity_type="chat", base_url=ctx.obj.auth_url)
 
 
 @recipe_group.command("export")
@@ -132,7 +141,9 @@ def recipe_export(ctx: click.Context, recipe_id: str, export_format: str) -> Non
     Read-only — generates output but does not modify the Recipe.
     """
     data = _client(ctx).post("/export_vistabook_to_skill", {"card_ids": [recipe_id]})
-    format_output(data, ctx.obj.output_format, title=f"Export: {recipe_id}")
+    format_output(
+        data, ctx.obj.output_format, title=f"Export: {recipe_id}", entity_type="recipe", base_url=ctx.obj.auth_url
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +179,14 @@ def recipe_discover(ctx: click.Context, search: str | None, category: str | None
     data = _client(ctx).post("/discover_recipes", body)
     recipes = data.get("recipes", [])
     result = {"recipes": recipes, "count": len(recipes), "has_more": data.get("has_more", False)}
-    format_output(result, ctx.obj.output_format, columns=DISCOVER_COLUMNS, title="Marketplace Recipes")
+    format_output(
+        result,
+        ctx.obj.output_format,
+        columns=DISCOVER_COLUMNS,
+        title="Marketplace Recipes",
+        entity_type="recipe",
+        base_url=ctx.obj.auth_url,
+    )
 
 
 @recipe_group.command("install")

--- a/deepvista_cli/commands/vistabase.py
+++ b/deepvista_cli/commands/vistabase.py
@@ -94,7 +94,14 @@ def vistabase_list(
         "has_more": data.get("has_more", False),
         "count": len(cards),
     }
-    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title="VistaBase Cards", entity_type="vistabase")
+    format_output(
+        result,
+        ctx.obj.output_format,
+        columns=CARD_COLUMNS,
+        title="VistaBase Cards",
+        entity_type="vistabase",
+        base_url=ctx.obj.auth_url,
+    )
 
 
 @vistabase_group.command("get")
@@ -103,7 +110,9 @@ def vistabase_list(
 def vistabase_get(ctx: click.Context, card_id: str) -> None:
     """Get a context card by ID."""
     data = _client(ctx).post("/get_context_card", {"card_id": card_id})
-    format_output(data, ctx.obj.output_format, title=f"Card: {card_id}", entity_type="vistabase")
+    format_output(
+        data, ctx.obj.output_format, title=f"Card: {card_id}", entity_type="vistabase", base_url=ctx.obj.auth_url
+    )
 
 
 @vistabase_group.command("create")
@@ -150,7 +159,7 @@ def vistabase_create(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Created Card", entity_type="vistabase")
+    format_output(data, ctx.obj.output_format, title="Created Card", entity_type="vistabase", base_url=ctx.obj.auth_url)
 
 
 @vistabase_group.command("update")
@@ -199,7 +208,13 @@ def vistabase_update(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/update_context_card", body)
-    format_output(data, ctx.obj.output_format, title=f"Updated Card: {card_id}", entity_type="vistabase")
+    format_output(
+        data,
+        ctx.obj.output_format,
+        title=f"Updated Card: {card_id}",
+        entity_type="vistabase",
+        base_url=ctx.obj.auth_url,
+    )
 
 
 @vistabase_group.command("delete")
@@ -215,7 +230,7 @@ def vistabase_delete(ctx: click.Context, card_id: str, card_type: str | None) ->
     if card_type:
         params["card_type"] = card_type
     data = _client(ctx).delete(f"/context_cards/{card_id}", params=params)
-    format_output(data, ctx.obj.output_format, entity_type="vistabase")
+    format_output(data, ctx.obj.output_format, entity_type="vistabase", base_url=ctx.obj.auth_url)
 
 
 # ---------------------------------------------------------------------------
@@ -241,7 +256,12 @@ def vistabase_search(ctx: click.Context, query: str, card_type: str | None, limi
     cards = data.get("cards", [])
     result = {"query": query, "results": cards, "count": len(cards)}
     format_output(
-        result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Search: {query}", entity_type="vistabase"
+        result,
+        ctx.obj.output_format,
+        columns=CARD_COLUMNS,
+        title=f"Search: {query}",
+        entity_type="vistabase",
+        base_url=ctx.obj.auth_url,
     )
 
 
@@ -269,7 +289,12 @@ def vistabase_similar(ctx: click.Context, card_id: str, limit: int) -> None:
     cards = [c for c in data.get("cards", []) if c.get("id") != card_id]
     result = {"source_card_id": card_id, "similar": cards, "count": len(cards)}
     format_output(
-        result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Similar to: {card_id}", entity_type="vistabase"
+        result,
+        ctx.obj.output_format,
+        columns=CARD_COLUMNS,
+        title=f"Similar to: {card_id}",
+        entity_type="vistabase",
+        base_url=ctx.obj.auth_url,
     )
 
 
@@ -282,7 +307,7 @@ def vistabase_pin(ctx: click.Context, card_id: str) -> None:
     > [!CAUTION] This is a write command.
     """
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "pinned"})
-    format_output(data, ctx.obj.output_format, entity_type="vistabase")
+    format_output(data, ctx.obj.output_format, entity_type="vistabase", base_url=ctx.obj.auth_url)
 
 
 @vistabase_group.command("+archive")
@@ -294,4 +319,4 @@ def vistabase_archive(ctx: click.Context, card_id: str) -> None:
     > [!CAUTION] This is a write command.
     """
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "archived"})
-    format_output(data, ctx.obj.output_format, entity_type="vistabase")
+    format_output(data, ctx.obj.output_format, entity_type="vistabase", base_url=ctx.obj.auth_url)

--- a/deepvista_cli/commands/vistabook.py
+++ b/deepvista_cli/commands/vistabook.py
@@ -50,7 +50,14 @@ def vistabook_list(ctx: click.Context, limit: int, page_number: int) -> None:
     )
     cards = data.get("cards", [])
     result = {"vistabooks": cards, "count": len(cards), "has_more": data.get("has_more", False)}
-    format_output(result, ctx.obj.output_format, columns=VISTABOOK_COLUMNS, title="VistaBooks", entity_type="vistabook")
+    format_output(
+        result,
+        ctx.obj.output_format,
+        columns=VISTABOOK_COLUMNS,
+        title="VistaBooks",
+        entity_type="vistabook",
+        base_url=ctx.obj.auth_url,
+    )
 
 
 @vistabook_group.command("get")
@@ -62,7 +69,13 @@ def vistabook_get(ctx: click.Context, vistabook_id: str) -> None:
     Read-only — never modifies the VistaBook.
     """
     data = _client(ctx).post("/get_context_card", {"card_id": vistabook_id, "card_type": "vistabook"})
-    format_output(data, ctx.obj.output_format, title=f"VistaBook: {vistabook_id}", entity_type="vistabook")
+    format_output(
+        data,
+        ctx.obj.output_format,
+        title=f"VistaBook: {vistabook_id}",
+        entity_type="vistabook",
+        base_url=ctx.obj.auth_url,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +128,7 @@ def vistabook_status(ctx: click.Context, run_id: str) -> None:
         "visibility": session.get("visibility", ""),
         "created_at": session.get("created_at", ""),
     }
-    format_output(result, ctx.obj.output_format, title=f"Run: {run_id}", entity_type="chat")
+    format_output(result, ctx.obj.output_format, title=f"Run: {run_id}", entity_type="chat", base_url=ctx.obj.auth_url)
 
 
 @vistabook_group.command("+export")
@@ -130,4 +143,6 @@ def vistabook_export(ctx: click.Context, vistabook_id: str, export_format: str) 
     Read-only — generates output but does not modify the VistaBook.
     """
     data = _client(ctx).post("/export_vistabook_to_skill", {"card_ids": [vistabook_id]})
-    format_output(data, ctx.obj.output_format, title=f"Export: {vistabook_id}", entity_type="vistabook")
+    format_output(
+        data, ctx.obj.output_format, title=f"Export: {vistabook_id}", entity_type="vistabook", base_url=ctx.obj.auth_url
+    )

--- a/deepvista_cli/output/formatter.py
+++ b/deepvista_cli/output/formatter.py
@@ -19,15 +19,17 @@ from deepvista_cli.config import DEFAULT_AUTH_URL
 # ---------------------------------------------------------------------------
 
 # URL patterns for different entity types
-# All context cards (vistabase, notes, recipes) use: /vistabase?contextId={id}
-# Chat sessions use: /chat?chatId={id}
+# Notes use: /notes/{id}
+# Recipes use: /recipes/{id}
+# Chat sessions use: /chat/{id}
+# Generic cards (vistabase) use: /vistabase?contextId={id}
 URL_PATTERNS = {
     "vistabase": "/vistabase?contextId={id}",
     "card": "/vistabase?contextId={id}",
     "note": "/notes/{id}",
     "recipe": "/recipes/{id}",
     "vistabook": "/recipes/{id}",
-    "chat": "/chat?chatId={id}",
+    "chat": "/chat/{id}",
 }
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.0a17"
+version = "0.1.0a18"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -81,7 +81,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "filelock", specifier = ">=3.12" },
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx", specifier = ">=0.27,<1" },
     { name = "rich", specifier = ">=13.0" },
     { name = "textual", marker = "extra == 'ui'", specifier = ">=0.80" },
 ]


### PR DESCRIPTION
## Summary

- Add web app URLs to all entity outputs (cards, notes, recipes, chat sessions)
- URLs are automatically generated based on entity type and profile's `auth_url`
- Included in both JSON and table output formats

## URL Patterns

| Entity Type | URL Pattern |
|-------------|-------------|
| Notes | `{base_url}/notes/{id}` |
| Chat Sessions | `{base_url}/chat/{id}` |
| Recipes/VistaBooks | `{base_url}/recipes/{id}` |
| Cards/VistaBase | `{base_url}/vistabase?contextId={id}` |

## Example Output

Before:
```json
{"id": "45aac061-6824-4d3e-8dcc-b976618f3397", "title": "My Note"}
```

After:
```json
{
  "id": "45aac061-6824-4d3e-8dcc-b976618f3397",
  "url": "https://app.deepvista.ai/notes/45aac061-6824-4d3e-8dcc-b976618f3397",
  "title": "My Note"
}
```

## Test Results (Local Profile)

| Command | URL |
|---------|-----|
| `uv run deepvista --profile local notes list` | `http://localhost:3000/notes/8e22a539-b6bf-42fc-8045-e2b2f3fc4062` |
| `uv run deepvista --profile local chat sessions` | `http://localhost:3000/chat/561310k3` |
| `uv run deepvista --profile local recipe list` | `http://localhost:3000/recipes/89a75fcf-8b29-4a63-8ed8-2b45939c8823` |
| `uv run deepvista --profile local recipe discover` | `http://localhost:3000/recipes/persona-researcher` |
| `uv run deepvista --profile local vistabase list` | `http://localhost:3000/vistabase?contextId=eb0d20f2-c14d-4ebf-a0d0-6ceb61892f35` |
| `uv run deepvista --profile local card list` | `http://localhost:3000/vistabase?contextId=eb0d20f2-c14d-4ebf-a0d0-6ceb61892f35` |

## Test Results (Production Profile)

| Command | URL |
|---------|-----|
| `uv run deepvista notes list` | `https://app.deepvista.ai/notes/bd8b1f70-a189-4298-8aeb-db100cef83d5` |
| `uv run deepvista chat sessions` | `https://app.deepvista.ai/chat/411313it` |
| `uv run deepvista recipe list` | `https://app.deepvista.ai/recipes/628d380a-5c9c-483a-885a-36c1a7ccbe8a` |
| `uv run deepvista vistabase list` | `https://app.deepvista.ai/vistabase?contextId=db78140d-e942-4c68-961c-795547dbc745` |

Resolves DV-223