### PR TITLE
chore(install): drop 'Load skill: deepvista' hint from post-install message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -361,6 +361,5 @@ fi
 echo ""
 echo "DeepVista is ready. Open your AI agent and say:"
 echo ""
-echo '  Load skill: deepvista'
 echo '  Help me get started with DeepVista.'
 echo ""


### PR DESCRIPTION
Followup to PR #85. I dropped the line from `README.md` but missed the identical one in `install.sh` (line 364). Same reasoning: skill loading is agent-specific, and by the time that message prints, `install.sh` has already copied the skill into every detected agent's skills dir.