### PR TITLE
feat: add recipe discover and install CLI commands

### DIFF
--- a/deepvista_cli/commands/recipe.py
+++ b/deepvista_cli/commands/recipe.py
@@ -132,3 +132,59 @@ def recipe_export(ctx: click.Context, recipe_id: str, export_format: str) -> Non
     """
     data = _client(ctx).post("/export_vistabook_to_skill", {"card_ids": [recipe_id]})
     format_output(data, ctx.obj.output_format, title=f"Export: {recipe_id}")
+
+
+# ---------------------------------------------------------------------------
+# Marketplace: Discover & Install
+# ---------------------------------------------------------------------------
+
+DISCOVER_COLUMNS = ["id", "title", "category", "version", "installed"]
+
+
+@recipe_group.command("discover")
+@click.option("--search", "-s", default=None, help="Search term to filter recipes.")
+@click.option(
+    "--category",
+    "-c",
+    type=click.Choice(["persona", "productivity", "workflow"]),
+    default=None,
+    help="Filter by category.",
+)
+@click.option("--limit", default=50, help="Max results (default 50).")
+@click.pass_context
+def recipe_discover(ctx: click.Context, search: str | None, category: str | None, limit: int) -> None:
+    """Discover public recipes from the marketplace.
+
+    Read-only — browse available recipes without installing anything.
+    Use `deepvista recipe install <id>` to install a recipe.
+    """
+    body: dict = {"limit": limit, "offset": 0}
+    if search:
+        body["search"] = search
+    if category:
+        body["category"] = category
+
+    data = _client(ctx).post("/discover_recipes", body)
+    recipes = data.get("recipes", [])
+    result = {"recipes": recipes, "count": len(recipes), "has_more": data.get("has_more", False)}
+    format_output(result, ctx.obj.output_format, columns=DISCOVER_COLUMNS, title="Marketplace Recipes")
+
+
+@recipe_group.command("install")
+@click.argument("recipe_id")
+@click.pass_context
+def recipe_install(ctx: click.Context, recipe_id: str) -> None:
+    """Install a marketplace recipe into your library.
+
+    > [!CAUTION] This is a write command — it creates a new Recipe in your
+    > library from the marketplace. Confirm with the user before executing.
+
+    The recipe_id must match an entry in the marketplace registry.
+    Use `deepvista recipe discover` to browse available recipes.
+    """
+    data = _client(ctx).post("/install_marketplace_recipe", {"recipe_id": recipe_id})
+
+    if data.get("already_installed"):
+        click.echo(json.dumps({"status": "already_installed", "card": data.get("card", {})}, indent=2, default=str))
+    else:
+        click.echo(json.dumps({"status": "installed", "card": data.get("card", {})}, indent=2, default=str))

--- a/skills/deepvista-recipe/SKILL.md
+++ b/skills/deepvista-recipe/SKILL.md
@@ -89,6 +89,35 @@ Export a Recipe as a SKILL.md file for use in AI agents.
 
 Read-only — generates output but does not modify the Recipe.
 
+### discover
+
+```bash
+deepvista recipe discover [--search "query"] [--category persona|productivity|workflow] [--limit N]
+```
+
+Read-only — browse available recipes from the marketplace.
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--search` / `-s` | No | — | Filter by title or description |
+| `--category` / `-c` | No | — | Filter: persona, productivity, workflow |
+| `--limit` | No | 50 | Max results |
+
+### install
+
+```bash
+deepvista recipe install <recipe_id>
+```
+
+Install a marketplace recipe into your library.
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `<recipe_id>` | Yes | — | ID from `deepvista recipe discover` output |
+
+> [!CAUTION]
+> Write command — creates a new Recipe in your library. Confirm with the user before executing.
+
 ## Examples
 
 ```bash
@@ -103,6 +132,15 @@ deepvista recipe status chat_xyz789
 
 # Export as a skill for other agents
 deepvista recipe export vb_abc123 --format skill
+
+# Browse marketplace recipes
+deepvista recipe discover --category persona
+
+# Search marketplace
+deepvista recipe discover --search "email"
+
+# Install a marketplace recipe
+deepvista recipe install persona-researcher
 ```
 
 ## See Also


### PR DESCRIPTION

https://app.visla.us/clip/1491588581653803154


## Summary
- Add `deepvista recipe discover` — browse/search the marketplace registry with `--search`, `--category`, and `--limit` options
- Add `deepvista recipe install <id>` — install a marketplace recipe into the user's library (calls `/install_marketplace_recipe` backend endpoint)
- Update `skills/deepvista-recipe/SKILL.md` with documentation for new commands

Companion PR: https://github.com/DeepVista-AI/deepvista/pull/1706

## Test plan
- [ ] `deepvista recipe discover` returns marketplace recipes
- [ ] `deepvista recipe discover --search "email"` filters results
- [ ] `deepvista recipe discover --category persona` shows only personas
- [ ] `deepvista recipe install persona-researcher` installs the recipe
- [ ] Re-running install returns `already_installed: true`