### PR TITLE
feat: inject skill interpretation rules into agent system prompts on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,6 +135,68 @@ if [ -d "$OPENCLAW_WORKSPACE" ]; then
   fi
 fi
 
+# Skill interpretation rules block (written to each agent's global instructions file)
+read -r -d '' SKILL_RULES_BLOCK << 'EOF' || true
+
+<!-- deepvista-skill-rules -->
+## Skill Interpretation Rules
+
+When you load or invoke any skill, check its frontmatter for two fields: `type` and `execution`.
+
+### Handling `type`
+
+**`type: persona`**
+Do not invoke this as a command. Load it as background context that shapes how you
+behave for the rest of the session. Apply its tone, expertise, and decision patterns silently.
+
+**`type: tool`**
+Treat this as a discrete capability. Invoke it when the task calls for it and return
+its result. No special handling needed.
+
+**`type: workflow`**
+Treat this as a self-contained sequence of steps. Work through them in order. Do not
+mix steps from other skills into this sequence unless explicitly instructed.
+
+### Handling `execution`
+
+**`execution: stateless`**
+Run freely. Retry on failure. No confirmation needed.
+
+**`execution: stateful`**
+Before executing, stop and do two things:
+1. If the skill or its underlying command supports `--dry-run`, run that first and show the output.
+2. Summarize what you are about to do and what will change, then ask for confirmation before proceeding.
+
+Never skip this checkpoint for stateful skills, even if the task seems straightforward.
+
+### Fallback rules
+- If `type` is missing, use the information in the skill to guess its type.
+- If `execution` is missing, treat as `stateful` and apply the checkpoint.
+- If a workflow is stateful, treat all its steps as stateful unless they declare otherwise.
+<!-- /deepvista-skill-rules -->
+EOF
+
+install_skill_rules() {
+  local config_file="$1"
+  mkdir -p "$(dirname "$config_file")"
+  # Idempotent: skip if already installed
+  if [ -f "$config_file" ] && grep -q "deepvista-skill-rules" "$config_file" 2>/dev/null; then
+    return
+  fi
+  printf '%s\n' "$SKILL_RULES_BLOCK" >> "$config_file"
+  echo "    Skill interpretation rules injected in $config_file"
+}
+
+echo "==> Injecting skill interpretation rules..."
+
+[ -d "$HOME/.claude" ]   && install_skill_rules "$HOME/.claude/CLAUDE.md"
+[ -d "$HOME/.cursor" ]   && install_skill_rules "$HOME/.cursor/rules"
+[ -d "$HOME/.opencode" ] && install_skill_rules "$HOME/.opencode/AGENTS.md"
+
+if [ -d "$OPENCLAW_WORKSPACE" ]; then
+  install_skill_rules "$OPENCLAW_WORKSPACE/AGENTS.md"
+fi
+
 echo "==> Installing DeepVista auto-capture hook..."
 
 # Write hook script directly (embedded) so installation works without network access

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.0a24"
+version = "0.1.0a25"
 description = "CLI for DeepVista — chat, notes, skills, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -72,6 +72,28 @@ remove_autocapture "$HOME/.claude/CLAUDE.md"
 remove_autocapture "$HOME/.cursor/rules"
 remove_autocapture "$HOME/.opencode/AGENTS.md"
 
+echo "==> Removing DeepVista skill interpretation rules..."
+
+remove_skill_rules() {
+  local config_file="$1"
+  if [ ! -f "$config_file" ]; then return; fi
+  if ! grep -q "deepvista-skill-rules" "$config_file" 2>/dev/null; then return; fi
+  local tmp
+  tmp=$(mktemp)
+  awk '/<!-- deepvista-skill-rules -->/{skip=1} !skip{print} /<!-- \/deepvista-skill-rules -->/{skip=0}' \
+    "$config_file" > "$tmp"
+  mv "$tmp" "$config_file"
+  echo "    Removed skill rules block from $config_file"
+}
+
+remove_skill_rules "$HOME/.claude/CLAUDE.md"
+remove_skill_rules "$HOME/.cursor/rules"
+remove_skill_rules "$HOME/.opencode/AGENTS.md"
+
+OPENCLAW_WORKSPACE="$HOME/.openclaw/workspace"
+[ -d "$OPENCLAW_WORKSPACE" ] && remove_autocapture "$OPENCLAW_WORKSPACE/AGENTS.md"
+[ -d "$OPENCLAW_WORKSPACE" ] && remove_skill_rules "$OPENCLAW_WORKSPACE/AGENTS.md"
+
 # Remove Stop hook from Claude Code settings.json
 echo "==> Removing DeepVista auto-capture hook..."
 


### PR DESCRIPTION
## Summary

- Adds `SKILL_RULES_BLOCK` heredoc to `install.sh` with the Skill Interpretation Rules section covering `type` (persona/tool/workflow) and `execution` (stateless/stateful) frontmatter fields plus fallback rules
- Adds `install_skill_rules()` function following the same idempotent guard pattern as `install_autocapture()` (HTML comment markers, `grep` check before appending)
- Injects the block into `~/.claude/CLAUDE.md`, `~/.cursor/rules`, `~/.opencode/AGENTS.md`, and the OpenClaw workspace `AGENTS.md` during install

## Test plan

- [ ] Run `install.sh` on a fresh system — verify block appears in each applicable config file
- [ ] Run `install.sh` again — verify block is not duplicated (idempotency)
- [ ] Run `install.sh` with only some agent dirs present — verify it only writes to dirs that exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)