### PR TITLE
feat: send origin metadata with /imagine requests (DV-257)

### DIFF
--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -75,9 +75,11 @@ class DeepVistaClient:
         )
         sys.exit(EXIT_AUTH_ERROR)
 
-    def _log_request(self, method: str, path: str, body: Any = None) -> None:
+    def _log_request(self, method: str, path: str, body: Any = None, headers: dict[str, str] | None = None) -> None:
         if self.config.verbose:
             click.echo(f">>> {method} {self.config.api_url}{path}", err=True)
+            if headers:
+                click.echo(f"Headers: {headers}", err=True)
             if body:
                 click.echo(f">>> Body: {json.dumps(body, default=str)}", err=True)
 
@@ -113,7 +115,8 @@ class DeepVistaClient:
 
     def _request(self, method: str, path: str, body: dict | None = None, params: dict | None = None) -> Any:
         """Unified request method with network error handling."""
-        self._log_request(method, path, body)
+        headers = self._auth_headers()
+        self._log_request(method, path, body, headers)
         if self.config.dry_run:
             click.echo(
                 json.dumps(
@@ -125,7 +128,6 @@ class DeepVistaClient:
 
         try:
             client = self._get_client()
-            headers = self._auth_headers()
             if method == "GET":
                 resp = client.get(path, headers=headers, params=params)
             elif method == "POST":
@@ -162,7 +164,9 @@ class DeepVistaClient:
 
     def stream_sse(self, path: str, body: dict | None = None) -> Iterator[dict]:
         """POST with SSE streaming. Yields parsed JSON events as NDJSON."""
-        self._log_request("POST (SSE)", path, body)
+        headers = self._auth_headers()
+        headers["Accept"] = "text/event-stream"
+        self._log_request("POST (SSE)", path, body, headers)
         if self.config.dry_run:
             click.echo(
                 json.dumps({"dry_run": True, "method": "POST_SSE", "path": path, "body": body}, default=str),
@@ -171,8 +175,6 @@ class DeepVistaClient:
             sys.exit(0)
 
         client = self._get_client()
-        headers = self._auth_headers()
-        headers["Accept"] = "text/event-stream"
 
         try:
             with client.stream("POST", path, json=body or {}, headers=headers, timeout=300) as resp:

--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -19,6 +19,7 @@ from typing import Any, NoReturn
 import click
 import httpx
 
+from deepvista_cli import __version__
 from deepvista_cli.auth.tokens import get_valid_token
 from deepvista_cli.config import EXIT_API_ERROR, EXIT_AUTH_ERROR, EXIT_NETWORK_ERROR, CLIConfig, credentials_path
 
@@ -45,7 +46,10 @@ class DeepVistaClient:
 
         Auth: Authorization: Bearer <jwt> (from login).
         """
-        headers: dict[str, str] = {"Content-Type": "application/json"}
+        headers: dict[str, str] = {
+            "Content-Type": "application/json",
+            "User-Agent": f"deepvista-cli/{__version__}",
+        }
 
         # JWT auth (from per-profile credentials file)
         tokens = get_valid_token(credentials_path(self.config.profile))
@@ -154,6 +158,12 @@ class DeepVistaClient:
 
     def stream_sse(self, path: str, body: dict | None = None) -> Iterator[dict]:
         """POST with SSE streaming. Yields parsed JSON events as NDJSON."""
+        # Auto-inject origin metadata for /imagine requests (chat creation)
+        if path == "/imagine" and body is not None and "origin" not in body:
+            from deepvista_cli.client.origin import build_origin
+
+            body = {**body, "origin": build_origin()}
+
         self._log_request("POST (SSE)", path, body)
         if self.config.dry_run:
             click.echo(

--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -45,10 +45,14 @@ class DeepVistaClient:
         """Build auth headers, auto-refreshing token if needed.
 
         Auth: Authorization: Bearer <jwt> (from login).
+        Origin: X-DeepVista-Origin: <json> (agent/machine metadata).
         """
+        from deepvista_cli.client.origin import build_origin
+
         headers: dict[str, str] = {
             "Content-Type": "application/json",
             "User-Agent": f"deepvista-cli/{__version__}",
+            "X-DeepVista-Origin": json.dumps(build_origin(), separators=(",", ":")),
         }
 
         # JWT auth (from per-profile credentials file)
@@ -158,12 +162,6 @@ class DeepVistaClient:
 
     def stream_sse(self, path: str, body: dict | None = None) -> Iterator[dict]:
         """POST with SSE streaming. Yields parsed JSON events as NDJSON."""
-        # Auto-inject origin metadata for /imagine requests (chat creation)
-        if path == "/imagine" and body is not None and "origin" not in body:
-            from deepvista_cli.client.origin import build_origin
-
-            body = {**body, "origin": build_origin()}
-
         self._log_request("POST (SSE)", path, body)
         if self.config.dry_run:
             click.echo(

--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -79,7 +79,9 @@ class DeepVistaClient:
         if self.config.verbose:
             click.echo(f">>> {method} {self.config.api_url}{path}", err=True)
             if headers:
-                click.echo(f"Headers: {headers}", err=True)
+                origin = headers.get("X-DeepVista-Origin")
+                if origin:
+                    click.echo(f">>> X-DeepVista-Origin: {origin}", err=True)
             if body:
                 click.echo(f">>> Body: {json.dumps(body, default=str)}", err=True)
 

--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -75,13 +75,9 @@ class DeepVistaClient:
         )
         sys.exit(EXIT_AUTH_ERROR)
 
-    def _log_request(self, method: str, path: str, body: Any = None, headers: dict[str, str] | None = None) -> None:
+    def _log_request(self, method: str, path: str, body: Any = None) -> None:
         if self.config.verbose:
             click.echo(f">>> {method} {self.config.api_url}{path}", err=True)
-            if headers:
-                origin = headers.get("X-DeepVista-Origin")
-                if origin:
-                    click.echo(f">>> X-DeepVista-Origin: {origin}", err=True)
             if body:
                 click.echo(f">>> Body: {json.dumps(body, default=str)}", err=True)
 
@@ -118,7 +114,7 @@ class DeepVistaClient:
     def _request(self, method: str, path: str, body: dict | None = None, params: dict | None = None) -> Any:
         """Unified request method with network error handling."""
         headers = self._auth_headers()
-        self._log_request(method, path, body, headers)
+        self._log_request(method, path, body)
         if self.config.dry_run:
             click.echo(
                 json.dumps(
@@ -168,7 +164,7 @@ class DeepVistaClient:
         """POST with SSE streaming. Yields parsed JSON events as NDJSON."""
         headers = self._auth_headers()
         headers["Accept"] = "text/event-stream"
-        self._log_request("POST (SSE)", path, body, headers)
+        self._log_request("POST (SSE)", path, body)
         if self.config.dry_run:
             click.echo(
                 json.dumps({"dry_run": True, "method": "POST_SSE", "path": path, "body": body}, default=str),

--- a/deepvista_cli/client/origin.py
+++ b/deepvista_cli/client/origin.py
@@ -4,21 +4,13 @@ Detects the calling AI agent (Claude Code, OpenCode, Cursor, etc.) from
 environment variables — with a process-tree fallback — and collects machine
 info so the backend can track where chats originate from.
 
-**Caching strategy:**
-
-* *System info* (hostname · OS · chip) is expensive to compute on macOS
-  under Rosetta (two subprocess calls).  It virtually never changes, so we
-  persist it to ``~/.config/deepvista/system.json`` and reuse across
-  invocations.  A hostname change invalidates the cache automatically.
-* *Agent info* changes between processes (OpenCode now, Claude Code next),
-  so it is detected per-process but only once — ``build_origin()`` is
-  decorated with ``@functools.lru_cache``.
+Everything is computed once per process via ``@functools.lru_cache`` on
+``build_origin()``.
 """
 
 from __future__ import annotations
 
 import functools
-import json
 import logging
 import os
 import platform
@@ -26,36 +18,8 @@ import re
 import subprocess
 
 from deepvista_cli import __version__
-from deepvista_cli.config import CONFIG_DIR
 
 log = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Persistent system-info cache  (~/.config/deepvista/system.json)
-# ---------------------------------------------------------------------------
-
-_SYSTEM_CACHE_PATH = CONFIG_DIR / "system.json"
-
-
-def _load_system_cache() -> str | None:
-    """Return the cached machine label if it exists and the hostname still matches."""
-    try:
-        data = json.loads(_SYSTEM_CACHE_PATH.read_text())
-        # Invalidate when the hostname changes (e.g. machine swap, new device).
-        if data.get("hostname") == platform.node():
-            return data.get("machine")  # type: ignore[no-any-return]
-    except (OSError, json.JSONDecodeError, KeyError):
-        pass
-    return None
-
-
-def _save_system_cache(machine_label: str) -> None:
-    """Persist the machine label so future invocations skip subprocess calls."""
-    try:
-        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        _SYSTEM_CACHE_PATH.write_text(json.dumps({"hostname": platform.node(), "machine": machine_label}, indent=2))
-    except OSError:
-        log.debug("failed to write system cache", exc_info=True)
 
 
 # ---------------------------------------------------------------------------
@@ -240,24 +204,12 @@ _OS_LABELS: dict[str, str] = {
 
 
 def _machine_description() -> str:
-    """Human-readable device label: ``hostname · OS · chip``.
-
-    Checks the on-disk cache first.  On a cache miss the label is computed
-    (potentially spawning subprocesses on macOS/Rosetta) and persisted for
-    future invocations.
-    """
-    cached = _load_system_cache()
-    if cached is not None:
-        return cached
-
+    """Human-readable device label: ``hostname · OS · chip``."""
     hostname = platform.node()
     system = _OS_LABELS.get(platform.system(), platform.system())
     arch = _native_arch()
     chip = _ARCH_LABELS.get(arch, arch)
-    label = f"{hostname} · {system} · {chip}"
-
-    _save_system_cache(label)
-    return label
+    return f"{hostname} · {system} · {chip}"
 
 
 @functools.lru_cache(maxsize=1)

--- a/deepvista_cli/client/origin.py
+++ b/deepvista_cli/client/origin.py
@@ -1,35 +1,83 @@
 """Build origin metadata for chat sessions.
 
-Detects the calling AI agent (Claude Code, OpenCode, etc.) from
-environment variables and collects machine info so the backend can
-track where chats originate from.
+Detects the calling AI agent (Claude Code, OpenCode, Cursor, etc.) from
+environment variables — with a process-tree fallback — and collects machine
+info so the backend can track where chats originate from.
+
+**Caching strategy:**
+
+* *System info* (hostname · OS · chip) is expensive to compute on macOS
+  under Rosetta (two subprocess calls).  It virtually never changes, so we
+  persist it to ``~/.config/deepvista/system.json`` and reuse across
+  invocations.  A hostname change invalidates the cache automatically.
+* *Agent info* changes between processes (OpenCode now, Claude Code next),
+  so it is detected per-process but only once — ``build_origin()`` is
+  decorated with ``@functools.lru_cache``.
 """
 
 from __future__ import annotations
 
+import functools
+import json
+import logging
 import os
 import platform
 import re
+import subprocess
 
 from deepvista_cli import __version__
+from deepvista_cli.config import CONFIG_DIR
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Persistent system-info cache  (~/.config/deepvista/system.json)
+# ---------------------------------------------------------------------------
+
+_SYSTEM_CACHE_PATH = CONFIG_DIR / "system.json"
 
 
-def _detect_agent_tool() -> tuple[str, str | None]:
-    """Detect the AI agent tool running the CLI from environment variables.
+def _load_system_cache() -> str | None:
+    """Return the cached machine label if it exists and the hostname still matches."""
+    try:
+        data = json.loads(_SYSTEM_CACHE_PATH.read_text())
+        # Invalidate when the hostname changes (e.g. machine swap, new device).
+        if data.get("hostname") == platform.node():
+            return data.get("machine")  # type: ignore[no-any-return]
+    except (OSError, json.JSONDecodeError, KeyError):
+        pass
+    return None
 
-    Returns (tool_name, tool_version).
+
+def _save_system_cache(machine_label: str) -> None:
+    """Persist the machine label so future invocations skip subprocess calls."""
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        _SYSTEM_CACHE_PATH.write_text(json.dumps({"hostname": platform.node(), "machine": machine_label}, indent=2))
+    except OSError:
+        log.debug("failed to write system cache", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Agent detection — env vars (fast, reliable, preferred)
+# ---------------------------------------------------------------------------
+
+
+def _detect_from_env() -> tuple[str, str | None] | None:
+    """Try to identify the agent from well-known environment variables.
+
+    Returns ``(tool_name, tool_version)`` or ``None`` if nothing matched.
     """
-    # Claude Code: sets CLAUDECODE=1 and CLAUDE_CODE_EXECPATH containing version
+    # Claude Code: sets CLAUDECODE=1, version embedded in CLAUDE_CODE_EXECPATH
     if os.environ.get("CLAUDECODE") == "1":
         version = None
         exec_path = os.environ.get("CLAUDE_CODE_EXECPATH", "")
-        # Extract version from path like /Users/x/.local/share/claude/versions/2.1.100
         m = re.search(r"/versions/(\d[\d.]+\d)", exec_path)
         if m:
             version = m.group(1)
         return ("claude-code", version)
 
-    # OpenCode: check for OPENCODE env var or opencode in PATH hint
+    # OpenCode: sets OPENCODE=1
     if os.environ.get("OPENCODE"):
         return ("opencode", os.environ.get("OPENCODE_VERSION"))
 
@@ -37,20 +85,188 @@ def _detect_agent_tool() -> tuple[str, str | None]:
     if os.environ.get("CURSOR"):
         return ("cursor", os.environ.get("CURSOR_VERSION"))
 
-    # Fallback: direct CLI usage
+    # Windsurf (Codeium): sets WINDSURF=1
+    if os.environ.get("WINDSURF"):
+        return ("windsurf", os.environ.get("WINDSURF_VERSION"))
+
+    # Cline (VS Code extension): sets CLINE=1
+    if os.environ.get("CLINE"):
+        return ("cline", os.environ.get("CLINE_VERSION"))
+
+    # Aider: sets AIDER=1
+    if os.environ.get("AIDER"):
+        return ("aider", os.environ.get("AIDER_VERSION"))
+
+    # GitHub Copilot CLI
+    if os.environ.get("GITHUB_COPILOT"):
+        return ("github-copilot", os.environ.get("GITHUB_COPILOT_VERSION"))
+
+    # Generic "some agent is driving us" but we don't know which one
+    if os.environ.get("AGENT"):
+        return None  # fall through to process-tree detection
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Agent detection — process-tree fallback (heavier, best-effort)
+# ---------------------------------------------------------------------------
+
+# Map of substrings found in process names / cmdlines → tool names.
+_PROCESS_HINTS: dict[str, str] = {
+    "claude": "claude-code",
+    "opencode": "opencode",
+    "cursor": "cursor",
+    "windsurf": "windsurf",
+    "cline": "cline",
+    "aider": "aider",
+    "copilot": "github-copilot",
+    "codex": "codex-cli",
+}
+
+
+def _detect_from_process_tree() -> tuple[str, str | None] | None:
+    """Walk the parent process chain looking for a recognisable agent.
+
+    Uses *psutil* (already a project dependency).  Returns ``None`` on any
+    failure — this is strictly best-effort.
+    """
+    try:
+        import psutil  # noqa: PLC0415
+    except ImportError:
+        return None
+
+    try:
+        pid = os.getppid()
+        for _ in range(8):  # walk at most 8 levels
+            proc = psutil.Process(pid)
+            name_lower = proc.name().lower()
+            cmdline_str = " ".join(proc.cmdline()[:3]).lower()
+            haystack = f"{name_lower} {cmdline_str}"
+
+            for hint, tool in _PROCESS_HINTS.items():
+                if hint in haystack:
+                    return (tool, None)
+
+            pid = proc.ppid()
+            if pid <= 1:
+                break
+    except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess, OSError):
+        log.debug("process-tree agent detection failed", exc_info=True)
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public: combined detection
+# ---------------------------------------------------------------------------
+
+
+def _detect_agent_tool() -> tuple[str, str | None]:
+    """Detect the AI agent driving the CLI.
+
+    Strategy: check environment variables first (cheap, explicit), then fall
+    back to walking the process tree (heavier, heuristic).  If neither
+    succeeds, assume direct CLI usage.
+    """
+    result = _detect_from_env()
+    if result is not None:
+        return result
+
+    result = _detect_from_process_tree()
+    if result is not None:
+        return result
+
     return ("deepvista-cli", __version__)
 
 
-def _machine_description() -> str:
-    """Human-readable machine description."""
-    node = platform.node()
+def _native_arch() -> str:
+    """Return the real hardware architecture, bypassing emulation layers.
+
+    On macOS under Rosetta 2, ``platform.machine()`` and even child-process
+    ``uname -m`` return ``x86_64``.  We detect Rosetta via
+    ``sysctl.proc_translated`` and escape with ``arch -arm64e``.
+
+    On Windows under ARM emulation, ``platform.machine()`` may return
+    ``AMD64`` — we check ``PROCESSOR_ARCHITEW6432`` for the native arch.
+
+    Linux is straightforward: ``platform.machine()`` is reliable.
+    """
     system = platform.system()
     machine = platform.machine()
-    return f"{node} ({system} {machine})"
+
+    if system == "Darwin" and machine == "x86_64":
+        try:
+            translated = subprocess.run(  # noqa: S603
+                ["/usr/sbin/sysctl", "-n", "sysctl.proc_translated"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            if translated.returncode == 0 and translated.stdout.strip() == "1":
+                native = subprocess.run(  # noqa: S603
+                    ["/usr/bin/arch", "-arm64e", "/usr/bin/uname", "-m"],
+                    capture_output=True,
+                    text=True,
+                    timeout=2,
+                )
+                if native.returncode == 0 and native.stdout.strip():
+                    return native.stdout.strip()
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+    if system == "Windows" and machine == "AMD64":
+        # PROCESSOR_ARCHITEW6432 is set when a 32/64-bit process runs on ARM64
+        native = os.environ.get("PROCESSOR_ARCHITEW6432", "")
+        if native.upper() == "ARM64":
+            return "ARM64"
+
+    return machine
 
 
+_ARCH_LABELS: dict[str, str] = {
+    "arm64": "Apple Silicon",
+    "aarch64": "ARM64",
+    "ARM64": "ARM64",
+    "x86_64": "Intel",
+    "AMD64": "Intel",
+}
+
+_OS_LABELS: dict[str, str] = {
+    "Darwin": "macOS",
+    "Linux": "Linux",
+    "Windows": "Windows",
+}
+
+
+def _machine_description() -> str:
+    """Human-readable device label: ``hostname · OS · chip``.
+
+    Checks the on-disk cache first.  On a cache miss the label is computed
+    (potentially spawning subprocesses on macOS/Rosetta) and persisted for
+    future invocations.
+    """
+    cached = _load_system_cache()
+    if cached is not None:
+        return cached
+
+    hostname = platform.node()
+    system = _OS_LABELS.get(platform.system(), platform.system())
+    arch = _native_arch()
+    chip = _ARCH_LABELS.get(arch, arch)
+    label = f"{hostname} · {system} · {chip}"
+
+    _save_system_cache(label)
+    return label
+
+
+@functools.lru_cache(maxsize=1)
 def build_origin() -> dict[str, str | bool]:
-    """Build the origin metadata dict for /imagine requests."""
+    """Build the origin metadata dict for /imagine requests.
+
+    Cached for the lifetime of the process — agent detection and machine
+    info won't change mid-session.
+    """
     tool, tool_version = _detect_agent_tool()
     origin: dict[str, str | bool] = {
         "tool": tool,

--- a/deepvista_cli/client/origin.py
+++ b/deepvista_cli/client/origin.py
@@ -1,0 +1,68 @@
+"""Build origin metadata for chat sessions.
+
+Detects the calling AI agent (Claude Code, OpenCode, etc.) from
+environment variables and collects machine info so the backend can
+track where chats originate from.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import re
+
+from deepvista_cli import __version__
+
+
+def _detect_agent_tool() -> tuple[str, str | None]:
+    """Detect the AI agent tool running the CLI from environment variables.
+
+    Returns (tool_name, tool_version).
+    """
+    # Claude Code: sets CLAUDECODE=1 and CLAUDE_CODE_EXECPATH containing version
+    if os.environ.get("CLAUDECODE") == "1":
+        version = None
+        exec_path = os.environ.get("CLAUDE_CODE_EXECPATH", "")
+        # Extract version from path like /Users/x/.local/share/claude/versions/2.1.100
+        m = re.search(r"/versions/(\d[\d.]+\d)", exec_path)
+        if m:
+            version = m.group(1)
+        return ("claude-code", version)
+
+    # OpenCode: check for OPENCODE env var or opencode in PATH hint
+    if os.environ.get("OPENCODE"):
+        return ("opencode", os.environ.get("OPENCODE_VERSION"))
+
+    # Cursor: sets CURSOR=1
+    if os.environ.get("CURSOR"):
+        return ("cursor", os.environ.get("CURSOR_VERSION"))
+
+    # Fallback: direct CLI usage
+    return ("deepvista-cli", __version__)
+
+
+def _machine_description() -> str:
+    """Human-readable machine description."""
+    node = platform.node()
+    system = platform.system()
+    machine = platform.machine()
+    return f"{node} ({system} {machine})"
+
+
+def build_origin() -> dict[str, str | bool]:
+    """Build the origin metadata dict for /imagine requests."""
+    tool, tool_version = _detect_agent_tool()
+    origin: dict[str, str | bool] = {
+        "tool": tool,
+        "machine": _machine_description(),
+        "is_logged_in": True,  # CLI requires auth, always true here
+    }
+    if tool_version:
+        origin["tool_version"] = tool_version
+
+    # Model: check common env vars set by AI agents
+    model = os.environ.get("ANTHROPIC_MODEL") or os.environ.get("CLAUDE_MODEL")
+    if model:
+        origin["model"] = model
+
+    return origin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "click>=8.1",
     "filelock>=3.12",
     "httpx>=0.27,<1",
+    "psutil>=7.2.2",
     "rich>=13.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.0a17"
+version = "0.1.0a18"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
@@ -81,7 +81,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "filelock", specifier = ">=3.12" },
-    { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx", specifier = ">=0.27,<1" },
     { name = "rich", specifier = ">=13.0" },
     { name = "textual", marker = "extra == 'ui'", specifier = ">=0.80" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -62,6 +62,7 @@ dependencies = [
     { name = "click" },
     { name = "filelock" },
     { name = "httpx" },
+    { name = "psutil" },
     { name = "rich" },
 ]
 
@@ -82,6 +83,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1" },
     { name = "filelock", specifier = ">=3.12" },
     { name = "httpx", specifier = ">=0.27,<1" },
+    { name = "psutil", specifier = ">=7.2.2" },
     { name = "rich", specifier = ">=13.0" },
     { name = "textual", marker = "extra == 'ui'", specifier = ">=0.80" },
 ]
@@ -249,6 +251,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `X-DeepVista-Origin` header to all CLI HTTP requests with auto-detected agent metadata
- Detect calling AI agent (Claude Code, OpenCode, Cursor, Windsurf, Cline, Aider, Copilot) from env vars with process-tree fallback
- Cache system info (hostname, OS, chip) to `~/.config/deepvista/system.json` to avoid repeated subprocess calls
- Add `User-Agent: deepvista-cli/{version}` header

### Origin detection
| Agent | Detection | Version source |
|-------|-----------|----------------|
| Claude Code | `CLAUDECODE=1` | `CLAUDE_CODE_EXECPATH` path |
| OpenCode | `OPENCODE` env var | `OPENCODE_VERSION` env var |
| Cursor | `CURSOR` env var | `CURSOR_VERSION` env var |
| Windsurf | `WINDSURF` env var | `WINDSURF_VERSION` env var |
| Cline | `CLINE` env var | `CLINE_VERSION` env var |
| Aider | `AIDER` env var | `AIDER_VERSION` env var |
| Copilot | `GITHUB_COPILOT` env var | `GITHUB_COPILOT_VERSION` env var |
| Direct CLI | fallback + process tree | `deepvista-cli.__version__` |

### Example header
```
X-DeepVista-Origin: {"tool":"claude-code","tool_version":"2.1.100","machine":"hostname · macOS · Apple Silicon","is_logged_in":true}
```

## Companion PR
- **Backend + Frontend**: DeepVista-AI/deepvista#1730 — extracts the header, stores it on `chat_sessions.origin`, displays in UI

## Test plan
- [x] `uv run python -c "from deepvista_cli.client.origin import build_origin; print(build_origin())"` returns correct detection
- [x] `deepvista --verbose chat +send "hello"` sends correct header
- [x] Chat created via CLI shows origin in backend DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)