### PR TITLE
fix: prevent 'Not a directory' error in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -79,7 +79,9 @@ fi
 for dir in "${SKILL_DIRS[@]}"; do
   mkdir -p "$dir"
   for skill in "${SKILLS[@]}"; do
-    cp -r "$SRC/$skill" "$dir/"
+    # Remove stale file/dir to avoid "Not a directory" errors on re-install
+    rm -rf "${dir:?}/$skill"
+    cp -r "$SRC/$skill" "$dir/$skill"
   done
   echo "    Skills installed to $dir"
 done


### PR DESCRIPTION
## Problem

The install script fails with:

```
cp: /Users/shiuli/.claude/skills/deepvista-shared: Not a directory
```

This happens when a stale file or broken symlink exists at the destination path from a prior partial install, or when `cp -r` behaves differently across platforms with the trailing slash syntax.

## Fix

- Remove any stale file/dir at the destination before copying (`rm -rf`)
- Use explicit destination path (`$dir/$skill`) instead of trailing slash (`$dir/`)

The `${dir:?}` guard prevents accidental `rm -rf /` if `$dir` is somehow empty.

## Linked

- Linear: [DV-294](https://linear.app/deepvista/issue/DV-294/install-script-fails-cp-skills-directory-not-found)