### PR TITLE
fix: use correct clawhub publish command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,7 @@ jobs:
             skill_name=$(basename "$skill_dir")
             echo "Publishing $skill_name v$VERSION..."
 
-            clawhub skill publish "$skill_dir" \
+            clawhub publish "$skill_dir" \
               --slug "$skill_name" \
               --version "$VERSION" \
               --tags latest \


### PR DESCRIPTION
The command is `clawhub publish`, not `clawhub skill publish`.

This fixes the ClawHub publishing step that failed in v0.1.0a13.