### PR TITLE
release: v0.1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.2"
+version = "0.1.3"
 description = "CLI for DeepVista — chat, notes, skills, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.2"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary
- Bump version from `0.1.2` → `0.1.3`
- Regenerate `uv.lock` to match

## Test plan
- [ ] CI passes on this branch
- [ ] After merge, tag `v0.1.3` and push to trigger PyPI publish + GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)