### PR TITLE
feat(cli): `skill create-from-note` — note→persona+workflow synthesis

### DIFF
--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import re
+from typing import Any
 
 import click
 
@@ -18,6 +19,10 @@ from deepvista_cli.client.http import DeepVistaClient
 from deepvista_cli.output.formatter import format_output, output_error
 
 SKILL_COLUMNS = ["id", "title", "display_status", "updated_at"]
+
+SKILL_KINDS = ("persona", "workflow")
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
 
 
 def _client(ctx: click.Context) -> DeepVistaClient:
@@ -95,7 +100,6 @@ def skill_run(ctx: click.Context, skill_id: str, user_input: str | None, dry_run
 
     Output is NDJSON (one JSON object per line) as the agent streams its response.
     """
-    _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
     if not _UUID_RE.match(skill_id):
         output_error(3, "Invalid skill ID", f"Expected UUID format, got: {skill_id!r}")
 
@@ -226,3 +230,147 @@ def skill_install(ctx: click.Context, skill_id: str, dry_run: bool) -> None:
         click.echo(json.dumps({"status": "already_installed", "card": data.get("card", {})}, indent=2, default=str))
     else:
         click.echo(json.dumps({"status": "installed", "card": data.get("card", {})}, indent=2, default=str))
+
+
+# ---------------------------------------------------------------------------
+# create-from-note — synthesize skills from a source note via the agent
+# ---------------------------------------------------------------------------
+
+
+_CREATE_FROM_NOTE_INSTRUCTIONS = {
+    "persona": (
+        "A **persona skill** named `persona-<interviewee-slug>` that captures the "
+        "interviewee's philosophy, voice, and decision-making lens. When loaded, "
+        "the agent should respond in their voice and apply their frameworks. "
+        "Include: who they are, core mental models drawn from the note, voice/"
+        "tone rules, and a 3-5 phase advising sequence using <accordion>/<nli> "
+        "shortcodes."
+    ),
+    "workflow": (
+        "A **workflow skill** named `workflow-<topic-slug>` that turns the "
+        "interviewee's frameworks or steps into an executable workflow. The user "
+        "provides inputs; the workflow classifies, recommends, and returns a "
+        "prioritized plan. Include: purpose, input schema, 4-6 phases using "
+        "<accordion>/<nli> shortcodes, cheat sheet, and output format template."
+    ),
+}
+
+
+def _build_create_from_note_prompt(note_id: str, kinds: tuple[str, ...]) -> str:
+    lines = [
+        f'Look up the note with id "{note_id}" using `read_context_card`. Read '
+        "its full content. From that note, generate the skill(s) listed below. "
+        "Ground every detail in the note — do not invent frameworks or advice "
+        "the note doesn't contain.",
+        "",
+        "Skills to generate:",
+    ]
+    for i, kind in enumerate(kinds, 1):
+        lines.append(f"{i}. {_CREATE_FROM_NOTE_INSTRUCTIONS[kind]}")
+    lines.append("")
+    lines.append(
+        "**You MUST persist each skill by calling `upsert_context_card` with "
+        '`card_type="skill"`.** Do not write the skill content to a local '
+        "file, do not paste it in the chat response, do not skip the tool "
+        "call. One `upsert_context_card` invocation per skill."
+    )
+    lines.append("")
+    lines.append(
+        "For each `upsert_context_card` call: set `title` to the skill name, "
+        "put the full SKILL.md body in `description`, add relevant `tags` "
+        "including the kind (`persona` or `workflow`), and link the source "
+        f'note via `related_context_card_ids=["{note_id}"]`. After each call, '
+        "confirm the returned card id in the chat response."
+    )
+    return "\n".join(lines)
+
+
+@skill_group.command("create-from-note")
+@click.argument("note_id")
+@click.option(
+    "--kind",
+    "kinds",
+    type=click.Choice(SKILL_KINDS, case_sensitive=False),
+    multiple=True,
+    default=SKILL_KINDS,
+    help="Which skill kinds to synthesize. Repeatable. Default: persona and workflow.",
+)
+@click.option("--chat-id", default=None, help="Continue an existing synthesis session.")
+@click.option(
+    "--yes",
+    "-y",
+    "assume_yes",
+    is_flag=True,
+    default=False,
+    help="Skip the write confirmation prompt. Use only in scripts/batch conversion.",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Preview the prompt without calling the agent.")
+@click.pass_context
+def skill_create_from_note(
+    ctx: click.Context,
+    note_id: str,
+    kinds: tuple[str, ...],
+    chat_id: str | None,
+    assume_yes: bool,
+    dry_run: bool,
+) -> None:
+    """Synthesize skill card(s) from a note via the DeepVista agent.
+
+    Reads the note identified by `note_id` and invokes the agent with a curated
+    prompt that produces one `persona` skill (interviewee's voice + frameworks)
+    and/or one `workflow` skill (executable steps), grounded in the note's
+    content. Each generated skill is stored as a context card of `type=skill`.
+
+    Designed for batch-converting podcast / interview notes into reusable
+    skills. Streams NDJSON identical to `chat +send` and `skill run`.
+
+    > [!CAUTION] This is a write command — the agent creates skill cards in
+    > the user's project. Confirm before executing.
+    """
+    if not _UUID_RE.match(note_id):
+        output_error(3, "Invalid note ID", f"Expected UUID format, got: {note_id!r}")
+
+    # Empty tuple shouldn't happen with default, but guard anyway.
+    selected = kinds or SKILL_KINDS
+    # De-dup while preserving order.
+    seen: set[str] = set()
+    selected = tuple(k for k in selected if not (k in seen or seen.add(k)))
+
+    prompt = _build_create_from_note_prompt(note_id, selected)
+    body: dict[str, Any] = {"user_instruction": prompt}
+    if chat_id:
+        body["chat_id"] = chat_id
+
+    if dry_run:
+        format_output(
+            {
+                "dry_run": True,
+                "would": "synthesize skills from note via DeepVista agent",
+                "note_id": note_id,
+                "kinds": list(selected),
+                "payload": body,
+            },
+            ctx.obj.output_format,
+            entity_type="skill",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    if not assume_yes:
+        click.confirm(
+            f"The agent will create {len(selected)} skill card(s) from note {note_id}. Continue?",
+            abort=True,
+        )
+
+    try:
+        for event in _client(ctx).stream_sse("/imagine", body):
+            click.echo(json.dumps(event, default=str))
+    except (KeyboardInterrupt, click.Abort):
+        click.echo(json.dumps({"type": "interrupted", "message": "skill synthesis aborted by user"}), err=True)
+        raise
+    except Exception as exc:
+        click.echo(
+            json.dumps({"type": "error", "message": f"skill synthesis stream failed: {exc}"}),
+            err=True,
+        )
+        raise

--- a/skills/deepvista/SKILL.md
+++ b/skills/deepvista/SKILL.md
@@ -51,6 +51,7 @@ other reference file assumes you know it.
 | — analyze notes | searching → reading → synthesizing notes to surface themes / patterns | [skill-analyze-notes.md](reference/skill-analyze-notes.md) |
 | — research → run | finding context in the knowledge base, then running a Skill with synthesized input | [skill-research-to-skill.md](reference/skill-research-to-skill.md) |
 | — export | exporting a DeepVista Skill as a portable `SKILL.md` file for another agent | [skill-export-knowledge.md](reference/skill-export-knowledge.md) |
+| — create from note | synthesizing a persona + workflow skill from a podcast / interview / book note; batch-converting a corpus | [skill-create-from-note.md](reference/skill-create-from-note.md) |
 | — import files | recursively importing a local folder as `type=file` cards | [skill-import-files.md](reference/skill-import-files.md) |
 | persona: knowledge worker | daily workflow — check pinned cards, capture insights, run a Skill, ask the agent to synthesize | [persona-knowledge-worker.md](reference/persona-knowledge-worker.md) |
 | auto-capture for OpenClaw | automatically saving notable facts from conversations without confirmation | [openclaw.md](reference/openclaw.md) |

--- a/skills/deepvista/reference/skill-create-from-note.md
+++ b/skills/deepvista/reference/skill-create-from-note.md
@@ -1,0 +1,93 @@
+# Create skills from a note
+
+`deepvista skill create-from-note <note_id>` asks the DeepVista agent to read
+a source note (podcast episode, interview transcript, book chapter, research
+summary) and synthesize one or more skill cards grounded in the note's
+content. Two kinds are produced by default:
+
+- **`persona`** — captures the interviewee/author's voice, philosophy, and
+  decision-making lens. When loaded, the agent responds in their voice and
+  applies their frameworks.
+- **`workflow`** — turns the frameworks or steps they shared into an
+  executable workflow (inputs → phases → output template).
+
+Streams NDJSON identical to `chat +send` and `skill run`. Each generated
+skill is stored as a context card of `type=skill` in the user's project.
+
+## Command
+
+> [!CAUTION] Write — the agent creates skill cards in the user's project.
+> Confirm before executing, or pass `--yes` for scripted/batch use.
+
+```bash
+deepvista skill create-from-note <note_id> \
+  [--kind persona|workflow]... [--chat-id ID] [--yes] [--dry-run]
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `<note_id>` | required | UUID of the source note. Must exist in the caller's project. |
+| `--kind KIND` | `persona` + `workflow` | Repeatable. Restrict to one kind, e.g. `--kind persona`. |
+| `--chat-id ID` | — | Continue an existing synthesis session (iterate on the skills). |
+| `--yes` / `-y` | off | Skip the confirmation prompt. Required for scripts and cron. |
+| `--dry-run` | — | Print the prompt without calling the agent. |
+
+## When to use
+
+- You've captured a podcast episode / interview / book chapter as a note.
+- You want a reusable persona or workflow skill extracted from it.
+- You want to batch-convert a corpus (e.g. every Lenny's Podcast note tagged
+  `lenny`, every FounderCoHo note tagged `foundercoho`) into installable
+  skills.
+
+## Batch pattern
+
+There's no built-in bulk flag — use a shell loop. The `--yes` flag avoids
+per-note confirmation prompts:
+
+```bash
+# Every note tagged "lenny" → persona + workflow skills
+deepvista notes list --limit 100 \
+  | jq -r '.notes[] | select(.tags | index("lenny")) | .id' \
+  | while read -r note_id; do
+      deepvista skill create-from-note "$note_id" --yes \
+        >> ~/.config/deepvista/logs/skill-synthesis.log 2>&1
+    done
+```
+
+For a narrower pass (only the workflow):
+
+```bash
+deepvista skill create-from-note <note_id> --kind workflow --yes
+```
+
+## After creation
+
+Generated skills land with `status=unconfirmed`. Inspect each with
+[`deepvista card get <card_id>`](vistabase-card.md) and verify the SKILL.md
+body before running or exporting. See [skill-export-knowledge.md](skill-export-knowledge.md)
+for turning a stored skill into a portable `SKILL.md` file.
+
+## Examples
+
+```bash
+# Both kinds, interactive confirm
+deepvista skill create-from-note 0d5d1fb2-7414-4593-abc4-fb74984f4b2f
+
+# Persona only, scripted
+deepvista skill create-from-note 0d5d1fb2-... --kind persona --yes
+
+# Preview prompt
+deepvista skill create-from-note 0d5d1fb2-... --dry-run
+
+# Iterate on a prior synthesis
+deepvista skill create-from-note 0d5d1fb2-... --chat-id gmrpoqqw
+```
+
+## See also
+
+- [notes.md](notes.md) — capturing the source note (`deepvista notes create`
+  with `--content-file`) and re-indexing.
+- [skill.md](skill.md) — listing, running, exporting the generated skills.
+- [skill-research-to-skill.md](skill-research-to-skill.md) — broader pattern
+  (search → synthesize → run) when the source material spans multiple cards.

--- a/skills/deepvista/reference/skill.md
+++ b/skills/deepvista/reference/skill.md
@@ -20,6 +20,19 @@ deepvista skill get <skill_id>
 
 Returns the full Skill definition including every phase and step.
 
+### `create-from-note` — write
+
+> [!CAUTION] The agent creates skill cards grounded in a source note.
+> Confirm first (or pass `--yes` in batch scripts).
+
+```bash
+deepvista skill create-from-note <note_id> [--kind persona|workflow]... [--yes] [--dry-run]
+```
+
+Synthesizes one `persona` skill and/or one `workflow` skill from a source
+note (podcast, interview, book chapter, research summary). Full guide:
+[skill-create-from-note.md](skill-create-from-note.md).
+
 ### `run` — write
 
 > [!CAUTION] Starts a new Skill run and creates a chat session. Confirm first.


### PR DESCRIPTION
Follow-up to [#90](https://github.com/DeepVista-AI/deepvista-cli/pull/90) (DV-419). Enables batch-converting podcast / interview / book notes into reusable skills.

## Command

```bash
deepvista skill create-from-note <note_id> \
  [--kind persona|workflow]... [--chat-id ID] [--yes] [--dry-run]
```

Sends a curated prompt to `/imagine` that instructs the agent to read the source note via `read_context_card` and persist one persona skill and/or one workflow skill via `upsert_context_card`. Both stored as `type=skill` context cards in the caller's project.

| Flag | Purpose |
|---|---|
| `--kind` | Repeatable. Defaults to both `persona` + `workflow`. |
| `--yes` / `-y` | Skip the confirm prompt for scripted/batch use. |
| `--chat-id` | Continue an existing synthesis session for iteration. |
| `--dry-run` | Print the prompt without calling the agent. |

Errors + `KeyboardInterrupt` emit structured NDJSON on stderr before re-raising (matches `deepvista lint` behavior from #90).

## Prompt tightening

First prompt draft let the agent drift into `run_command` + local file writes instead of persisting cards. Tightened to:

> You MUST persist each skill by calling \`upsert_context_card\` with \`card_type=\"skill\"\`. Do not write the skill content to a local file, do not paste it in the chat response, do not skip the tool call.

After tightening, reliable two-skill output. See end-to-end results below.

## Batch pattern

No built-in bulk flag — shell loop. Example: convert every note tagged \`lenny\`:

```bash
deepvista notes list --limit 100 \
  | jq -r '.notes[] | select(.tags | index(\"lenny\")) | .id' \
  | while read -r nid; do
      deepvista skill create-from-note \"$nid\" --yes \
        >> ~/.config/deepvista/logs/skill-synthesis.log 2>&1
    done
```

## Test plan

- [x] Ruff + pyright + skill publish dry-run all pass.
- [x] Unit: `--dry-run` prints the prompt, `--kind persona` restricts to one, repeatable flag de-dupes.
- [x] End-to-end against \`--profile local\` on a Ravi Mehta Lenny note:
  - 2 \`upsert_context_card\` calls observed in the stream
  - \`persona-ravi-mehta\` (\`41b2c73b-…\`, 5169-char SKILL.md body, 8 tags including \`persona\`, \`lenny-podcast\`)
  - \`workflow-product-triad-and-pm-growth\` (\`7be22f66-…\`)
- [ ] Batch run across a real Lenny / FounderCoHo corpus.

## Known gaps (separate follow-ups)

1. **\`deepvista skill list\` returns empty** — endpoint queries \`card_type=vistabook\` but backend stores \`type=skill\`. Generated skills invisible via \`skill list\`; use \`card get <id>\` until the CLI-side rename lands.
2. **Skills land as \`status=unconfirmed\`** — no CLI verb to confirm/publish yet. Needs \`skill confirm <id>\` or auto-confirm flag.
3. **Agent occasionally omits \`related_context_card_ids\`** linking back to the source note. Worth strengthening the prompt or post-processing in a future iteration.

None of these block merging this PR — the command works; the three gaps are pre-existing or orthogonal.

## Refs

- \`deepvista_cli/commands/skill.py::skill_create_from_note\` — new subcommand. Lifted \`_UUID_RE\` to module scope (was duplicated inside \`skill_run\`).
- \`skills/deepvista/reference/skill-create-from-note.md\` — new reference with batch pattern + \"after creation\" notes.
- \`skills/deepvista/reference/skill.md\` + top-level \`SKILL.md\` index updated.