### PR TITLE
feat: add OpenClaw auto-capture support

### DIFF
--- a/deepvista_cli/commands/upgrade.py
+++ b/deepvista_cli/commands/upgrade.py
@@ -32,6 +32,7 @@ SKILL_DIRS = [
     Path.home() / ".agents" / "skills",
     Path.home() / ".cursor" / "skills",
     Path.home() / ".opencode" / "skills",
+    Path.home() / ".openclaw" / "workspace" / "skills",
 ]
 
 

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@ SKILLS=(
   deepvista-recipe-research-to-recipe
   deepvista-recipe-export-knowledge-as-skills
   deepvista-recipe-analyze-notes
+  deepvista-openclaw
 )
 
 echo "==> Installing deepvista CLI..."
@@ -47,6 +48,8 @@ SKILL_DIRS=()
 [ -d "$HOME/.agents" ]  && SKILL_DIRS+=("$HOME/.agents/skills")
 [ -d "$HOME/.cursor" ]  && SKILL_DIRS+=("$HOME/.cursor/skills")
 [ -d "$HOME/.opencode" ] && SKILL_DIRS+=("$HOME/.opencode/skills")
+# OpenClaw: skills live in the workspace directory
+[ -d "$HOME/.openclaw/workspace" ] && SKILL_DIRS+=("$HOME/.openclaw/workspace/skills")
 
 # Default to Claude if no agent directory found
 if [ ${#SKILL_DIRS[@]} -eq 0 ]; then
@@ -117,6 +120,18 @@ echo "==> Enabling DeepVista auto-capture..."
 [ -d "$HOME/.claude" ]   && install_autocapture "$HOME/.claude/CLAUDE.md"
 [ -d "$HOME/.cursor" ]   && install_autocapture "$HOME/.cursor/rules"
 [ -d "$HOME/.opencode" ] && install_autocapture "$HOME/.opencode/AGENTS.md"
+
+# OpenClaw: install autocapture to workspace AGENTS.md
+OPENCLAW_WORKSPACE="$HOME/.openclaw/workspace"
+if [ -d "$OPENCLAW_WORKSPACE" ]; then
+  install_autocapture "$OPENCLAW_WORKSPACE/AGENTS.md"
+  # Also copy the OpenClaw-specific skill to the workspace for reference
+  if [ -d "$SRC/deepvista-openclaw" ]; then
+    mkdir -p "$OPENCLAW_WORKSPACE/skills/deepvista-openclaw"
+    cp -r "$SRC/deepvista-openclaw/"* "$OPENCLAW_WORKSPACE/skills/deepvista-openclaw/"
+    echo "    OpenClaw skill installed to $OPENCLAW_WORKSPACE/skills/deepvista-openclaw"
+  fi
+fi
 
 echo "==> Installing DeepVista auto-capture hook..."
 

--- a/skills/deepvista-openclaw/SKILL.md
+++ b/skills/deepvista-openclaw/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: deepvista-openclaw
+description: DeepVista auto-capture and knowledge integration for OpenClaw agents. Automatically saves notable user statements, decisions, and insights to DeepVista knowledge base. Use when the user shares facts about themselves, their work, decisions, or plans.
+---
+
+# DeepVista Auto-Capture for OpenClaw
+
+## Overview
+
+This skill enables automatic knowledge capture from OpenClaw conversations into DeepVista.
+When the user shares notable information during a conversation, save it to DeepVista without
+asking for confirmation.
+
+## Prerequisites
+
+- `deepvista` CLI installed and authenticated (`deepvista auth status`)
+- If not authenticated, prompt: `deepvista auth login`
+
+## Auto-Capture Rules
+
+### ALWAYS capture (no confirmation needed):
+
+- Personal or professional facts: role, company, team, background
+- Decisions made or conclusions reached
+- Key insights, learnings, or observations
+- Action items, commitments, or plans
+- Meeting or conversation highlights
+- Relationships between people (who works with whom, who met whom)
+- Product/business strategy decisions
+- Important dates, deadlines, milestones
+
+### NEVER capture:
+
+- Passwords, API keys, tokens, or secrets
+- Pure questions with no factual content
+- Small talk, greetings, acknowledgments
+- Commands directed at the agent (e.g., "list my notes")
+
+## How to Capture
+
+For single-line facts or short insights:
+```bash
+deepvista notes +quick "<text>"
+```
+
+For longer structured content (meeting notes, analyses, multi-point insights):
+```bash
+deepvista notes create --title "<title>" --content "<markdown content>"
+```
+
+## Capture Format Guidelines
+
+- Preserve the user's original wording when possible
+- For decisions: include the decision AND the reasoning
+- For people: include the relationship context (e.g., "Jing is working with Bruce Wang on a thesis")
+- For meetings: structure as bullet points with key takeaways
+- Keep notes concise — capture the essence, not the entire conversation
+
+## Integration with OpenClaw Heartbeat
+
+If configured in HEARTBEAT.md, this skill supports periodic knowledge base maintenance:
+- Search for recent notes and check for duplicates
+- Suggest merges for similar notes
+- Flag outdated information
+
+## Checking DeepVista Status
+
+Before first capture in a session, verify authentication:
+```bash
+deepvista auth status
+```
+
+If token is expired, inform the user:
+> DeepVista auth expired. Please run: `deepvista auth login` and share the code.


### PR DESCRIPTION
## Summary

Adds DeepVista auto-capture capability for OpenClaw agents, matching the existing Claude Code auto-capture functionality.

## Changes

### New: `skills/deepvista-openclaw/SKILL.md`
An OpenClaw-native skill that instructs the agent to automatically capture notable user statements to DeepVista. Includes:
- **Auto-capture rules**: What to save (facts, decisions, insights, people, plans) vs what to skip (secrets, commands, small talk)
- **Capture format guidelines**: How to format different types of captures
- **CLI commands**: `deepvista notes +quick` for one-liners, `deepvista notes create` for structured content
- **Auth handling**: Detect expired tokens and prompt re-auth

### Updated: `install.sh`
- Detects `~/.openclaw/workspace` directory
- Installs autocapture block to `AGENTS.md` (OpenClaw's instruction file, equivalent to `CLAUDE.md`)
- Copies `deepvista-openclaw` skill to workspace `skills/` directory
- Added `deepvista-openclaw` to the SKILLS array

### Updated: `deepvista_cli/commands/upgrade.py`
- Added `~/.openclaw/workspace/skills/` to SKILL_DIRS so `deepvista upgrade` updates OpenClaw skills too

## How It Works

Unlike Claude Code which uses stop hooks (bash scripts triggered after each turn), OpenClaw uses **instruction-based** auto-capture:

1. The `AGENTS.md` autocapture block tells the agent what types of user statements to save
2. The `deepvista-openclaw` SKILL.md provides detailed rules and CLI commands
3. The agent calls `deepvista notes +quick` or `deepvista notes create` during the conversation

This matches OpenClaw's architecture where agent behavior is driven by workspace files rather than external hooks.

## Testing

After install, verify:
```bash
# Check AGENTS.md has autocapture block
grep 'deepvista-auto-capture' ~/.openclaw/workspace/AGENTS.md

# Check skill is installed
ls ~/.openclaw/workspace/skills/deepvista-openclaw/SKILL.md

# Test capture
deepvista notes +quick "Test autocapture from OpenClaw"
```