### PR TITLE
feat(cli): synthesize skills from multiple notes (DV-428)

### DIFF
--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from typing import Any
 
 import click
@@ -21,6 +22,14 @@ from deepvista_cli.output.formatter import format_output, output_error
 SKILL_COLUMNS = ["id", "title", "display_status", "updated_at"]
 
 SKILL_KINDS = ("persona", "workflow")
+
+# Cap applied when a selector returns a large set so a single synthesis run stays
+# within the agent's usable context. Overridable via --limit.
+_DEFAULT_MULTI_NOTE_LIMIT = 5
+
+# Upper cap when scanning `/get_context_cards` for tag filtering — tags are filtered
+# client-side since the list endpoint has no native tag filter.
+_TAG_SCAN_LIMIT = 200
 
 _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.IGNORECASE)
 
@@ -256,15 +265,48 @@ _CREATE_FROM_NOTE_INSTRUCTIONS = {
 }
 
 
-def _build_create_from_note_prompt(note_id: str, kinds: tuple[str, ...]) -> str:
-    lines = [
-        f'Look up the note with id "{note_id}" using `read_context_card`. Read '
-        "its full content. From that note, generate the skill(s) listed below. "
-        "Ground every detail in the note — do not invent frameworks or advice "
-        "the note doesn't contain.",
-        "",
-        "Skills to generate:",
-    ]
+def _build_create_from_note_prompt(notes: list[tuple[str, str]], kinds: tuple[str, ...]) -> str:
+    """Build the synthesis prompt for 1..N source notes.
+
+    ``notes`` is a list of ``(note_id, title)`` tuples; ``title`` may be empty
+    when the caller couldn't resolve it cheaply. The prompt stays compatible
+    with the single-note wording when ``len(notes) == 1`` so existing agents
+    keep producing the same output shape.
+    """
+    if not notes:
+        raise ValueError("at least one note is required")
+
+    ids_json = json.dumps([nid for nid, _ in notes])
+
+    if len(notes) == 1:
+        note_id = notes[0][0]
+        lines = [
+            f'Look up the note with id "{note_id}" using `read_context_card`. Read '
+            "its full content. From that note, generate the skill(s) listed below. "
+            "Ground every detail in the note — do not invent frameworks or advice "
+            "the note doesn't contain.",
+        ]
+    else:
+        bullets = []
+        for nid, title in notes:
+            label = f'"{title}" ({nid})' if title else nid
+            bullets.append(f"- {label}")
+        lines = [
+            f"Look up each of the following {len(notes)} source notes using "
+            "`read_context_card` and read their full content:",
+            "",
+            *bullets,
+            "",
+            "From those notes **together**, generate the skill(s) listed below. "
+            "Ground every detail in the notes — do not invent frameworks or advice "
+            "they don't contain. When the notes agree, state the shared principle "
+            "and cite each note that supports it. When they disagree, surface the "
+            "tension explicitly and let the user pick. Prefer synthesis over "
+            "averaging: the goal is a skill that is stronger than any single note.",
+        ]
+
+    lines.append("")
+    lines.append("Skills to generate:")
     for i, kind in enumerate(kinds, 1):
         lines.append(f"{i}. {_CREATE_FROM_NOTE_INSTRUCTIONS[kind]}")
     lines.append("")
@@ -278,15 +320,203 @@ def _build_create_from_note_prompt(note_id: str, kinds: tuple[str, ...]) -> str:
     lines.append(
         "For each `upsert_context_card` call: set `title` to the skill name, "
         "put the full SKILL.md body in `description`, add relevant `tags` "
-        "including the kind (`persona` or `workflow`), and link the source "
-        f'note via `related_context_card_ids=["{note_id}"]`. After each call, '
+        "including the kind (`persona` or `workflow`), and link every source "
+        f"note via `related_context_card_ids={ids_json}`. After each call, "
         "confirm the returned card id in the chat response."
     )
     return "\n".join(lines)
 
 
+# ---------------------------------------------------------------------------
+# Selector resolution — turn flags into a concrete list of note IDs
+# ---------------------------------------------------------------------------
+
+
+def _read_ids_from_file(path: str) -> list[str]:
+    """Read one ID per line from a file. ``-`` means stdin."""
+    if path == "-":
+        raw = sys.stdin.read()
+    else:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                raw = fh.read()
+        except OSError as exc:
+            output_error(4, "Cannot read --from-file", str(exc))
+            return []  # unreachable; output_error exits
+
+    ids: list[str] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Tolerate `jq -r '.notes[].id'` style or whitespace-separated tokens.
+        ids.extend(tok for tok in line.split() if tok and not tok.startswith("#"))
+    return ids
+
+
+def _cards_to_pairs(cards: list[dict], *, skip_id: str | None = None) -> list[tuple[str, str]]:
+    """Extract ``(id, title)`` pairs from an API card list, dropping ``skip_id``."""
+    pairs: list[tuple[str, str]] = []
+    for card in cards:
+        cid = card.get("id")
+        if not cid or cid == skip_id:
+            continue
+        pairs.append((cid, card.get("title", "") or ""))
+    return pairs
+
+
+def _resolve_from_search(client: DeepVistaClient, query: str, limit: int) -> list[tuple[str, str]]:
+    body = {"query_text": query, "card_type": "note", "limit": limit}
+    data = client.post("/get_context_cards", body)
+    return _cards_to_pairs(data.get("cards", []))
+
+
+def _resolve_from_similar(client: DeepVistaClient, seed_id: str, limit: int) -> list[tuple[str, str]]:
+    """Find notes related to a seed card via hybrid search on its title + snippet.
+
+    Matches the behaviour of `card +similar` (card.py) so results feel consistent.
+    """
+    seed = client.post("/get_context_card", {"card_id": seed_id})
+    title = seed.get("title", "") or ""
+    snippet = seed.get("snippet", "") or ""
+    query = f"{title} {snippet}".strip()
+    if not query:
+        output_error(3, "Seed card has no content for similarity search", f"Card: {seed_id}")
+    # Ask for one extra so we can drop the seed itself and still satisfy --limit.
+    body = {"query_text": query, "card_type": "note", "limit": limit + 1}
+    data = client.post("/get_context_cards", body)
+    return _cards_to_pairs(data.get("cards", []), skip_id=seed_id)[:limit]
+
+
+def _resolve_from_tag(client: DeepVistaClient, tag: str, limit: int) -> list[tuple[str, str]]:
+    """Filter notes by tag (client-side — the list endpoint has no tag filter)."""
+    body = {"card_type": "note", "limit": _TAG_SCAN_LIMIT, "page_number": 1}
+    data = client.post("/get_context_cards", body)
+    matched = [c for c in data.get("cards", []) if tag in (c.get("tags") or [])]
+    return _cards_to_pairs(matched)[:limit]
+
+
+def _resolve_from_grep(client: DeepVistaClient, pattern: str, limit: int) -> list[tuple[str, str]]:
+    """Regex-match note content via `/grep_context_cards`."""
+    body = {
+        "pattern": pattern,
+        "case_insensitive": False,
+        "limit": limit,
+        "context_lines": 0,
+        "card_type": "note",
+    }
+    data = client.post("/grep_context_cards", body)
+    # The grep endpoint returns `matches` grouped by card; we only need ids+titles.
+    pairs: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for match in data.get("matches", data.get("results", [])):
+        cid = match.get("card_id") or match.get("id")
+        if not cid or cid in seen:
+            continue
+        seen.add(cid)
+        pairs.append((cid, match.get("title", "") or ""))
+    return pairs[:limit]
+
+
+def _dedupe_pairs(pairs: list[tuple[str, str]]) -> list[tuple[str, str]]:
+    """De-duplicate while preserving first-seen order. Prefer non-empty titles."""
+    seen: dict[str, str] = {}
+    order: list[str] = []
+    for cid, title in pairs:
+        if cid not in seen:
+            seen[cid] = title
+            order.append(cid)
+        elif not seen[cid] and title:
+            seen[cid] = title
+    return [(cid, seen[cid]) for cid in order]
+
+
+def _resolve_note_ids(
+    client: DeepVistaClient | None,
+    *,
+    positional: tuple[str, ...],
+    extra: tuple[str, ...],
+    from_file: str | None,
+    from_search: str | None,
+    from_similar: str | None,
+    from_tag: str | None,
+    from_grep: str | None,
+    limit: int,
+) -> list[tuple[str, str]]:
+    """Merge every source of note IDs into a single ordered, capped list.
+
+    ``client`` may be ``None`` when the caller only supplies explicit IDs (tests
+    rely on this). Selectors that need the API will fail loudly if it's missing.
+    """
+    pairs: list[tuple[str, str]] = [(nid, "") for nid in positional]
+    pairs.extend((nid, "") for nid in extra)
+    if from_file is not None:
+        pairs.extend((nid, "") for nid in _read_ids_from_file(from_file))
+
+    def require_client() -> DeepVistaClient:
+        if client is None:
+            raise RuntimeError("API client is required for search/similar/tag/grep selectors")
+        return client
+
+    if from_search:
+        pairs.extend(_resolve_from_search(require_client(), from_search, limit))
+    if from_similar:
+        if not _UUID_RE.match(from_similar):
+            output_error(3, "Invalid --from-similar seed", f"Expected UUID, got: {from_similar!r}")
+        pairs.extend(_resolve_from_similar(require_client(), from_similar, limit))
+    if from_tag:
+        pairs.extend(_resolve_from_tag(require_client(), from_tag, limit))
+    if from_grep:
+        pairs.extend(_resolve_from_grep(require_client(), from_grep, limit))
+
+    pairs = _dedupe_pairs(pairs)
+    return pairs[:limit]
+
+
 @skill_group.command("create-from-note")
-@click.argument("note_id")
+@click.argument("note_ids_positional", metavar="[NOTE_ID]...", nargs=-1)
+@click.option(
+    "--note-id",
+    "note_id_flags",
+    multiple=True,
+    help="Source note by ID. Repeatable — pass multiple to synthesize across notes.",
+)
+@click.option(
+    "--from-file",
+    default=None,
+    metavar="PATH",
+    help="Read note IDs (one per line) from a file. Use '-' for stdin.",
+)
+@click.option(
+    "--from-search",
+    default=None,
+    metavar="QUERY",
+    help="Resolve source notes via hybrid search (same backend as `card +search`).",
+)
+@click.option(
+    "--from-similar",
+    default=None,
+    metavar="SEED_NOTE_ID",
+    help="Resolve source notes related to a seed note (graph-style neighbours).",
+)
+@click.option(
+    "--from-tag",
+    default=None,
+    metavar="TAG",
+    help="Resolve source notes whose tags list contains TAG.",
+)
+@click.option(
+    "--from-grep",
+    default=None,
+    metavar="REGEX",
+    help="Resolve source notes whose content matches a regex.",
+)
+@click.option(
+    "--limit",
+    type=click.IntRange(1, 25),
+    default=_DEFAULT_MULTI_NOTE_LIMIT,
+    help=f"Cap resolved source notes (default {_DEFAULT_MULTI_NOTE_LIMIT}, max 25).",
+)
 @click.option(
     "--kind",
     "kinds",
@@ -308,35 +538,69 @@ def _build_create_from_note_prompt(note_id: str, kinds: tuple[str, ...]) -> str:
 @click.pass_context
 def skill_create_from_note(
     ctx: click.Context,
-    note_id: str,
+    note_ids_positional: tuple[str, ...],
+    note_id_flags: tuple[str, ...],
+    from_file: str | None,
+    from_search: str | None,
+    from_similar: str | None,
+    from_tag: str | None,
+    from_grep: str | None,
+    limit: int,
     kinds: tuple[str, ...],
     chat_id: str | None,
     assume_yes: bool,
     dry_run: bool,
 ) -> None:
-    """Synthesize skill card(s) from a note via the DeepVista agent.
+    """Synthesize skill card(s) from one or more notes via the DeepVista agent.
 
-    Reads the note identified by `note_id` and invokes the agent with a curated
-    prompt that produces one `persona` skill (interviewee's voice + frameworks)
-    and/or one `workflow` skill (executable steps), grounded in the note's
-    content. Each generated skill is stored as a context card of `type=skill`.
+    Pass a single note UUID positionally for the original single-note behaviour,
+    or combine multiple notes via repeated positionals, `--note-id`, `--from-file`
+    (including stdin via `-`), `--from-search`, `--from-similar`, `--from-tag`,
+    and `--from-grep`. The agent produces one `persona` skill (voice + frameworks)
+    and/or one `workflow` skill (executable steps), grounded in the union of all
+    resolved notes and linked back to every source.
 
-    Designed for batch-converting podcast / interview notes into reusable
-    skills. Streams NDJSON identical to `chat +send` and `skill run`.
+    Streams NDJSON identical to `chat +send` and `skill run`.
 
     > [!CAUTION] This is a write command — the agent creates skill cards in
     > the user's project. Confirm before executing.
     """
-    if not _UUID_RE.match(note_id):
-        output_error(3, "Invalid note ID", f"Expected UUID format, got: {note_id!r}")
+    # Validate any directly-supplied IDs up front — cheap + gives a useful error.
+    for nid in (*note_ids_positional, *note_id_flags):
+        if not _UUID_RE.match(nid):
+            output_error(3, "Invalid note ID", f"Expected UUID format, got: {nid!r}")
 
-    # Empty tuple shouldn't happen with default, but guard anyway.
-    selected = kinds or SKILL_KINDS
-    # De-dup while preserving order.
-    seen: set[str] = set()
-    selected = tuple(k for k in selected if not (k in seen or seen.add(k)))
+    # Selectors that require API access skip in dry-run with no client yet? We still
+    # want to dry-run from real data to show the exact prompt the agent will see,
+    # so the client is always built lazily on first access.
+    selectors_used = any([from_file, from_search, from_similar, from_tag, from_grep])
+    api_needed = bool(from_search or from_similar or from_tag or from_grep)
 
-    prompt = _build_create_from_note_prompt(note_id, selected)
+    client = _client(ctx) if api_needed else None
+    resolved = _resolve_note_ids(
+        client,
+        positional=note_ids_positional,
+        extra=note_id_flags,
+        from_file=from_file,
+        from_search=from_search,
+        from_similar=from_similar,
+        from_tag=from_tag,
+        from_grep=from_grep,
+        limit=limit,
+    )
+
+    if not resolved:
+        hint = (
+            "pass a NOTE_ID or a selector (--note-id, --from-file, --from-search, "
+            "--from-similar, --from-tag, --from-grep)"
+        )
+        output_error(3, "No source notes resolved", hint if not selectors_used else "selectors returned zero notes")
+
+    # De-dup `--kind` while preserving order. Empty tuple shouldn't happen (has default).
+    seen_k: set[str] = set()
+    selected = tuple(k for k in (kinds or SKILL_KINDS) if not (k in seen_k or seen_k.add(k)))
+
+    prompt = _build_create_from_note_prompt(resolved, selected)
     body: dict[str, Any] = {"user_instruction": prompt}
     if chat_id:
         body["chat_id"] = chat_id
@@ -345,8 +609,9 @@ def skill_create_from_note(
         format_output(
             {
                 "dry_run": True,
-                "would": "synthesize skills from note via DeepVista agent",
-                "note_id": note_id,
+                "would": "synthesize skills from note(s) via DeepVista agent",
+                "note_ids": [nid for nid, _ in resolved],
+                "resolved_notes": [{"id": nid, "title": title} for nid, title in resolved],
                 "kinds": list(selected),
                 "payload": body,
             },
@@ -358,12 +623,16 @@ def skill_create_from_note(
 
     if not assume_yes:
         click.confirm(
-            f"The agent will create {len(selected)} skill card(s) from note {note_id}. Continue?",
+            (
+                f"The agent will create {len(selected)} skill card(s) synthesized from "
+                f"{len(resolved)} source note(s). Continue?"
+            ),
             abort=True,
         )
 
     try:
-        for event in _client(ctx).stream_sse("/imagine", body):
+        active_client = client or _client(ctx)
+        for event in active_client.stream_sse("/imagine", body):
             click.echo(json.dumps(event, default=str))
     except (KeyboardInterrupt, click.Abort):
         click.echo(json.dumps({"type": "interrupted", "message": "skill synthesis aborted by user"}), err=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,13 @@ packages = ["deepvista_cli"]
 dev = [
     "pre-commit>=3.7",
     "pyright>=1.1",
+    "pytest>=8.0",
     "ruff>=0.4",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra --strict-markers"
 
 [tool.ruff]
 line-length = 120

--- a/skills/deepvista/reference/skill-create-from-note.md
+++ b/skills/deepvista/reference/skill-create-from-note.md
@@ -1,9 +1,9 @@
-# Create skills from a note
+# Create skills from one or more notes
 
-`deepvista skill create-from-note <note_id>` asks the DeepVista agent to read
-a source note (podcast episode, interview transcript, book chapter, research
-summary) and synthesize one or more skill cards grounded in the note's
-content. Two kinds are produced by default:
+`deepvista skill create-from-note` asks the DeepVista agent to read one or more
+source notes (podcast episodes, interview transcripts, book chapters, research
+summaries) and synthesize skill cards grounded in their content. Two kinds are
+produced by default:
 
 - **`persona`** — captures the interviewee/author's voice, philosophy, and
   decision-making lens. When loaded, the agent responds in their voice and
@@ -12,7 +12,8 @@ content. Two kinds are produced by default:
   executable workflow (inputs → phases → output template).
 
 Streams NDJSON identical to `chat +send` and `skill run`. Each generated
-skill is stored as a context card of `type=skill` in the user's project.
+skill is stored as a context card of `type=skill`, linked back to every
+source note via `related_context_card_ids`.
 
 ## Command
 
@@ -20,73 +21,119 @@ skill is stored as a context card of `type=skill` in the user's project.
 > Confirm before executing, or pass `--yes` for scripted/batch use.
 
 ```bash
-deepvista skill create-from-note <note_id> \
-  [--kind persona|workflow]... [--chat-id ID] [--yes] [--dry-run]
+deepvista skill create-from-note [NOTE_ID]...
+  [--note-id UUID]...
+  [--from-file PATH | -]
+  [--from-search QUERY]
+  [--from-similar SEED_NOTE_ID]
+  [--from-tag TAG]
+  [--from-grep REGEX]
+  [--limit N]
+  [--kind persona|workflow]...
+  [--chat-id ID] [--yes] [--dry-run]
 ```
 
 | Flag | Default | Purpose |
-|---|---|---|
-| `<note_id>` | required | UUID of the source note. Must exist in the caller's project. |
+| --- | --- | --- |
+| `NOTE_ID...` | — | Zero or more positional source-note UUIDs. Back-compat: a single positional keeps the exact legacy prompt. |
+| `--note-id UUID` | — | Repeatable alternative to positional IDs (friendlier in scripts). |
+| `--from-file PATH` | — | Read one ID per line from a file. `#` lines and blank lines are ignored. Pass `-` for stdin. |
+| `--from-search QUERY` | — | Hybrid vector + keyword search over notes (same backend as `card +search`). |
+| `--from-similar SEED` | — | Graph-style neighbours: notes similar to a seed note by title + snippet. |
+| `--from-tag TAG` | — | All notes whose `tags` list contains TAG (client-side filter over the latest 200 notes). |
+| `--from-grep REGEX` | — | Notes whose content matches a regex (via `/grep_context_cards`). |
+| `--limit N` | `5` (max 25) | Cap on resolved source notes so the synthesis prompt stays within the agent's usable context. |
 | `--kind KIND` | `persona` + `workflow` | Repeatable. Restrict to one kind, e.g. `--kind persona`. |
 | `--chat-id ID` | — | Continue an existing synthesis session (iterate on the skills). |
 | `--yes` / `-y` | off | Skip the confirmation prompt. Required for scripts and cron. |
-| `--dry-run` | — | Print the prompt without calling the agent. |
+| `--dry-run` | — | Resolve the source notes and print the prompt without calling the agent. |
+
+All selectors compose. Positional + `--note-id` + every `--from-*` flag are
+union-merged and de-duplicated, capped by `--limit`.
 
 ## When to use
 
-- You've captured a podcast episode / interview / book chapter as a note.
-- You want a reusable persona or workflow skill extracted from it.
-- You want to batch-convert a corpus (e.g. every Lenny's Podcast note tagged
-  `lenny`, every FounderCoHo note tagged `foundercoho`) into installable
-  skills.
+- You've captured one or more podcast episodes / interviews / book chapters
+  as notes and want a reusable persona or workflow skill extracted.
+- You want to synthesize across notes — e.g. three Lenny episodes on
+  positioning → a single positioning workflow — not one skill per episode.
+- You want to batch-convert a corpus (e.g. every note tagged `lenny`) into
+  installable skills.
 
-## Batch pattern
+## Usage patterns
 
-There's no built-in bulk flag — use a shell loop. The `--yes` flag avoids
-per-note confirmation prompts:
+### 1. Single note — unchanged
 
 ```bash
-# Every note tagged "lenny" → persona + workflow skills
+deepvista skill create-from-note 0d5d1fb2-7414-4593-abc4-fb74984f4b2f
+```
+
+### 2. Multiple notes pinned by hand
+
+```bash
+deepvista skill create-from-note \
+  0d5d1fb2-... 8a1f2c40-... 4f9e6b17-... \
+  --kind workflow --yes
+```
+
+### 3. Pipe from a prior search
+
+```bash
+# Every note matching "positioning" → one synthesized workflow skill
 deepvista notes list --limit 100 \
-  | jq -r '.notes[] | select(.tags | index("lenny")) | .id' \
-  | while read -r note_id; do
-      deepvista skill create-from-note "$note_id" --yes \
-        >> ~/.config/deepvista/logs/skill-synthesis.log 2>&1
-    done
+  | jq -r '.notes[] | select(.title | test("positioning"; "i")) | .id' \
+  | deepvista skill create-from-note --from-file - --kind workflow --yes
 ```
 
-For a narrower pass (only the workflow):
+### 4. Semantic selector — no prior IDs needed
 
 ```bash
-deepvista skill create-from-note <note_id> --kind workflow --yes
+deepvista skill create-from-note \
+  --from-search "product-market fit signals" \
+  --limit 5 --kind workflow --yes
 ```
+
+### 5. Graph expansion from a seed
+
+```bash
+# Start from one great Lenny episode → synthesize across its neighbours.
+deepvista skill create-from-note \
+  --from-similar 0d5d1fb2-... --limit 4 --yes
+```
+
+### 6. Tag corpus rollup
+
+```bash
+# One skill that distills everything you've captured from Lenny's Podcast.
+deepvista skill create-from-note --from-tag lenny --limit 10 --yes
+```
+
+### 7. Regex selector for ad-hoc corpora
+
+```bash
+deepvista skill create-from-note --from-grep "DRI|operating rhythm" --yes
+```
+
+### 8. Preview first
+
+```bash
+deepvista skill create-from-note --from-tag lenny --limit 5 --dry-run
+```
+
+The dry-run output includes `resolved_notes` (every ID + title the agent
+will see) and the full `user_instruction` — inspect before spending tokens.
 
 ## After creation
 
 Generated skills land with `status=unconfirmed`. Inspect each with
 [`deepvista card get <card_id>`](vistabase-card.md) and verify the SKILL.md
-body before running or exporting. See [skill-export-knowledge.md](skill-export-knowledge.md)
-for turning a stored skill into a portable `SKILL.md` file.
-
-## Examples
-
-```bash
-# Both kinds, interactive confirm
-deepvista skill create-from-note 0d5d1fb2-7414-4593-abc4-fb74984f4b2f
-
-# Persona only, scripted
-deepvista skill create-from-note 0d5d1fb2-... --kind persona --yes
-
-# Preview prompt
-deepvista skill create-from-note 0d5d1fb2-... --dry-run
-
-# Iterate on a prior synthesis
-deepvista skill create-from-note 0d5d1fb2-... --chat-id gmrpoqqw
-```
+body before running or exporting. See
+[skill-export-knowledge.md](skill-export-knowledge.md) for turning a stored
+skill into a portable `SKILL.md` file.
 
 ## See also
 
-- [notes.md](notes.md) — capturing the source note (`deepvista notes create`
+- [notes.md](notes.md) — capturing the source notes (`deepvista notes create`
   with `--content-file`) and re-indexing.
 - [skill.md](skill.md) — listing, running, exporting the generated skills.
 - [skill-research-to-skill.md](skill-research-to-skill.md) — broader pattern

--- a/tests/test_skill_create_from_multi_notes.py
+++ b/tests/test_skill_create_from_multi_notes.py
@@ -1,0 +1,376 @@
+"""Tests for multi-note skill synthesis (`deepvista skill create-from-note`).
+
+Scenarios are inspired by three Lenny's Podcast episodes — April Dunford
+(positioning), Shreyas Doshi (PM excellence), and Shishir Mehrotra (product
+operating system). The episodes are treated as three separate notes; the
+multi-note synthesis should produce a single skill (persona or workflow) that
+draws on all three rather than picking one.
+
+Full transcripts live at
+https://github.com/ChatPRD/lennys-podcast-transcripts/tree/main/episodes —
+we only embed short title + snippet stubs so tests stay hermetic and fast.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, cast
+
+import pytest
+from click.testing import CliRunner
+
+from deepvista_cli.client.http import DeepVistaClient
+from deepvista_cli.commands.skill import (
+    _build_create_from_note_prompt,
+    _dedupe_pairs,
+    _read_ids_from_file,
+    _resolve_note_ids,
+    skill_create_from_note,
+)
+from deepvista_cli.config import CLIConfig
+
+# ---------------------------------------------------------------------------
+# Fixtures — three Lenny episode stubs treated as notes in the KB
+# ---------------------------------------------------------------------------
+
+APRIL_ID = "11111111-1111-4111-8111-111111111111"
+SHREYAS_ID = "22222222-2222-4222-8222-222222222222"
+SHISHIR_ID = "33333333-3333-4333-8333-333333333333"
+
+LENNY_NOTES: list[dict] = [
+    {
+        "id": APRIL_ID,
+        "type": "note",
+        "title": "Lenny × April Dunford — Positioning fixes everything",
+        "snippet": (
+            "Positioning is the context that makes your product obviously valuable. "
+            "Five inputs: competitive alternatives, unique attributes, value, customers, "
+            "market category."
+        ),
+        "tags": ["lenny", "positioning", "marketing"],
+    },
+    {
+        "id": SHREYAS_ID,
+        "type": "note",
+        "title": "Lenny × Shreyas Doshi — The 3 levels of PM excellence",
+        "snippet": (
+            "Execution, strategic, and visionary PMs differ in the problems they see. "
+            "High-agency PMs exit the bubble and own outcomes, not outputs."
+        ),
+        "tags": ["lenny", "product-management", "craft"],
+    },
+    {
+        "id": SHISHIR_ID,
+        "type": "note",
+        "title": "Lenny × Shishir Mehrotra — Rituals + the product operating system",
+        "snippet": (
+            "DRIs, narratives, and metrics rituals create a company's operating system. "
+            "Memos beat slides; prioritization is a language, not an act."
+        ),
+        "tags": ["lenny", "operating-system", "leadership"],
+    },
+]
+
+# Fast lookup for the fake client
+LENNY_BY_ID = {n["id"]: n for n in LENNY_NOTES}
+
+
+# ---------------------------------------------------------------------------
+# Fake HTTP client — mimics the real DeepVistaClient surface we touch
+# ---------------------------------------------------------------------------
+
+
+class FakeClient:
+    """In-memory stand-in for DeepVistaClient.
+
+    Records every call so tests can assert on the requests we made, and returns
+    canned responses for the three endpoints the selector resolution uses.
+    """
+
+    def __init__(self, cards: list[dict] | None = None) -> None:
+        self.cards = cards if cards is not None else list(LENNY_NOTES)
+        self.calls: list[tuple[str, dict]] = []
+        self.sse_events: list[dict] = []
+
+    def post(self, path: str, body: dict) -> dict:
+        self.calls.append((path, dict(body)))
+        if path == "/get_context_card":
+            cid = body["card_id"]
+            return dict(LENNY_BY_ID.get(cid, {"id": cid, "title": "", "snippet": ""}))
+        if path == "/get_context_cards":
+            # Ignore semantic ranking — return filtered-by-type cards in order.
+            results = [c for c in self.cards if body.get("card_type") in (None, c.get("type"))]
+            limit = int(body.get("limit", 20))
+            return {"cards": results[:limit], "has_more": len(results) > limit}
+        if path == "/grep_context_cards":
+            # Trivially pretend every card matched, reusing the cards list.
+            limit = int(body.get("limit", 20))
+            matches = [{"card_id": c["id"], "title": c.get("title", "")} for c in self.cards[:limit]]
+            return {"matches": matches}
+        raise AssertionError(f"Unexpected POST {path}")
+
+    def stream_sse(self, path: str, body: dict):  # pragma: no cover - unused in tests
+        self.calls.append((path, dict(body)))
+        yield from self.sse_events
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+class TestDedupePairs:
+    def test_preserves_first_seen_order(self) -> None:
+        pairs = [("a", ""), ("b", "B"), ("a", "A"), ("c", "C")]
+        assert _dedupe_pairs(pairs) == [("a", "A"), ("b", "B"), ("c", "C")]
+
+    def test_later_title_fills_empty(self) -> None:
+        # If the positional pass seeded ("id", "") first and the search pass
+        # returned a real title later, we should adopt the title.
+        assert _dedupe_pairs([("x", ""), ("x", "Real Title")]) == [("x", "Real Title")]
+
+    def test_nonempty_title_is_not_overwritten(self) -> None:
+        assert _dedupe_pairs([("x", "Keep"), ("x", "Other")]) == [("x", "Keep")]
+
+
+class TestReadIdsFromFile:
+    def test_reads_one_per_line_skipping_comments_and_blanks(self, tmp_path) -> None:
+        f = tmp_path / "ids.txt"
+        f.write_text(
+            f"""
+            # Lenny podcast batch
+            {APRIL_ID}
+
+            {SHREYAS_ID}   {SHISHIR_ID}
+            # trailing comment
+            """
+        )
+        assert _read_ids_from_file(str(f)) == [APRIL_ID, SHREYAS_ID, SHISHIR_ID]
+
+    def test_stdin_dash(self, monkeypatch) -> None:
+        import io
+
+        monkeypatch.setattr("sys.stdin", io.StringIO(f"{APRIL_ID}\n{SHREYAS_ID}\n"))
+        assert _read_ids_from_file("-") == [APRIL_ID, SHREYAS_ID]
+
+
+# ---------------------------------------------------------------------------
+# Prompt builder
+# ---------------------------------------------------------------------------
+
+
+class TestPromptBuilder:
+    def test_single_note_prompt_preserves_legacy_wording(self) -> None:
+        # Backward-compat guard: the wording here is what agents were trained on
+        # for the single-note case. Changing it changes output shape for every
+        # existing user, so it's worth pinning.
+        prompt = _build_create_from_note_prompt([(APRIL_ID, "")], ("persona",))
+        assert f'Look up the note with id "{APRIL_ID}"' in prompt
+        assert f'related_context_card_ids=["{APRIL_ID}"]' in prompt
+        # Only one note → no multi-note instructions.
+        assert "source notes" not in prompt
+
+    def test_multi_note_prompt_lists_every_source(self) -> None:
+        notes = [
+            (APRIL_ID, LENNY_NOTES[0]["title"]),
+            (SHREYAS_ID, LENNY_NOTES[1]["title"]),
+            (SHISHIR_ID, LENNY_NOTES[2]["title"]),
+        ]
+        prompt = _build_create_from_note_prompt(notes, ("persona", "workflow"))
+        for nid, title in notes:
+            assert nid in prompt
+            assert title in prompt
+        assert "3 source notes" in prompt
+        # Synthesis instructions push the agent to cite + surface tensions
+        assert "When they disagree" in prompt
+        assert "cite each note" in prompt
+        # All three IDs must appear in the related_context_card_ids JSON array
+        ids_json = json.dumps([APRIL_ID, SHREYAS_ID, SHISHIR_ID])
+        assert f"related_context_card_ids={ids_json}" in prompt
+
+    def test_empty_notes_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _build_create_from_note_prompt([], ("persona",))
+
+
+# ---------------------------------------------------------------------------
+# Selector resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveNoteIds:
+    def _resolve(self, client: FakeClient | None = None, **kwargs: Any) -> list[tuple[str, str]]:
+        defaults: dict[str, Any] = {
+            "positional": (),
+            "extra": (),
+            "from_file": None,
+            "from_search": None,
+            "from_similar": None,
+            "from_tag": None,
+            "from_grep": None,
+            "limit": 5,
+        }
+        defaults.update(kwargs)
+        # FakeClient is structurally compatible with DeepVistaClient for the subset
+        # of methods the resolver uses — cast to keep pyright happy.
+        return _resolve_note_ids(cast(DeepVistaClient | None, client), **defaults)
+
+    def test_positional_only_no_client_needed(self) -> None:
+        pairs = self._resolve(positional=(APRIL_ID, SHREYAS_ID))
+        assert pairs == [(APRIL_ID, ""), (SHREYAS_ID, "")]
+
+    def test_note_id_flag_merges_with_positional(self) -> None:
+        pairs = self._resolve(positional=(APRIL_ID,), extra=(SHREYAS_ID,))
+        assert [p[0] for p in pairs] == [APRIL_ID, SHREYAS_ID]
+
+    def test_limit_caps_output(self) -> None:
+        pairs = self._resolve(positional=(APRIL_ID, SHREYAS_ID, SHISHIR_ID), limit=2)
+        assert len(pairs) == 2
+
+    def test_from_search_hits_hybrid_endpoint(self) -> None:
+        client = FakeClient()
+        pairs = self._resolve(client, from_search="product management", limit=3)
+        assert [p[0] for p in pairs] == [APRIL_ID, SHREYAS_ID, SHISHIR_ID]
+        assert client.calls == [
+            (
+                "/get_context_cards",
+                {"query_text": "product management", "card_type": "note", "limit": 3},
+            )
+        ]
+
+    def test_from_similar_drops_the_seed_itself(self) -> None:
+        client = FakeClient()
+        pairs = self._resolve(client, from_similar=APRIL_ID, limit=5)
+        ids = [p[0] for p in pairs]
+        assert APRIL_ID not in ids
+        assert SHREYAS_ID in ids and SHISHIR_ID in ids
+        # Seed fetch + similarity search ⇒ 2 calls
+        assert [c[0] for c in client.calls] == ["/get_context_card", "/get_context_cards"]
+
+    def test_from_tag_filters_client_side(self) -> None:
+        client = FakeClient()
+        pairs = self._resolve(client, from_tag="operating-system")
+        assert [p[0] for p in pairs] == [SHISHIR_ID]
+
+    def test_from_tag_missing_returns_empty(self) -> None:
+        pairs = self._resolve(FakeClient(), from_tag="nonexistent-tag")
+        assert pairs == []
+
+    def test_positional_and_selector_union(self) -> None:
+        """Mixing a manually-pinned seed with a tag selector should merge both."""
+        client = FakeClient()
+        pairs = self._resolve(client, positional=(APRIL_ID,), from_tag="lenny", limit=10)
+        ids = [p[0] for p in pairs]
+        # April pinned first, then tag results (which include April — deduped).
+        assert ids[0] == APRIL_ID
+        assert set(ids) == {APRIL_ID, SHREYAS_ID, SHISHIR_ID}
+
+    def test_client_none_with_api_selector_raises(self) -> None:
+        with pytest.raises(RuntimeError):
+            self._resolve(client=None, from_search="anything")
+
+
+# ---------------------------------------------------------------------------
+# CLI integration — dry-run so we never need to stream SSE
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx_obj(client: FakeClient) -> CLIConfig:
+    cfg = CLIConfig()
+    cfg.output_format = "json"
+    # Stash the fake client where the command helper expects it.
+    cfg._client = client  # type: ignore[attr-defined]
+    return cfg
+
+
+def _invoke_dry_run(client: FakeClient, args: list[str]) -> dict:
+    runner = CliRunner()
+    result = runner.invoke(
+        skill_create_from_note,
+        [*args, "--dry-run"],
+        obj=_make_ctx_obj(client),
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    return json.loads(result.output)
+
+
+class TestCliDryRun:
+    def test_single_positional_backward_compat(self) -> None:
+        """A single positional ID still goes through the legacy single-note path."""
+        payload = _invoke_dry_run(FakeClient(), [APRIL_ID])
+        assert payload["dry_run"] is True
+        assert payload["note_ids"] == [APRIL_ID]
+        assert f'Look up the note with id "{APRIL_ID}"' in payload["payload"]["user_instruction"]
+
+    def test_multiple_positionals_trigger_multi_note_prompt(self) -> None:
+        payload = _invoke_dry_run(FakeClient(), [APRIL_ID, SHREYAS_ID, SHISHIR_ID])
+        assert payload["note_ids"] == [APRIL_ID, SHREYAS_ID, SHISHIR_ID]
+        instruction = payload["payload"]["user_instruction"]
+        assert "3 source notes" in instruction
+        # Multi-note prompt includes the synthesis instructions.
+        assert "When they disagree" in instruction
+
+    def test_from_search_dry_run_resolves_via_fake_client(self) -> None:
+        client = FakeClient()
+        payload = _invoke_dry_run(client, ["--from-search", "strategic pm", "--limit", "2"])
+        assert [n["id"] for n in payload["resolved_notes"]] == [APRIL_ID, SHREYAS_ID]
+        # Search endpoint was called exactly once with the expected body.
+        assert ("/get_context_cards", {"query_text": "strategic pm", "card_type": "note", "limit": 2}) in client.calls
+
+    def test_from_tag_lenny_picks_up_all_three_episodes(self) -> None:
+        client = FakeClient()
+        payload = _invoke_dry_run(client, ["--from-tag", "lenny", "--limit", "5"])
+        assert {n["id"] for n in payload["resolved_notes"]} == {APRIL_ID, SHREYAS_ID, SHISHIR_ID}
+
+    def test_from_file_reads_ids(self, tmp_path) -> None:
+        f = tmp_path / "episodes.txt"
+        f.write_text(f"{APRIL_ID}\n{SHREYAS_ID}\n")
+        payload = _invoke_dry_run(FakeClient(), ["--from-file", str(f)])
+        assert payload["note_ids"] == [APRIL_ID, SHREYAS_ID]
+
+    def test_from_stdin_reads_ids_via_dash(self) -> None:
+        runner = CliRunner()
+        client = FakeClient()
+        result = runner.invoke(
+            skill_create_from_note,
+            ["--from-file", "-", "--dry-run"],
+            obj=_make_ctx_obj(client),
+            input=f"{APRIL_ID}\n{SHREYAS_ID}\n",
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["note_ids"] == [APRIL_ID, SHREYAS_ID]
+
+    def test_no_sources_errors(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            skill_create_from_note,
+            ["--dry-run"],
+            obj=_make_ctx_obj(FakeClient()),
+            catch_exceptions=False,
+        )
+        # output_error exits with the code it was passed (3).
+        assert result.exit_code == 3
+        err = json.loads(result.output)
+        assert err["error"]["message"] == "No source notes resolved"
+
+    def test_invalid_uuid_errors(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            skill_create_from_note,
+            ["not-a-uuid", "--dry-run"],
+            obj=_make_ctx_obj(FakeClient()),
+            catch_exceptions=False,
+        )
+        assert result.exit_code == 3
+        err = json.loads(result.output)
+        assert err["error"]["message"] == "Invalid note ID"
+
+    def test_kind_filter_is_respected(self) -> None:
+        payload = _invoke_dry_run(FakeClient(), [APRIL_ID, SHREYAS_ID, "--kind", "workflow"])
+        assert payload["kinds"] == ["workflow"]
+        instruction = payload["payload"]["user_instruction"]
+        assert "workflow skill" in instruction
+        assert "persona skill" not in instruction

--- a/uv.lock
+++ b/uv.lock
@@ -75,6 +75,7 @@ ui = [
 dev = [
     { name = "pre-commit" },
     { name = "pyright" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -93,6 +94,7 @@ provides-extras = ["ui"]
 dev = [
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pyright", specifier = ">=1.1" },
+    { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.4" },
 ]
 
@@ -170,6 +172,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "linkify-it-py"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -229,12 +240,30 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -301,6 +330,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/b2/5db700e52554b8f025faa9c3c624c59f1f6c8841ba81ab97641b54322f16/pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684", size = 4400578, upload-time = "2026-01-08T08:07:38.795Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/82/a2c93e32800940d9573fb28c346772a14778b84ba7524e691b324620ab89/pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1", size = 6399144, upload-time = "2026-01-08T08:07:37.082Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Extends `deepvista skill create-from-note` to accept **many** source notes — not just one — via variadic positionals, repeatable `--note-id`, or one of five declarative selectors (`--from-file/-`, `--from-search`, `--from-similar`, `--from-tag`, `--from-grep`). Sources compose, dedupe, and cap at `--limit` (default 5, max 25).
- Keeps single-note behaviour byte-for-byte identical so existing agents and batch scripts keep working. The prompt only switches to the synthesis variant (cite each note, surface disagreements, link all IDs in `related_context_card_ids`) when ≥ 2 notes are resolved.
- Adds `tests/` (pytest suite, 26 tests) covering the pure helpers, selector resolution against a fake HTTP client, and CLI dry-runs. Fixtures stub three Lenny's Podcast episodes (April Dunford · Shreyas Doshi · Shishir Mehrotra) to exercise multi-note synthesis hermetically.
- Updates `skills/deepvista/reference/skill-create-from-note.md` with the new surface and eight usage patterns — single note, manual multi, stdin pipe, semantic search, graph neighbours, tag rollup, regex, preview.

## Why this shape

DV-428 asked for multi-note skill synthesis where notes can come from a prior search, a graph neighbourhood, or arbitrary criteria. Three design trade-offs worth flagging:

1. **Single command, many selectors** — instead of a new `create-from-notes` (plural) command, I extended the existing one. Agents and docs already point at `create-from-note`; a new verb would fork the surface. All selectors union into the same resolver, so `… ID1 ID2 --from-tag lenny --from-search "positioning"` behaves as the natural union.
2. **Resolver returns `(id, title)` pairs** — titles are optional and populated only when the API already returns them (search / similar / grep). The prompt inlines titles when present so the agent has a cheap hint before it calls `read_context_card`. Positional/file IDs get titles lazily from the agent's own reads.
3. **`--limit` cap (default 5, max 25)** — synthesis quality degrades sharply past ~5 long-form transcripts in the window. Cap is explicit and overridable but bounded to keep naïve `--from-tag lenny --yes` from nuking your token budget.

## Usage cheat sheet

```bash
# Backward-compat — unchanged prompt
deepvista skill create-from-note <UUID>

# Multi-note synthesis, three ways
deepvista skill create-from-note ID1 ID2 ID3 --kind workflow --yes
deepvista notes list | jq -r '.notes[].id' | deepvista skill create-from-note --from-file - --yes
deepvista skill create-from-note --from-tag lenny --limit 5 --yes

# Graph expansion from a seed
deepvista skill create-from-note --from-similar <SEED_ID> --limit 4

# Preview the resolved notes + full prompt before spending tokens
deepvista skill create-from-note --from-search "product-market fit" --dry-run
```

## Test plan

- [x] `uv run pytest tests/` → 26 passing, <0.2s runtime
- [x] `uv run ruff check` + `ruff format --check` clean
- [x] `uv run pyright deepvista_cli/commands/skill.py tests/` clean (0 errors)
- [x] `gh skill publish --dry-run` → ok
- [x] `deepvista skill create-from-note --help` shows every new flag with ranges + help text
- [x] Single positional UUID → legacy single-note prompt verbatim (regression guard in `TestPromptBuilder::test_single_note_prompt_preserves_legacy_wording`)
- [x] Piped multi-UUID stdin → synthesis prompt with all three IDs in `related_context_card_ids`
- [ ] Follow-up: wire the pytest step into CI (`.github/workflows`) — out of scope for this PR, see DV-428 comment.

Ref: https://linear.app/deepvista/issue/DV-428