### PR TITLE
fix(publish): handle stable releases where PEP440 == semver tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -110,9 +110,32 @@ jobs:
           PEP440_VERSION="${{ needs.build.outputs.version }}"
           SEMVER=$(echo "$PEP440_VERSION" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+)a([0-9]+)/\1-alpha.\2/; s/([0-9]+\.[0-9]+\.[0-9]+)b([0-9]+)/\1-beta.\2/; s/([0-9]+\.[0-9]+\.[0-9]+)rc([0-9]+)/\1-rc.\2/')
           echo "tag=v$SEMVER" >> $GITHUB_OUTPUT
+          if [ "$PEP440_VERSION" = "$SEMVER" ]; then
+            echo "is_stable=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_stable=false" >> $GITHUB_OUTPUT
+          fi
           echo "PEP 440: $PEP440_VERSION -> semver tag: v$SEMVER"
 
-      - name: Publish to GitHub skills (gh skill publish)
+      - name: Publish to GitHub skills — pre-release (gh skill publish --tag)
+        # Pre-releases (alpha/beta/rc) need a new semver-aliased tag distinct from the
+        # PyPI PEP 440 tag (e.g. v0.1.0a27 -> v0.1.0-alpha.27), so gh skill publish
+        # creates both the tag and the release.
+        if: steps.semver.outputs.is_stable == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh skill publish --tag "${{ steps.semver.outputs.tag }}"
+
+      - name: Publish to GitHub skills — stable (validate + gh release create)
+        # Stable versions (e.g. 0.1.1) have PEP 440 == semver, so the PyPI tag
+        # IS the semver tag — gh skill publish would refuse to reuse it. Split
+        # validation from release creation.
+        if: steps.semver.outputs.is_stable == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh skill publish --dry-run
+          gh release create "${{ steps.semver.outputs.tag }}" \
+            --generate-notes \
+            --latest \
+            --title "${{ steps.semver.outputs.tag }}"


### PR DESCRIPTION
## Problem
v0.1.1 publish run ([24650889508](https://github.com/DeepVista-AI/deepvista-cli/actions/runs/24650889508)) shipped to PyPI but the `publish-github-skills` job failed with:

> tag v0.1.1 already exists; choose a different version

Root cause: `gh skill publish --tag X` always tries to create tag `X`. For pre-releases, the converted semver tag (`v0.1.0-alpha.27`) is distinct from the PyPI tag (`v0.1.0a27`), so creation succeeds. For stable releases, PEP 440 and semver are identical (`0.1.1` → `0.1.1`), so the tag already exists and `gh skill publish` refuses.

## Fix
Split the step by release type:

- **Pre-release** (`v0.1.0a27` → `v0.1.0-alpha.27`): `gh skill publish --tag` — creates both tag and release, as before.
- **Stable** (`v0.1.1`): `gh skill publish --dry-run` for validation, then `gh release create --generate-notes --latest` against the already-pushed PyPI tag.

## Tested
- v0.1.1 GH release created manually via `gh release create v0.1.1 --generate-notes --latest --title v0.1.1`. Next stable release (v0.1.2+) will exercise the new path automatically.
- Pre-release path unchanged, so v0.1.0-alpha.27 flow still works.