### PR TITLE
fix: add URL to wrapped entity responses (DV-292)

### DIFF
--- a/deepvista_cli/output/formatter.py
+++ b/deepvista_cli/output/formatter.py
@@ -92,6 +92,22 @@ def add_urls_to_data(
         if "id" in data and list_key is None:
             return add_url_to_entity(data, entity_type, base_url)
 
+        # Handle wrapped single-entity responses like {"card": {..., "id": "..."}, "created": true}
+        single_entity_keys = ["card", "note", "recipe", "vistabook", "session"]
+        for key in single_entity_keys:
+            if key in data and isinstance(data[key], dict) and "id" in data[key]:
+                result = dict(data)
+                key_to_type = {
+                    "card": entity_type,
+                    "note": "note",
+                    "recipe": "recipe",
+                    "vistabook": "vistabook",
+                    "session": "chat",
+                }
+                item_type = key_to_type.get(key, entity_type)
+                result[key] = add_url_to_entity(data[key], item_type, base_url)
+                return result
+
         # Look for known list keys and add URLs to items
         known_keys = ["cards", "notes", "recipes", "vistabooks", "sessions", "results", "similar"]
         keys_to_check = [list_key] if list_key else known_keys


### PR DESCRIPTION
## Problem

When creating a note via `notes create` or `notes +quick`, the CLI output does not include the URL to the created note. Users cannot click through to view the note directly.

## Root Cause

The API returns a wrapped response:
```json
{"card": {..., "id": "ef5e..."}, "created": true}
```

The URL generator (`add_urls_to_data`) only checked for `id` at the top level of the response dict. Since `id` is nested inside the `card` key, the URL was never generated.

## Fix

Added handling for wrapped single-entity responses (`card`, `note`, `recipe`, `vistabook`, `session`). When the response contains a known entity key wrapping a dict with an `id`, the URL is generated and added to the nested entity.

### Before
```json
{"card": {"id": "ef5e...", "title": "My note"}, "created": true}
```

### After
```json
{"card": {"id": "ef5e...", "title": "My note", "url": "https://app.deepvista.ai/vistabase?contextId=ef5e..."}, "created": true}
```

## Changes
- `deepvista_cli/output/formatter.py`: Added wrapped entity detection in `add_urls_to_data()`

Fixes DV-292