### PR TITLE
feat(card): add vistabook and vistabook_run to CARD_TYPES

### DIFF
--- a/deepvista_cli/commands/card.py
+++ b/deepvista_cli/commands/card.py
@@ -28,6 +28,8 @@ CARD_TYPES = [
     "note",
     "recipe",
     "recipe_run",
+    "vistabook",
+    "vistabook_run",
 ]
 
 CARD_COLUMNS = ["id", "type", "title", "display_status", "updated_at"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.0a8"
+version = "0.1.0a9"
 description = "CLI for DeepVista — chat, notes, recipes, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary

- Adds `vistabook` and `vistabook_run` to the `CARD_TYPES` list in `card.py`
- These types are already supported by the API (used in `vistabook.py`) but were previously rejected by the CLI as invalid choices
- Fixes `deepvista card create --type vistabook` returning a usage error

## Test plan

- [ ] `deepvista card create --type vistabook --title "Test"` no longer errors with invalid choice
- [ ] `deepvista card list --type vistabook` works
- [ ] `deepvista card update <id> --type vistabook` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)