### PR TITLE
feat(DV-280): add edit and +grep commands to card CLI

### DIFF
--- a/deepvista_cli/commands/card.py
+++ b/deepvista_cli/commands/card.py
@@ -1,4 +1,4 @@
-"""deepvista card — CRUD + search for context cards (knowledge base).
+"""deepvista card — CRUD + file-ops for context cards (knowledge base).
 
 Five resources: card · recipe · memory · chat · skill
 
@@ -7,6 +7,8 @@ Endpoints:
   POST /get_context_card       -> get by id
   POST /create_context_card    -> create
   POST /update_context_card    -> update
+  POST /edit_context_card      -> targeted string replacement (file-ops Edit)
+  POST /grep_context_cards     -> regex content search (file-ops Grep)
   DELETE /context_cards/{id}   -> delete
 """
 
@@ -206,6 +208,39 @@ def card_update(
     format_output(data, ctx.obj.output_format, title=f"Updated Card: {card_id}", entity_type="card")
 
 
+@card_group.command("edit")
+@click.argument("card_id")
+@click.option("--old-string", required=True, help="The exact text to find in the card content.")
+@click.option("--new-string", required=True, help="The replacement text.")
+@click.option(
+    "--replace-all", is_flag=True, default=False, help="Replace all occurrences (default: unique match only)."
+)
+@click.pass_context
+def card_edit(
+    ctx: click.Context,
+    card_id: str,
+    old_string: str,
+    new_string: str,
+    replace_all: bool,
+) -> None:
+    """Targeted string replacement in a card's content.
+
+    Like Claude Code's Edit tool — finds old_string in the card description
+    and replaces it with new_string. By default, old_string must appear
+    exactly once (provide more context to disambiguate).
+
+    > [!CAUTION] This is a write command — confirm with the user before executing.
+    """
+    body: dict = {
+        "card_id": card_id,
+        "old_string": old_string,
+        "new_string": new_string,
+        "replace_all": replace_all,
+    }
+    data = _client(ctx).post("/edit_context_card", body)
+    format_output(data, ctx.obj.output_format, title=f"Edited Card: {card_id}", entity_type="card")
+
+
 @card_group.command("delete")
 @click.argument("card_id")
 @click.option("--type", "card_type", default=None, help="Card type hint (optional, speeds up deletion).")
@@ -295,3 +330,38 @@ def card_archive(ctx: click.Context, card_id: str) -> None:
     """
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "archived"})
     format_output(data, ctx.obj.output_format, entity_type="card")
+
+
+@card_group.command("+grep")
+@click.argument("pattern")
+@click.option("--type", "card_type", type=click.Choice(CARD_TYPES, case_sensitive=False), default=None)
+@click.option("-i", "--ignore-case", is_flag=True, default=False, help="Case-insensitive matching.")
+@click.option("--limit", default=20, help="Max cards to return (default 20).")
+@click.option("-C", "--context", "context_lines", default=0, type=int, help="Lines of context around each match.")
+@click.pass_context
+def card_grep(
+    ctx: click.Context,
+    pattern: str,
+    card_type: str | None,
+    ignore_case: bool,
+    limit: int,
+    context_lines: int,
+) -> None:
+    """Regex search through card content. Returns matching lines with line numbers.
+
+    Different from +search (semantic/keyword) — this does literal/regex matching
+    on card content, like grep or ripgrep.
+
+    Read-only — never modifies your knowledge base.
+    """
+    body: dict = {
+        "pattern": pattern,
+        "case_insensitive": ignore_case,
+        "limit": limit,
+        "context_lines": context_lines,
+    }
+    if card_type:
+        body["card_type"] = card_type
+
+    data = _client(ctx).post("/grep_context_cards", body)
+    format_output(data, ctx.obj.output_format, title=f"Grep: {pattern}", entity_type="card")

--- a/skills/deepvista-vistabase-card/SKILL.md
+++ b/skills/deepvista-vistabase-card/SKILL.md
@@ -74,6 +74,23 @@ deepvista card update <card_id> [--title "..."] [--content "..."] [--type TYPE] 
 
 > [!CAUTION] Write command — confirm with user before executing.
 
+### edit
+
+```bash
+deepvista card edit <card_id> --old-string "text to find" --new-string "replacement" [--replace-all]
+```
+
+Targeted string replacement in a card's content — like Claude Code's Edit tool. Finds `old_string` in the card description and replaces it with `new_string`. By default, `old_string` must appear exactly once (provide more surrounding context to disambiguate).
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `<card_id>` | Yes | — | Card to edit |
+| `--old-string` | Yes | — | Exact text to find |
+| `--new-string` | Yes | — | Replacement text |
+| `--replace-all` | No | false | Replace all occurrences |
+
+> [!CAUTION] Write command — confirm with user before executing.
+
 ### delete
 
 ```bash
@@ -126,6 +143,24 @@ deepvista card +archive <card_id>
 
 > [!CAUTION] Write command.
 
+### +grep
+
+```bash
+deepvista card +grep "pattern" [--type TYPE] [-i] [--limit N] [-C N]
+```
+
+Regex search through card content. Returns matching lines with line numbers — like grep or ripgrep. Different from `+search` (semantic/keyword): this does literal/regex matching on card content.
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `<pattern>` | Yes | — | Regex pattern to search for |
+| `--type` | No | all | Filter by card type |
+| `-i` / `--ignore-case` | No | false | Case-insensitive matching |
+| `--limit` | No | 20 | Max cards to return |
+| `-C` / `--context` | No | 0 | Lines of context around each match |
+
+Read-only. Use `card get <id>` to read the full content of a result.
+
 ## Card Types
 
 `person`, `organization`, `message`, `todo`, `topic`, `keypoint`, `file`, `note`, `recipe`, `recipe_run`
@@ -139,11 +174,20 @@ deepvista card +search "quarterly metrics"
 # Find people related to a topic
 deepvista card +search "machine learning team" --type person
 
+# Grep for a specific pattern in card content
+deepvista card +grep "TODO|FIXME" --type note -i
+
+# Grep with context lines
+deepvista card +grep "API endpoint" -C 2
+
 # List all notes
 deepvista card list --type note
 
 # Create a topic card
 deepvista card create --type topic --title "Machine Learning Strategy" --content "Our approach to ML..."
+
+# Edit a card's content (targeted replacement)
+deepvista card edit abc123 --old-string "old API URL" --new-string "new API URL"
 
 # Pin an important card
 deepvista card +pin abc123

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.0a12"
+version = "0.1.0a17"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -75,7 +75,6 @@ dev = [
     { name = "pre-commit" },
     { name = "pyright" },
     { name = "ruff" },
-    { name = "skills-ref" },
 ]
 
 [package.metadata]
@@ -93,7 +92,6 @@ dev = [
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pyright", specifier = ">=1.1" },
     { name = "ruff", specifier = ">=0.4" },
-    { name = "skills-ref", specifier = ">=0.1.1" },
 ]
 
 [[package]]
@@ -276,18 +274,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-dateutil"
-version = "2.9.0.post0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
 name = "python-discovery"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -382,40 +368,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
     { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
     { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
-]
-
-[[package]]
-name = "six"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
-]
-
-[[package]]
-name = "skills-ref"
-version = "0.1.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "strictyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/23/42/943d3ba8b097af7068b7178563a5062ad8a977982f4a7b4f67facfc575e9/skills_ref-0.1.1.tar.gz", hash = "sha256:6b400ca6e0049be62dca0167ff943ba2745fd67efb37fbba4d0ee341fccd2695", size = 93519, upload-time = "2026-01-10T13:23:41.423Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/af/25/36a43c3a61fb6cc3984e6ad5e556929b8ae71c95eba615dae4cf2f427964/skills_ref-0.1.1-py3-none-any.whl", hash = "sha256:d35db5bb8de71ae301daf5ca9cb71f8a555e8c6f83a6d40e46a5bc09f8f461b5", size = 12918, upload-time = "2026-01-10T13:23:40.106Z" },
-]
-
-[[package]]
-name = "strictyaml"
-version = "1.7.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/08/efd28d49162ce89c2ad61a88bd80e11fb77bc9f6c145402589112d38f8af/strictyaml-1.7.3.tar.gz", hash = "sha256:22f854a5fcab42b5ddba8030a0e4be51ca89af0267961c8d6cfa86395586c407", size = 115206, upload-time = "2023-03-10T12:50:27.062Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/7c/a81ef5ef10978dd073a854e0fa93b5d8021d0594b639cc8f6453c3c78a1d/strictyaml-1.7.3-py3-none-any.whl", hash = "sha256:fb5c8a4edb43bebb765959e420f9b3978d7f1af88c80606c03fb420888f5d1c7", size = 123917, upload-time = "2023-03-10T12:50:17.242Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Companion to DeepVista-AI/deepvista#1715. Adds CLI commands for the new file-ops API endpoints.

**Linear:** [DV-280](https://linear.app/deepvista/issue/DV-280)

### New commands

- **`deepvista card edit <card_id>`** — Targeted string replacement in card content
  - `--old-string` / `--new-string` — the text to find and replace
  - `--replace-all` — replace all occurrences (default: unique match only)
  
- **`deepvista card +grep <pattern>`** — Regex search through card content
  - `--type` — filter by card type
  - `-i` / `--ignore-case` — case-insensitive matching
  - `-C` / `--context` — lines of context around matches
  - `--limit` — max cards to return

### Updated

- `skills/deepvista-vistabase-card/SKILL.md` — documents both new commands with examples

## Test plan

- [x] `deepvista card edit <id> --old-string "x" --new-string "y"` replaces content
- [x] `deepvista card edit` with ambiguous old_string returns error
- [x] `deepvista card +grep "pattern"` returns matching lines
- [ ] `deepvista card +grep "pattern" -i -C 2` works with flags
- [x] `--format table` and `--format json` both work