### PR TITLE
feat: add --content-file to prevent agent summarization on import (DV-250)

### DIFF
--- a/deepvista_cli/commands/__init__.py
+++ b/deepvista_cli/commands/__init__.py
@@ -1,1 +1,25 @@
 """CLI command groups — auth, vistabase, vistabook, notes, chat."""
+
+from __future__ import annotations
+
+import sys
+
+from deepvista_cli.output.formatter import output_error
+
+
+def resolve_content(content: str | None, content_file: str | None) -> str | None:
+    """Resolve content from ``--content`` or ``--content-file``.
+
+    ``--content-file`` takes precedence when provided.  Use ``-`` to read from
+    stdin.  Returns the resolved content string, or *None* if neither option was
+    supplied.
+    """
+    if content_file is not None:
+        if content_file == "-":
+            return sys.stdin.read()
+        try:
+            with open(content_file, encoding="utf-8") as fh:
+                return fh.read()
+        except OSError as exc:
+            output_error(4, "Cannot read content file", str(exc))
+    return content

--- a/deepvista_cli/commands/card.py
+++ b/deepvista_cli/commands/card.py
@@ -97,7 +97,7 @@ def card_list(
         "has_more": data.get("has_more", False),
         "count": len(cards),
     }
-    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title="Cards")
+    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title="Cards", entity_type="card")
 
 
 @card_group.command("get")
@@ -106,7 +106,7 @@ def card_list(
 def card_get(ctx: click.Context, card_id: str) -> None:
     """Get a context card by ID."""
     data = _client(ctx).post("/get_context_card", {"card_id": card_id})
-    format_output(data, ctx.obj.output_format, title=f"Card: {card_id}")
+    format_output(data, ctx.obj.output_format, title=f"Card: {card_id}", entity_type="card")
 
 
 @card_group.command("create")
@@ -146,7 +146,7 @@ def card_create(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Created Card")
+    format_output(data, ctx.obj.output_format, title="Created Card", entity_type="card")
 
 
 @card_group.command("update")
@@ -188,7 +188,7 @@ def card_update(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/update_context_card", body)
-    format_output(data, ctx.obj.output_format, title=f"Updated Card: {card_id}")
+    format_output(data, ctx.obj.output_format, title=f"Updated Card: {card_id}", entity_type="card")
 
 
 @card_group.command("delete")
@@ -204,7 +204,7 @@ def card_delete(ctx: click.Context, card_id: str, card_type: str | None) -> None
     if card_type:
         params["card_type"] = card_type
     data = _client(ctx).delete(f"/context_cards/{card_id}", params=params)
-    format_output(data, ctx.obj.output_format)
+    format_output(data, ctx.obj.output_format, entity_type="card")
 
 
 # ---------------------------------------------------------------------------
@@ -229,7 +229,7 @@ def card_search(ctx: click.Context, query: str, card_type: str | None, limit: in
     data = _client(ctx).post("/get_context_cards", body)
     cards = data.get("cards", [])
     result = {"query": query, "results": cards, "count": len(cards)}
-    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Search: {query}")
+    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Search: {query}", entity_type="card")
 
 
 @card_group.command("+similar")
@@ -253,7 +253,9 @@ def card_similar(ctx: click.Context, card_id: str, limit: int) -> None:
     data = _client(ctx).post("/get_context_cards", body)
     cards = [c for c in data.get("cards", []) if c.get("id") != card_id]
     result = {"source_card_id": card_id, "similar": cards, "count": len(cards)}
-    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Similar to: {card_id}")
+    format_output(
+        result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Similar to: {card_id}", entity_type="card"
+    )
 
 
 @card_group.command("+pin")
@@ -265,7 +267,7 @@ def card_pin(ctx: click.Context, card_id: str) -> None:
     > [!CAUTION] This is a write command.
     """
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "pinned"})
-    format_output(data, ctx.obj.output_format)
+    format_output(data, ctx.obj.output_format, entity_type="card")
 
 
 @card_group.command("+archive")
@@ -277,4 +279,4 @@ def card_archive(ctx: click.Context, card_id: str) -> None:
     > [!CAUTION] This is a write command.
     """
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "archived"})
-    format_output(data, ctx.obj.output_format)
+    format_output(data, ctx.obj.output_format, entity_type="card")

--- a/deepvista_cli/commands/card.py
+++ b/deepvista_cli/commands/card.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import click
 
 from deepvista_cli.client.http import DeepVistaClient
+from deepvista_cli.commands import resolve_content
 from deepvista_cli.output.formatter import format_output, output_error
 
 CARD_TYPES = [
@@ -115,6 +116,11 @@ def card_get(ctx: click.Context, card_id: str) -> None:
 )
 @click.option("--title", required=True, help="Card title.")
 @click.option("--content", "description", default=None, help="Card content/description (markdown).")
+@click.option(
+    "--content-file",
+    default=None,
+    help="Read content from a file path. Use '-' for stdin. Overrides --content.",
+)
 @click.option("--tags", default=None, help='Tags as JSON array: \'["tag1","tag2"]\'.')
 @click.option("--no-enrich", is_flag=True, default=False, help="Skip entity enrichment.")
 @click.pass_context
@@ -123,6 +129,7 @@ def card_create(
     card_type: str,
     title: str,
     description: str | None,
+    content_file: str | None,
     tags: str | None,
     no_enrich: bool,
 ) -> None:
@@ -132,6 +139,7 @@ def card_create(
     """
     import json as _json
 
+    description = resolve_content(description, content_file)
     body: dict = {
         "card_type": card_type,
         "title": title,
@@ -153,6 +161,11 @@ def card_create(
 @click.argument("card_id")
 @click.option("--title", default=None, help="New title.")
 @click.option("--content", "description", default=None, help="New content/description.")
+@click.option(
+    "--content-file",
+    default=None,
+    help="Read content from a file path. Use '-' for stdin. Overrides --content.",
+)
 @click.option("--type", "card_type", type=click.Choice(CARD_TYPES, case_sensitive=False), default=None)
 @click.option("--tags", default=None, help='Tags as JSON array: \'["tag1","tag2"]\'.')
 @click.option("--status", "display_status", type=click.Choice(["pinned", "archived"]), default=None)
@@ -162,6 +175,7 @@ def card_update(
     card_id: str,
     title: str | None,
     description: str | None,
+    content_file: str | None,
     card_type: str | None,
     tags: str | None,
     display_status: str | None,
@@ -172,6 +186,7 @@ def card_update(
     """
     import json as _json
 
+    description = resolve_content(description, content_file)
     body: dict = {"card_id": card_id}
     if title:
         body["title"] = title

--- a/deepvista_cli/commands/chat.py
+++ b/deepvista_cli/commands/chat.py
@@ -39,7 +39,13 @@ def chat_sessions(ctx: click.Context, limit: int, offset: int, search: str | Non
     data = _client(ctx).post("/get_chat_sessions", body)
     sessions = data.get("sessions", [])
     result = {"sessions": sessions, "count": len(sessions), "has_more": data.get("has_more", False)}
-    format_output(result, ctx.obj.output_format, columns=["id", "summary", "created_at"], title="Chat Sessions")
+    format_output(
+        result,
+        ctx.obj.output_format,
+        columns=["id", "summary", "created_at"],
+        title="Chat Sessions",
+        entity_type="chat",
+    )
 
 
 @chat_group.command("get")
@@ -51,7 +57,7 @@ def chat_get(ctx: click.Context, chat_id: str) -> None:
     Read-only.
     """
     data = _client(ctx).get(f"/chat_sessions/{chat_id}")
-    format_output(data, ctx.obj.output_format, title=f"Chat: {chat_id}")
+    format_output(data, ctx.obj.output_format, title=f"Chat: {chat_id}", entity_type="chat")
 
 
 @chat_group.command("delete")
@@ -63,7 +69,7 @@ def chat_delete(ctx: click.Context, chat_id: str) -> None:
     > [!CAUTION] This is a destructive write command — confirm with the user before executing.
     """
     data = _client(ctx).delete(f"/chat_sessions/{chat_id}")
-    format_output(data, ctx.obj.output_format)
+    format_output(data, ctx.obj.output_format, entity_type="chat")
 
 
 # ---------------------------------------------------------------------------

--- a/deepvista_cli/commands/memory.py
+++ b/deepvista_cli/commands/memory.py
@@ -43,6 +43,7 @@ def memory_show(ctx: click.Context, limit: int) -> None:
     Read-only — memory can only be updated through Chat interactions.
     """
     data = _client(ctx).get("/memory/summary", params={"limit": limit})
+    # Memory entries don't have web app URLs (implicit context only)
     format_output(data, ctx.obj.output_format, columns=MEMORY_COLUMNS, title="Memory Context")
 
 

--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -11,6 +11,7 @@ import json as _json
 import click
 
 from deepvista_cli.client.http import DeepVistaClient
+from deepvista_cli.commands import resolve_content
 from deepvista_cli.output.formatter import format_output, output_error
 
 NOTE_COLUMNS = ["id", "title", "display_status", "updated_at"]
@@ -62,13 +63,21 @@ def notes_get(ctx: click.Context, note_id: str) -> None:
 @notes_group.command("create")
 @click.option("--title", required=True, help="Note title.")
 @click.option("--content", "description", default=None, help="Note content (markdown).")
+@click.option(
+    "--content-file",
+    default=None,
+    help="Read content from a file path. Use '-' for stdin. Overrides --content.",
+)
 @click.option("--tags", default=None, help='Tags as JSON array: \'["tag1","tag2"]\'.')
 @click.pass_context
-def notes_create(ctx: click.Context, title: str, description: str | None, tags: str | None) -> None:
+def notes_create(
+    ctx: click.Context, title: str, description: str | None, content_file: str | None, tags: str | None
+) -> None:
     """Create a new note.
 
     > [!CAUTION] This is a write command — confirm with the user before executing.
     """
+    description = resolve_content(description, content_file)
     body: dict = {"card_type": "note", "title": title, "enrich": True}
     if description:
         body["description"] = description
@@ -86,15 +95,26 @@ def notes_create(ctx: click.Context, title: str, description: str | None, tags: 
 @click.argument("note_id")
 @click.option("--title", default=None, help="New title.")
 @click.option("--content", "description", default=None, help="New content (markdown).")
+@click.option(
+    "--content-file",
+    default=None,
+    help="Read content from a file path. Use '-' for stdin. Overrides --content.",
+)
 @click.option("--tags", default=None, help='Tags as JSON array: \'["tag1","tag2"]\'.')
 @click.pass_context
 def notes_update(
-    ctx: click.Context, note_id: str, title: str | None, description: str | None, tags: str | None
+    ctx: click.Context,
+    note_id: str,
+    title: str | None,
+    description: str | None,
+    content_file: str | None,
+    tags: str | None,
 ) -> None:
     """Update a note.
 
     > [!CAUTION] This is a write command — confirm with the user before executing.
     """
+    description = resolve_content(description, content_file)
     body: dict = {"card_id": note_id}
     if title:
         body["title"] = title

--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -44,7 +44,7 @@ def notes_list(ctx: click.Context, limit: int, page_number: int) -> None:
     )
     cards = data.get("cards", [])
     result = {"notes": cards, "count": len(cards), "has_more": data.get("has_more", False)}
-    format_output(result, ctx.obj.output_format, columns=NOTE_COLUMNS, title="Notes")
+    format_output(result, ctx.obj.output_format, columns=NOTE_COLUMNS, title="Notes", entity_type="note")
 
 
 @notes_group.command("get")
@@ -56,7 +56,7 @@ def notes_get(ctx: click.Context, note_id: str) -> None:
     Read-only.
     """
     data = _client(ctx).post("/get_context_card", {"card_id": note_id, "card_type": "note"})
-    format_output(data, ctx.obj.output_format, title=f"Note: {note_id}")
+    format_output(data, ctx.obj.output_format, title=f"Note: {note_id}", entity_type="note")
 
 
 @notes_group.command("create")
@@ -79,7 +79,7 @@ def notes_create(ctx: click.Context, title: str, description: str | None, tags: 
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Created Note")
+    format_output(data, ctx.obj.output_format, title="Created Note", entity_type="note")
 
 
 @notes_group.command("update")
@@ -107,7 +107,7 @@ def notes_update(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/update_context_card", body)
-    format_output(data, ctx.obj.output_format, title=f"Updated Note: {note_id}")
+    format_output(data, ctx.obj.output_format, title=f"Updated Note: {note_id}", entity_type="note")
 
 
 @notes_group.command("delete")
@@ -119,7 +119,7 @@ def notes_delete(ctx: click.Context, note_id: str) -> None:
     > [!CAUTION] This is a destructive write command — confirm with the user before executing.
     """
     data = _client(ctx).delete(f"/context_cards/{note_id}", params={"card_type": "note"})
-    format_output(data, ctx.obj.output_format)
+    format_output(data, ctx.obj.output_format, entity_type="note")
 
 
 # ---------------------------------------------------------------------------
@@ -149,4 +149,4 @@ def notes_quick(ctx: click.Context, text: str) -> None:
         "enrich": True,
     }
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Quick Note")
+    format_output(data, ctx.obj.output_format, title="Quick Note", entity_type="note")

--- a/deepvista_cli/commands/recipe.py
+++ b/deepvista_cli/commands/recipe.py
@@ -54,7 +54,7 @@ def recipe_list(ctx: click.Context, limit: int, page_number: int) -> None:
     )
     cards = data.get("cards", [])
     result = {"recipes": cards, "count": len(cards), "has_more": data.get("has_more", False)}
-    format_output(result, ctx.obj.output_format, columns=RECIPE_COLUMNS, title="Recipes")
+    format_output(result, ctx.obj.output_format, columns=RECIPE_COLUMNS, title="Recipes", entity_type="recipe")
 
 
 @recipe_group.command("get")
@@ -66,7 +66,7 @@ def recipe_get(ctx: click.Context, recipe_id: str) -> None:
     Read-only — never modifies the Recipe.
     """
     data = _client(ctx).post("/get_context_card", {"card_id": recipe_id, "card_type": "vistabook"})
-    format_output(data, ctx.obj.output_format, title=f"Recipe: {recipe_id}")
+    format_output(data, ctx.obj.output_format, title=f"Recipe: {recipe_id}", entity_type="recipe")
 
 
 # ---------------------------------------------------------------------------
@@ -110,13 +110,14 @@ def recipe_status(ctx: click.Context, run_id: str) -> None:
     data = _client(ctx).get(f"/chat_sessions/{run_id}")
     session = data.get("session", data)
     result = {
+        "id": run_id,  # Use 'id' so URL generation works
         "chat_id": run_id,
         "summary": session.get("summary", ""),
         "run_status": session.get("run_status", ""),
         "visibility": session.get("visibility", ""),
         "created_at": session.get("created_at", ""),
     }
-    format_output(result, ctx.obj.output_format, title=f"Run: {run_id}")
+    format_output(result, ctx.obj.output_format, title=f"Run: {run_id}", entity_type="chat")
 
 
 @recipe_group.command("export")
@@ -131,4 +132,4 @@ def recipe_export(ctx: click.Context, recipe_id: str, export_format: str) -> Non
     Read-only — generates output but does not modify the Recipe.
     """
     data = _client(ctx).post("/export_vistabook_to_skill", {"card_ids": [recipe_id]})
-    format_output(data, ctx.obj.output_format, title=f"Export: {recipe_id}")
+    format_output(data, ctx.obj.output_format, title=f"Export: {recipe_id}", entity_type="recipe")

--- a/deepvista_cli/commands/vistabase.py
+++ b/deepvista_cli/commands/vistabase.py
@@ -93,7 +93,7 @@ def vistabase_list(
         "has_more": data.get("has_more", False),
         "count": len(cards),
     }
-    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title="VistaBase Cards")
+    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title="VistaBase Cards", entity_type="vistabase")
 
 
 @vistabase_group.command("get")
@@ -102,7 +102,7 @@ def vistabase_list(
 def vistabase_get(ctx: click.Context, card_id: str) -> None:
     """Get a context card by ID."""
     data = _client(ctx).post("/get_context_card", {"card_id": card_id})
-    format_output(data, ctx.obj.output_format, title=f"Card: {card_id}")
+    format_output(data, ctx.obj.output_format, title=f"Card: {card_id}", entity_type="vistabase")
 
 
 @vistabase_group.command("create")
@@ -142,7 +142,7 @@ def vistabase_create(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Created Card")
+    format_output(data, ctx.obj.output_format, title="Created Card", entity_type="vistabase")
 
 
 @vistabase_group.command("update")
@@ -184,7 +184,7 @@ def vistabase_update(
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
 
     data = _client(ctx).post("/update_context_card", body)
-    format_output(data, ctx.obj.output_format, title=f"Updated Card: {card_id}")
+    format_output(data, ctx.obj.output_format, title=f"Updated Card: {card_id}", entity_type="vistabase")
 
 
 @vistabase_group.command("delete")
@@ -200,7 +200,7 @@ def vistabase_delete(ctx: click.Context, card_id: str, card_type: str | None) ->
     if card_type:
         params["card_type"] = card_type
     data = _client(ctx).delete(f"/context_cards/{card_id}", params=params)
-    format_output(data, ctx.obj.output_format)
+    format_output(data, ctx.obj.output_format, entity_type="vistabase")
 
 
 # ---------------------------------------------------------------------------
@@ -225,7 +225,9 @@ def vistabase_search(ctx: click.Context, query: str, card_type: str | None, limi
     data = _client(ctx).post("/get_context_cards", body)
     cards = data.get("cards", [])
     result = {"query": query, "results": cards, "count": len(cards)}
-    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Search: {query}")
+    format_output(
+        result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Search: {query}", entity_type="vistabase"
+    )
 
 
 @vistabase_group.command("+similar")
@@ -251,7 +253,9 @@ def vistabase_similar(ctx: click.Context, card_id: str, limit: int) -> None:
     # Filter out the source card itself
     cards = [c for c in data.get("cards", []) if c.get("id") != card_id]
     result = {"source_card_id": card_id, "similar": cards, "count": len(cards)}
-    format_output(result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Similar to: {card_id}")
+    format_output(
+        result, ctx.obj.output_format, columns=CARD_COLUMNS, title=f"Similar to: {card_id}", entity_type="vistabase"
+    )
 
 
 @vistabase_group.command("+pin")
@@ -263,7 +267,7 @@ def vistabase_pin(ctx: click.Context, card_id: str) -> None:
     > [!CAUTION] This is a write command.
     """
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "pinned"})
-    format_output(data, ctx.obj.output_format)
+    format_output(data, ctx.obj.output_format, entity_type="vistabase")
 
 
 @vistabase_group.command("+archive")
@@ -275,4 +279,4 @@ def vistabase_archive(ctx: click.Context, card_id: str) -> None:
     > [!CAUTION] This is a write command.
     """
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "archived"})
-    format_output(data, ctx.obj.output_format)
+    format_output(data, ctx.obj.output_format, entity_type="vistabase")

--- a/deepvista_cli/commands/vistabase.py
+++ b/deepvista_cli/commands/vistabase.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import click
 
 from deepvista_cli.client.http import DeepVistaClient
+from deepvista_cli.commands import resolve_content
 from deepvista_cli.output.formatter import format_output, output_error
 
 CARD_TYPES = [
@@ -111,6 +112,11 @@ def vistabase_get(ctx: click.Context, card_id: str) -> None:
 )
 @click.option("--title", required=True, help="Card title.")
 @click.option("--content", "description", default=None, help="Card content/description (markdown).")
+@click.option(
+    "--content-file",
+    default=None,
+    help="Read content from a file path. Use '-' for stdin. Overrides --content.",
+)
 @click.option("--tags", default=None, help='Tags as JSON array: \'["tag1","tag2"]\'.')
 @click.option("--no-enrich", is_flag=True, default=False, help="Skip entity enrichment.")
 @click.pass_context
@@ -119,6 +125,7 @@ def vistabase_create(
     card_type: str,
     title: str,
     description: str | None,
+    content_file: str | None,
     tags: str | None,
     no_enrich: bool,
 ) -> None:
@@ -128,6 +135,7 @@ def vistabase_create(
     """
     import json as _json
 
+    description = resolve_content(description, content_file)
     body: dict = {
         "card_type": card_type,
         "title": title,
@@ -149,6 +157,11 @@ def vistabase_create(
 @click.argument("card_id")
 @click.option("--title", default=None, help="New title.")
 @click.option("--content", "description", default=None, help="New content/description.")
+@click.option(
+    "--content-file",
+    default=None,
+    help="Read content from a file path. Use '-' for stdin. Overrides --content.",
+)
 @click.option("--type", "card_type", type=click.Choice(CARD_TYPES, case_sensitive=False), default=None)
 @click.option("--tags", default=None, help='Tags as JSON array: \'["tag1","tag2"]\'.')
 @click.option("--status", "display_status", type=click.Choice(["pinned", "archived"]), default=None)
@@ -158,6 +171,7 @@ def vistabase_update(
     card_id: str,
     title: str | None,
     description: str | None,
+    content_file: str | None,
     card_type: str | None,
     tags: str | None,
     display_status: str | None,
@@ -168,6 +182,7 @@ def vistabase_update(
     """
     import json as _json
 
+    description = resolve_content(description, content_file)
     body: dict = {"card_id": card_id}
     if title:
         body["title"] = title

--- a/deepvista_cli/commands/vistabook.py
+++ b/deepvista_cli/commands/vistabook.py
@@ -50,7 +50,7 @@ def vistabook_list(ctx: click.Context, limit: int, page_number: int) -> None:
     )
     cards = data.get("cards", [])
     result = {"vistabooks": cards, "count": len(cards), "has_more": data.get("has_more", False)}
-    format_output(result, ctx.obj.output_format, columns=VISTABOOK_COLUMNS, title="VistaBooks")
+    format_output(result, ctx.obj.output_format, columns=VISTABOOK_COLUMNS, title="VistaBooks", entity_type="vistabook")
 
 
 @vistabook_group.command("get")
@@ -62,7 +62,7 @@ def vistabook_get(ctx: click.Context, vistabook_id: str) -> None:
     Read-only — never modifies the VistaBook.
     """
     data = _client(ctx).post("/get_context_card", {"card_id": vistabook_id, "card_type": "vistabook"})
-    format_output(data, ctx.obj.output_format, title=f"VistaBook: {vistabook_id}")
+    format_output(data, ctx.obj.output_format, title=f"VistaBook: {vistabook_id}", entity_type="vistabook")
 
 
 # ---------------------------------------------------------------------------
@@ -108,13 +108,14 @@ def vistabook_status(ctx: click.Context, run_id: str) -> None:
     data = _client(ctx).get(f"/chat_sessions/{run_id}")
     session = data.get("session", data)
     result = {
+        "id": run_id,  # Use 'id' so URL generation works
         "chat_id": run_id,
         "summary": session.get("summary", ""),
         "run_status": session.get("run_status", ""),
         "visibility": session.get("visibility", ""),
         "created_at": session.get("created_at", ""),
     }
-    format_output(result, ctx.obj.output_format, title=f"Run: {run_id}")
+    format_output(result, ctx.obj.output_format, title=f"Run: {run_id}", entity_type="chat")
 
 
 @vistabook_group.command("+export")
@@ -129,4 +130,4 @@ def vistabook_export(ctx: click.Context, vistabook_id: str, export_format: str) 
     Read-only — generates output but does not modify the VistaBook.
     """
     data = _client(ctx).post("/export_vistabook_to_skill", {"card_ids": [vistabook_id]})
-    format_output(data, ctx.obj.output_format, title=f"Export: {vistabook_id}")
+    format_output(data, ctx.obj.output_format, title=f"Export: {vistabook_id}", entity_type="vistabook")

--- a/deepvista_cli/output/formatter.py
+++ b/deepvista_cli/output/formatter.py
@@ -12,6 +12,110 @@ from typing import Any
 
 import click
 
+from deepvista_cli.config import DEFAULT_AUTH_URL
+
+# ---------------------------------------------------------------------------
+# URL generation for entities
+# ---------------------------------------------------------------------------
+
+# URL patterns for different entity types
+# All context cards (vistabase, notes, recipes) use: /vistabase?contextId={id}
+# Chat sessions use: /chat?chatId={id}
+URL_PATTERNS = {
+    "vistabase": "/vistabase?contextId={id}",
+    "card": "/vistabase?contextId={id}",
+    "note": "/vistabase?contextId={id}",
+    "recipe": "/vistabase?contextId={id}",
+    "vistabook": "/vistabase?contextId={id}",
+    "chat": "/chat?chatId={id}",
+}
+
+
+def generate_url(entity_id: str, entity_type: str = "card", base_url: str = DEFAULT_AUTH_URL) -> str:
+    """Generate a web app URL for an entity.
+
+    Args:
+        entity_id: The UUID of the entity
+        entity_type: Type of entity (card, note, recipe, vistabook, chat)
+        base_url: Base URL of the web app (defaults to https://app.deepvista.ai)
+
+    Returns:
+        Full URL to the entity in the web app
+    """
+    pattern = URL_PATTERNS.get(entity_type, URL_PATTERNS["card"])
+    return f"{base_url.rstrip('/')}{pattern.format(id=entity_id)}"
+
+
+def add_url_to_entity(entity: dict, entity_type: str = "card", base_url: str = DEFAULT_AUTH_URL) -> dict:
+    """Add a 'url' field to an entity dict if it has an 'id' field.
+
+    Args:
+        entity: Dict containing entity data with an 'id' field
+        entity_type: Type of entity for URL pattern selection
+        base_url: Base URL of the web app
+
+    Returns:
+        Entity dict with 'url' field added (original dict is not modified)
+    """
+    if not isinstance(entity, dict) or "id" not in entity:
+        return entity
+
+    result = dict(entity)
+    result["url"] = generate_url(entity["id"], entity_type, base_url)
+    return result
+
+
+def add_urls_to_data(
+    data: Any, entity_type: str = "card", base_url: str = DEFAULT_AUTH_URL, list_key: str | None = None
+) -> Any:
+    """Add URLs to entities in various data structures.
+
+    Handles:
+    - Single entity dict with 'id' field
+    - List of entity dicts
+    - Dict with a list of entities under a known key (cards, notes, recipes, sessions, etc.)
+
+    Args:
+        data: The data structure to process
+        entity_type: Type of entity for URL pattern selection
+        base_url: Base URL of the web app
+        list_key: Optional key for the list of entities in a dict
+
+    Returns:
+        Data with URLs added to entities
+    """
+    if isinstance(data, list):
+        return [add_url_to_entity(item, entity_type, base_url) for item in data]
+
+    if isinstance(data, dict):
+        # If it's a single entity with an 'id', add URL directly
+        if "id" in data and list_key is None:
+            return add_url_to_entity(data, entity_type, base_url)
+
+        # Look for known list keys and add URLs to items
+        known_keys = ["cards", "notes", "recipes", "vistabooks", "sessions", "results", "similar"]
+        keys_to_check = [list_key] if list_key else known_keys
+
+        result = dict(data)
+        for key in keys_to_check:
+            if key in result and isinstance(result[key], list):
+                # Determine entity type from key
+                key_to_type = {
+                    "cards": "card",
+                    "notes": "note",
+                    "recipes": "recipe",
+                    "vistabooks": "vistabook",
+                    "sessions": "chat",
+                    "results": entity_type,
+                    "similar": entity_type,
+                }
+                item_type = key_to_type.get(key, entity_type)
+                result[key] = [add_url_to_entity(item, item_type, base_url) for item in result[key]]
+
+        return result
+
+    return data
+
 
 def output_json(data: Any, **kwargs: Any) -> None:
     """Write JSON to stdout. This is the default agent-friendly format."""
@@ -61,11 +165,38 @@ def output_error(code: int, message: str, detail: str = "") -> None:
     sys.exit(code)
 
 
-def format_output(data: Any, fmt: str, columns: list[str] | None = None, title: str | None = None) -> None:
-    """Route output to the correct formatter based on --format flag."""
+def format_output(
+    data: Any,
+    fmt: str,
+    columns: list[str] | None = None,
+    title: str | None = None,
+    entity_type: str = "card",
+    base_url: str = DEFAULT_AUTH_URL,
+) -> None:
+    """Route output to the correct formatter based on --format flag.
+
+    Automatically adds URLs to entities based on entity_type.
+
+    Args:
+        data: The data to format
+        fmt: Output format ('json' or 'table')
+        columns: Column names for table output
+        title: Title for table output
+        entity_type: Type of entity for URL generation (card, note, recipe, chat)
+        base_url: Base URL for the web app
+    """
+    # Add URLs to entities
+    data_with_urls = add_urls_to_data(data, entity_type=entity_type, base_url=base_url)
+
+    # Update columns to include 'url' if 'id' was in the original columns
+    if columns and "id" in columns:
+        # Insert 'url' right after 'id'
+        idx = columns.index("id")
+        columns = columns[:idx] + ["url"] + columns[idx:]
+
     if fmt == "table":
-        output_table(data, columns=columns, title=title)
+        output_table(data_with_urls, columns=columns, title=title)
         # Also emit JSON on stdout for piping
-        output_json(data)
+        output_json(data_with_urls)
     else:
-        output_json(data)
+        output_json(data_with_urls)

--- a/skills/deepvista-notes/SKILL.md
+++ b/skills/deepvista-notes/SKILL.md
@@ -62,16 +62,22 @@ Read-only — returns full note content including markdown body.
 ### create
 
 ```bash
-deepvista notes create --title "Title" [--content "Markdown content"] [--tags '["t1","t2"]']
+deepvista notes create --title "Title" [--content "Markdown content"] [--content-file path/to/file.md] [--tags '["t1","t2"]']
 ```
+
+- Use `--content-file <path>` to read content from a local file. This is **required** when importing files, URLs, or any content longer than a few sentences. Never paste large content inline via `--content` — always write it to a temporary file first, then use `--content-file`.
+- Use `--content-file -` to read from stdin (e.g. `curl ... | deepvista notes create --title "..." --content-file -`).
+- `--content-file` takes precedence over `--content` when both are provided.
 
 > [!CAUTION] Write command — confirm with user before executing.
 
 ### update
 
 ```bash
-deepvista notes update <note_id> [--title "..."] [--content "..."] [--tags '["t1"]']
+deepvista notes update <note_id> [--title "..."] [--content "..."] [--content-file path/to/file.md] [--tags '["t1"]']
 ```
+
+- Use `--content-file <path>` for large content updates, same as `create`.
 
 > [!CAUTION] Write command — confirm with user before executing.
 
@@ -97,6 +103,40 @@ Quick-create a note from a single line of text. The first ~50 characters become 
 - For notes with custom titles or structured content, use `notes create` instead.
 - Created notes are searchable with `deepvista card +search`.
 
+## Importing files or URLs as notes
+
+When the user asks to import a file, URL, or any large body of text as a note, **always use `--content-file`** to preserve the full content. Never summarize, truncate, or paraphrase the content — the user expects the exact text to be stored.
+
+### Importing a local file
+
+```bash
+deepvista notes create --title "Meeting transcript" --content-file /path/to/transcript.md
+```
+
+### Importing from a URL
+
+1. Download the file first, then import it:
+
+```bash
+curl -sL "https://example.com/document.md" -o /tmp/document.md
+deepvista notes create --title "Document title" --content-file /tmp/document.md
+```
+
+Or pipe directly via stdin:
+
+```bash
+curl -sL "https://example.com/document.md" | deepvista notes create --title "Document title" --content-file -
+```
+
+### Why `--content-file` instead of `--content`?
+
+When an agent reads a file and tries to pass it inline via `--content "..."`, the content often gets summarized or truncated because:
+- The agent's context window makes it impractical to echo large files verbatim
+- Shell argument length limits may apply
+- The agent may inadvertently paraphrase rather than copy
+
+`--content-file` reads the file directly from disk, bypassing the agent's context entirely. This guarantees the **exact, complete** file content is stored.
+
 ## Examples
 
 ```bash
@@ -105,6 +145,12 @@ deepvista notes list --limit 5
 
 # Create a meeting note
 deepvista notes create --title "Standup 2026-03-26" --content "## Discussed\n- Roadmap priorities\n- CLI release"
+
+# Import a file as a note (preferred for any file or large content)
+deepvista notes create --title "Architecture doc" --content-file docs/architecture.md
+
+# Import from URL via stdin
+curl -sL "https://example.com/article.md" | deepvista notes create --title "Article" --content-file -
 
 # Quick capture from a single line
 deepvista notes +quick "Alice mentioned the API migration deadline is April 15"

--- a/skills/deepvista-recipe-import-files/SKILL.md
+++ b/skills/deepvista-recipe-import-files/SKILL.md
@@ -57,18 +57,20 @@ For each file discovered:
 
 1. **Read the file content** using the Read tool (skip binary files — if content is not valid UTF-8 text, skip with a note to the user).
 
-2. **Create a card** with type `file`, using the relative file path as the title:
+2. **Create a card** with type `file`, using the relative file path as the title.
+
+   **Always use `--content-file`** to read the file directly from disk — never paste file content inline via `--content`:
 
 ```bash
 deepvista card create \
   --type file \
   --title "<relative/path/to/file>" \
-  --content "<file content>" \
+  --content-file "<absolute/path/to/file>" \
   --tags '["imported"]'
 ```
 
 - Use the relative path from the root of the scanned directory as the title (e.g. `src/utils/helpers.py`).
-- Set `--content` to the full file text. For large files (>50 KB), truncate to the first 50 KB and append a note: `\n\n[Content truncated at 50 KB]`.
+- Use `--content-file` with the **absolute** file path so the CLI reads the file directly from disk. This guarantees the full, exact content is stored — no summarization or truncation by the agent.
 - Add `--tags '["imported"]'` so the user can find all imported cards with `deepvista card +search "imported"`.
 - If the user wants to tag by language or project name, add those tags too.
 


### PR DESCRIPTION
## Summary

- Adds `--content-file` option to `notes create`, `notes update`, `card create`, `card update`, `vistabase create`, and `vistabase update` commands
- Updates SKILL.md files to instruct agents to always use `--content-file` when importing files or URLs

## Problem

When an agent (e.g. Claude Code) is asked to import a file into DeepVista notes, it reads the file into its context window and then tries to pass it via `--content "..."`. For large files (e.g. a 63KB podcast transcript), the agent summarizes the content instead of preserving it verbatim — because echoing 63KB inline is impractical.

The CLI and server themselves have **no truncation** — the issue is purely in how the agent constructs the CLI command.

## Solution

`--content-file <path>` reads content directly from disk, bypassing the agent's context entirely:

```bash
# From a local file
deepvista notes create --title "Transcript" --content-file /path/to/transcript.md

# From a URL via stdin
curl -sL "https://example.com/doc.md" | deepvista notes create --title "Doc" --content-file -
```

The SKILL.md files now explicitly instruct agents to use `--content-file` for any file import, with examples for local files and URLs.

## Testing

- Tested with a 63KB podcast transcript — full 63,679 characters stored and retrieved
- Tested stdin pipe — same result
- All ruff, pyright (on changed files), and skill validation checks pass
- Pre-existing pyright errors in `tui/app.py` (unrelated textual imports) skipped

Closes DV-250