### PR TITLE
chore: add PyPI, ClawHub, and skills.sh badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # deepvista-cli
 
+[![PyPI - Status](https://img.shields.io/pypi/status/deepvista-cli)](https://pypi.org/project/deepvista-cli/)
 [![PyPI](https://img.shields.io/pypi/v/deepvista-cli)](https://pypi.org/project/deepvista-cli/)
-[![ClawHub](https://img.shields.io/badge/ClawHub-skills-blue)](https://clawhub.ai/skills?q=deepvista)
+[![ClawHub](https://img.shields.io/badge/ClawHub-deepvista-blue)](https://clawhub.ai/skills?q=deepvista)
 [![skills.sh](https://img.shields.io/badge/skills.sh-DeepVista--AI-purple)](https://skills.sh/deepvista-ai/deepvista-cli)
 
 CLI for DeepVista — chat, notes, recipes, and vistabase from your terminal. Designed for both humans and AI agents.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # deepvista-cli
 
 [![PyPI](https://img.shields.io/pypi/v/deepvista-cli)](https://pypi.org/project/deepvista-cli/)
-[![ClawHub](https://img.shields.io/badge/ClawHub-skills-blue)](https://clawhub.ai)
-[![skills.sh](https://img.shields.io/badge/skills.sh-DeepVista--AI-purple)](https://skills.sh)
+[![ClawHub](https://img.shields.io/badge/ClawHub-skills-blue)](https://clawhub.ai/skills?q=deepvista)
+[![skills.sh](https://img.shields.io/badge/skills.sh-DeepVista--AI-purple)](https://skills.sh/deepvista-ai/deepvista-cli)
 
 CLI for DeepVista — chat, notes, recipes, and vistabase from your terminal. Designed for both humans and AI agents.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # deepvista-cli
 
+[![PyPI](https://img.shields.io/pypi/v/deepvista-cli)](https://pypi.org/project/deepvista-cli/)
+[![ClawHub](https://img.shields.io/badge/ClawHub-skills-blue)](https://clawhub.ai)
+[![skills.sh](https://img.shields.io/badge/skills.sh-DeepVista--AI-purple)](https://skills.sh)
+
 CLI for DeepVista — chat, notes, recipes, and vistabase from your terminal. Designed for both humans and AI agents.
 
 ## Table of Contents


### PR DESCRIPTION

<img width="1141" height="330" alt="image" src="https://github.com/user-attachments/assets/76e704b7-540a-4eaa-8918-36240c2c78ad" />

## Summary
- Add PyPI version badge (live from shields.io)
- Add ClawHub skills badge
- Add skills.sh badge