### PR TITLE
feat: publish skills via gh skill publish, drop ClawHub (#75)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,14 @@ jobs:
 
       - name: Dependency vulnerability check
         run: uv run --with pip-audit pip-audit
+
+      - name: Ensure gh >= 2.90 (gh skill requires it)
+        run: |
+          sudo apt-get update
+          sudo apt-get install --only-upgrade -y gh
+          gh --version
+
+      - name: Validate skills (gh skill publish --dry-run)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh skill publish --dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,11 @@ jobs:
       - name: Dependency vulnerability check
         run: uv run --with pip-audit pip-audit
 
-      - name: Ensure gh >= 2.90 (gh skill requires it)
+      - name: Install gh >= 2.90 (gh skill requires it)
         run: |
-          sudo apt-get update
-          sudo apt-get install --only-upgrade -y gh
+          GH_VERSION=2.90.0
+          curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+            | sudo tar xz -C /usr/local --strip-components=1
           gh --version
 
       - name: Validate skills (gh skill publish --dry-run)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ on:
         options:
           - testpypi
           - pypi
-          - clawhub
+          - github-skills
           - all
 
 jobs:
@@ -80,41 +80,38 @@ jobs:
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 
-  publish-clawhub:
+  publish-github-skills:
+    # Creates a semver-tagged GitHub Release (e.g. v0.1.0-alpha.26 mirroring v0.1.0a26)
+    # so `gh skill install deepvista/deepvista-cli@v0.1.0-alpha.26` works.
+    # `gh skill publish --tag` validates skills before releasing, so no separate
+    # validate job is needed here — CI runs `gh skill publish --dry-run` on PRs.
     if: >
       github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && (github.event.inputs.target == 'clawhub' || github.event.inputs.target == 'all'))
+      (github.event_name == 'workflow_dispatch' && (github.event.inputs.target == 'github-skills' || github.event.inputs.target == 'all'))
     needs: build
     runs-on: ubuntu-latest
-    environment: clawhub
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Install clawhub CLI
-        run: npm install -g clawhub
+      - name: Ensure gh >= 2.90 (gh skill requires it)
+        run: |
+          sudo apt-get update
+          sudo apt-get install --only-upgrade -y gh
+          gh --version
 
-      - name: Authenticate with ClawHub
-        run: clawhub login --token "${{ secrets.CLAWHUB_TOKEN }}" --no-browser
-
-      - name: Publish skills to ClawHub
+      - name: Compute semver tag
+        id: semver
         run: |
           PEP440_VERSION="${{ needs.build.outputs.version }}"
-
-          # Convert PEP 440 to semver: 0.1.0a15 -> 0.1.0-alpha.15, 0.1.0b3 -> 0.1.0-beta.3, 0.1.0rc1 -> 0.1.0-rc.1
           SEMVER=$(echo "$PEP440_VERSION" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+)a([0-9]+)/\1-alpha.\2/; s/([0-9]+\.[0-9]+\.[0-9]+)b([0-9]+)/\1-beta.\2/; s/([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)/\1-rc.\2/')
-          echo "PEP 440 version: $PEP440_VERSION -> Semver: $SEMVER"
+          echo "tag=v$SEMVER" >> $GITHUB_OUTPUT
+          echo "PEP 440: $PEP440_VERSION -> semver tag: v$SEMVER"
 
-          for skill_dir in skills/*/; do
-            skill_name=$(basename "$skill_dir")
-            echo "Publishing $skill_name v$SEMVER..."
-
-            clawhub publish "$skill_dir" \
-              --slug "$skill_name" \
-              --version "$SEMVER" \
-              --tags latest \
-              --changelog "Release v$SEMVER" \
-              || echo "  Warning: Failed to publish $skill_name (may already exist at this version)"
-          done
-
-          echo ""
-          echo "Skills published to: https://clawhub.ai/skills"
+      - name: Publish to GitHub skills (gh skill publish)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh skill publish --tag "${{ steps.semver.outputs.tag }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,10 +97,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Ensure gh >= 2.90 (gh skill requires it)
+      - name: Install gh >= 2.90 (gh skill requires it)
         run: |
-          sudo apt-get update
-          sudo apt-get install --only-upgrade -y gh
+          GH_VERSION=2.90.0
+          curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+            | sudo tar xz -C /usr/local --strip-components=1
           gh --version
 
       - name: Compute semver tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ users what's new between the version they have installed and the latest release.
 ## Unreleased
 
 ### Added
+- GitHub skills publishing via `gh skill publish` (issue #75). Release workflow
+  now creates a semver-tagged GitHub Release (e.g. `v0.1.0a27` → `v0.1.0-alpha.27`)
+  so skills install with `gh skill install deepvista/deepvista-cli@v0.1.0-alpha.27`.
+  Agent Skills spec compliance is validated on every PR via
+  `gh skill publish --dry-run` in CI.
+
+### Removed
+- ClawHub publish step from the release workflow.
+
+### Added
 - Auto-update flow for the CLI and bundled skills, modeled after `gstack`
   (DV-378). Skills now run `deepvista upgrade check` when they load; if a newer
   version is on PyPI, the agent is instructed to tell the user and offer to


### PR DESCRIPTION
## Summary
- Adds `publish-github-skills` job to `.github/workflows/publish.yml` that converts the PEP 440 tag (e.g. `v0.1.0a27`) to semver (`v0.1.0-alpha.27`) and runs `gh skill publish --tag`, which validates against the agentskills.io spec and creates an immutable GitHub Release.
- Adds `gh skill publish --dry-run` validation step to `.github/workflows/ci.yml` so bad SKILL.md frontmatter is caught on PRs, not at release time.
- Removes the ClawHub publish job (no longer needed).
- Updates `CHANGELOG.md`.

Closes #75.

## Install paths after this ships
| Path | Command |
|---|---|
| PyPI | `uv tool install deepvista-cli` |
| GitHub skills | `gh skill install deepvista/deepvista-cli@v0.1.0-alpha.27` |
| skills.sh | `npx skills add deepvista/deepvista-cli` (auto-discovery, no CI) |

## Notes for first release
- `gh skill publish --tag` may try to add the `agent-skills` repo topic. If it fails due to `GITHUB_TOKEN` permission, pre-add the topic once: `gh repo edit --add-topic agent-skills`.
- Optional hardening suggested by `gh skill publish`: enable secret scanning + tag protection in repo settings.

## Test plan
- [ ] CI passes on this PR (validates skills via `gh skill publish --dry-run`)
- [ ] After merge, cut `v0.1.0a27` release; verify `publish-github-skills` job creates a `v0.1.0-alpha.27` release
- [ ] `gh skill install deepvista/deepvista-cli@v0.1.0-alpha.27` succeeds