### PR TITLE
fix: remove recipe and recipe_run from card CARD_TYPES

### DIFF
--- a/deepvista_cli/commands/card.py
+++ b/deepvista_cli/commands/card.py
@@ -26,8 +26,6 @@ CARD_TYPES = [
     "keypoint",
     "file",
     "note",
-    "recipe",
-    "recipe_run",
     "vistabook",
     "vistabook_run",
 ]


### PR DESCRIPTION
## Summary
- Removes `recipe` and `recipe_run` from `CARD_TYPES` in `card.py`
- These types are not accepted by the API (returns 422), which only supports: `person`, `organization`, `message`, `todo`, `topic`, `keypoint`, `file`, `note`, `vistabook`, `vistabook_run`

## Test plan
- [ ] Run `deepvista card create --type recipe ...` and confirm it is no longer an accepted option
- [ ] Run `deepvista card create --type vistabook ...` and confirm it still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)