### PR TITLE
release: v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ users what's new between the version they have installed and the latest release.
 
 ## Unreleased
 
+## v0.1.1
+
+First non-alpha release. Graduates from `0.1.0aN` (PEP 440 alpha) to a plain
+semver. No `0.1.0` stable was ever published to PyPI — the jump is intentional
+to keep the PyPI version and the git `v0.1.0` artifact (which was tagged at the
+a24 commit and only exists on GitHub) from colliding.
+
 - Auto-update flow for the CLI and bundled skills, modeled after `gstack`
   (DV-378). Skills now run `deepvista upgrade check` when they load; if a newer
   version is on PyPI, the agent is instructed to tell the user and offer to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.0a27"
+version = "0.1.1"
 description = "CLI for DeepVista — chat, notes, skills, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
First non-alpha release. Graduates from `0.1.0a27` to `0.1.1`.

## Why skip v0.1.0
The git tag `v0.1.0` was cut at the `a24` commit (2026-04-17) as a project-launch marker on GitHub, but `pyproject.toml` was never bumped to match, so PyPI has no `0.1.0`. Jumping straight to `0.1.1` avoids collision with that stale artifact and keeps PyPI + git tags aligned going forward.

## Post-merge
```
git checkout main && git pull
git tag v0.1.1
git push origin v0.1.1
```

The publish workflow will:
- Upload `deepvista-cli==0.1.1` to PyPI
- Run `gh skill publish --tag v0.1.1` (PEP 440 → semver is a no-op for stable versions, so the same `v0.1.1` tag is used for skills).

## Follow-ups (not in this PR)
- Bump `Development Status` classifier in `pyproject.toml` (currently `3 - Alpha`). Decide between `4 - Beta` and `5 - Production/Stable` and do it in a follow-up.