### PR TITLE
release: v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ users what's new between the version they have installed and the latest release.
 
 ## Unreleased
 
+## v0.1.2
+
 ### Changed
 - **Skill pack collapsed to one consolidated `deepvista` skill** (DV-385, issue #75
   follow-up). Replaces the 12 top-level `deepvista-*` skills with a single
@@ -24,6 +26,9 @@ users what's new between the version they have installed and the latest release.
   `deepvista-skill-import-files`, `deepvista-skill-research-to-skill`,
   `deepvista-vistabase`, `deepvista-vistabase-card`). All content preserved under
   the consolidated skill.
+- `INSTALL_PROMPT.md` — unreferenced and drifting (still mentioned
+  `deepvista-vistabook` after the rename). The install flow is already documented
+  in `README.md` and `install.sh`.
 - Stale ClawHub and MIT license references from `README.md` and `CLAUDE.md` (license
   has been Apache-2.0 for a while; ClawHub publish was removed in #78).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.1"
+version = "0.1.2"
 description = "CLI for DeepVista — chat, notes, skills, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bump version for release.

## What ships in v0.1.2

- **Consolidated skill pack (DV-385).** 12 `deepvista-*` skills collapse to a single `deepvista` skill with per-subcommand `reference/*.md` files. `install.sh` sweeps the legacy 12 on upgrade.
- **Deleted** `INSTALL_PROMPT.md` — unreferenced and drifting.
- **Docs housekeeping** — ClawHub badge removed, MIT license badge corrected to Apache-2.0, CLAUDE.md skill-editing section rewritten for `gh skill publish` flow.

Full details: PR #85.

## Post-merge

```
git checkout main && git pull
git tag v0.1.2
git push origin v0.1.2
```

Tag push triggers PyPI publish + `gh release create v0.1.2` (stable path — same tag as PyPI).