### PR TITLE
release: v0.1.0a11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.0a10"
+version = "0.1.0a11"
 description = "CLI for DeepVista — chat, notes, recipes, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Summary
- Bump version from 0.1.0a10 to 0.1.0a11

## Test plan
- [ ] CI passes
- [ ] Package publishes to PyPI after tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)