### PR TITLE
fix(skills): add license: Apache-2.0 to SKILL.md frontmatter

### DIFF
--- a/skills/deepvista-chat/SKILL.md
+++ b/skills/deepvista-chat/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-chat
 description: "DeepVista Chat: Send messages to the AI agent and manage chat sessions."
 metadata:

--- a/skills/deepvista-notes/SKILL.md
+++ b/skills/deepvista-notes/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-notes
 description: |
   DeepVista Notes: Create, read, update, and delete notes (explicit knowledge managed by the user).

--- a/skills/deepvista-openclaw/SKILL.md
+++ b/skills/deepvista-openclaw/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-openclaw
 description: DeepVista auto-capture and knowledge integration for OpenClaw agents. Automatically saves notable user statements, decisions, and insights to DeepVista knowledge base. Use when the user shares facts about themselves, their work, decisions, or plans.
 ---

--- a/skills/deepvista-persona-knowledge-worker/SKILL.md
+++ b/skills/deepvista-persona-knowledge-worker/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-persona-knowledge-worker
 description: "Persona: Knowledge worker daily workflow — check cards, process notes, run Skills."
 metadata:

--- a/skills/deepvista-shared/SKILL.md
+++ b/skills/deepvista-shared/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-shared
 description: "DeepVista CLI: Authentication, global flags, and security conventions."
 metadata:

--- a/skills/deepvista-skill-analyze-notes/SKILL.md
+++ b/skills/deepvista-skill-analyze-notes/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-skill-analyze-notes
 description: |
   Skill: Analyze, summarize, and find patterns across notes in your DeepVista knowledge base.

--- a/skills/deepvista-skill-export-knowledge/SKILL.md
+++ b/skills/deepvista-skill-export-knowledge/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-skill-export-knowledge
 description: "Skill: Export Skills as installable SKILL.md files for AI agents."
 metadata:

--- a/skills/deepvista-skill-import-files/SKILL.md
+++ b/skills/deepvista-skill-import-files/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-skill-import-files
 description: |
   Skill: Import files from the current directory (recursively) as context cards in DeepVista.

--- a/skills/deepvista-skill-research-to-skill/SKILL.md
+++ b/skills/deepvista-skill-research-to-skill/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-skill-research-to-skill
 description: "Skill: Search your knowledge base, synthesize findings, and run a Skill workflow."
 metadata:

--- a/skills/deepvista-skill/SKILL.md
+++ b/skills/deepvista-skill/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-skill
 description: "DeepVista Skill: Manage structured executable workflows (Skills) and run them via the AI agent."
 metadata:

--- a/skills/deepvista-vistabase-card/SKILL.md
+++ b/skills/deepvista-vistabase-card/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-vistabase-card
 description: "DeepVista Card: Manage your knowledge cards — create, search, and organize context cards."
 metadata:

--- a/skills/deepvista-vistabase/SKILL.md
+++ b/skills/deepvista-vistabase/SKILL.md
@@ -1,4 +1,5 @@
 ---
+license: Apache-2.0
 name: deepvista-vistabase
 description: "DeepVista Vistabase: View and search implicit memory context automatically accumulated from Chat."
 metadata:


### PR DESCRIPTION
Clears the \`recommended field missing: license\` warning from \`gh skill publish --dry-run\` for all 12 bundled skills. Matches the project-level Apache-2.0 license already declared in \`pyproject.toml\`.

Before:
\`\`\`
warning  deepvista-chat  recommended field missing: license
warning  deepvista-notes recommended field missing: license
...
\`\`\`

After: no skill-level warnings. Only repo-level warnings remain (secret scanning enabled separately via \`gh repo edit\`; tag protection ruleset is a follow-up decision).