### PR TITLE
fix: cap httpx dependency to <1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
     "click>=8.1",
     "filelock>=3.12",
-    "httpx>=0.27",
+    "httpx>=0.27,<1",
     "rich>=13.0",
 ]
 


### PR DESCRIPTION
## Summary
- Cap `httpx>=0.27,<1` to prevent uv/pip from resolving httpx 1.0 dev pre-releases
- httpx 1.0.dev3 is a complete API rewrite that breaks `Client(base_url=)`, `ConnectError`, `TimeoutException`, and `json=` parameter

## Test plan
- [x] `deepvista notes list` no longer crashes with `TypeError: Client.__init__() got an unexpected keyword argument 'base_url'`
- [x] Verified httpx 0.28.1 resolves correctly after reinstall