### PR TITLE
fix: use correct URL patterns for recipes and notes

### DIFF
--- a/deepvista_cli/output/formatter.py
+++ b/deepvista_cli/output/formatter.py
@@ -24,9 +24,9 @@ from deepvista_cli.config import DEFAULT_AUTH_URL
 URL_PATTERNS = {
     "vistabase": "/vistabase?contextId={id}",
     "card": "/vistabase?contextId={id}",
-    "note": "/vistabase?contextId={id}",
-    "recipe": "/vistabase?contextId={id}",
-    "vistabook": "/vistabase?contextId={id}",
+    "note": "/notes/{id}",
+    "recipe": "/recipes/{id}",
+    "vistabook": "/recipes/{id}",
     "chat": "/chat?chatId={id}",
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.0a16"
+version = "0.1.0a17"
 description = "CLI for DeepVista — chat, notes, recipes, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/skills/deepvista-recipe/SKILL.md
+++ b/skills/deepvista-recipe/SKILL.md
@@ -30,7 +30,7 @@ Recipes are structured checklist workflows. Each Recipe is a template with phase
 After any write operation (run, create), always show the recipe URL to the user:
 
 ```
-https://app.deepvista.ai/memory?contextId=<id>
+https://app.deepvista.ai/recipes/<id>
 ```
 
 Extract the `id` from the JSON response and present it as a clickable link.


### PR DESCRIPTION
## Problem

Recipe and note URLs generated by the CLI formatter were pointing to the wrong paths:
- Recipes → `/vistabase?contextId={id}` (wrong)
- Notes → `/vistabase?contextId={id}` (wrong)
- Recipe SKILL.md → `/memory?contextId=<id>` (wrong)

## Fix

- **Recipes/vistabooks** now use `/recipes/{id}`
- **Notes** now use `/notes/{id}`
- Updated `skills/deepvista-recipe/SKILL.md` to show the correct URL format

## Files Changed

- `deepvista_cli/output/formatter.py` — Fixed `URL_PATTERNS` dict
- `skills/deepvista-recipe/SKILL.md` — Fixed example URL in docs