### PR TITLE
feat(cli): session-scoped notes + version history (DV-449)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ users what's new between the version they have installed and the latest release.
 
 ## Unreleased
 
+### Added
+- **Session-scoped conversation notes** (DV-449 M1/M2). One rolling DeepVista
+  note per Claude Code session, updated every conversation turn with
+  heuristic per-turn summaries. Frontmatter records agent, project dir, git
+  branch/commit, turn count, and version. New subcommands:
+  `deepvista notes session-init` (idempotent create-or-get by session_id),
+  `session-tick` (append newest turn, bump version), `session-finalize`
+  (mark complete, queue enrichment). Three shell hooks for Claude Code:
+  `hooks/deepvista-session-{start,turn,end}.sh` — non-blocking, silent
+  fallback when the CLI is missing.
+- **Version history for notes** (DV-449 M2). `deepvista notes history`
+  lists prior versions, `notes diff <id> <a> <b>` shows a unified diff,
+  `notes restore <id> <version>` rolls back (itself reversible). Backed by
+  the server-side `context_card_versions` audit table that captures every
+  note update via trigger.
+- **Session-note lookup uses server-side `tag_contains`** instead of
+  client-side scan of recent notes — O(1) resolution of
+  `cc-session:<session_id>` tag via the existing `/get_context_cards`
+  filter.
+
 ## v0.1.2
 
 ### Changed

--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -15,6 +15,7 @@ import click
 
 from deepvista_cli import session_note as sn
 from deepvista_cli.client.http import DeepVistaClient
+from deepvista_cli.client.origin import detect_agent_tool
 from deepvista_cli.commands import resolve_content
 from deepvista_cli.output.formatter import format_output, output_error
 
@@ -290,8 +291,8 @@ def _find_session_note(client: DeepVistaClient, session_id: str) -> dict[str, An
 @click.option("--session-id", required=True, help="Agent session ID (Claude Code session_id).")
 @click.option("--transcript", required=True, help="Path to the transcript JSONL.")
 @click.option("--cwd", required=True, help="Project working directory the session is running in.")
-@click.option("--agent", default=sn.DEFAULT_AGENT, help=f"Agent type (default: {sn.DEFAULT_AGENT}).")
-@click.option("--agent-version", default=None, help="Agent version string.")
+@click.option("--agent", default=None, help="Agent type. Auto-detected from env/process-tree when omitted.")
+@click.option("--agent-version", default=None, help="Agent version string. Auto-detected when omitted.")
 @click.option("--dry-run", is_flag=True, default=False, help="Preview what would happen without making any changes.")
 @click.pass_context
 def notes_session_init(
@@ -299,7 +300,7 @@ def notes_session_init(
     session_id: str,
     transcript: str,
     cwd: str,
-    agent: str,
+    agent: str | None,
     agent_version: str | None,
     dry_run: bool,
 ) -> None:
@@ -309,6 +310,11 @@ def notes_session_init(
 
     > [!CAUTION] This is a write command (creates a note on first call).
     """
+    if agent is None:
+        detected_agent, detected_version = detect_agent_tool()
+        agent = detected_agent
+        if agent_version is None:
+            agent_version = detected_version
     state = sn.load_state(session_id)
     note_id = state.get("note_id")
     if not note_id:

--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -632,10 +632,12 @@ def notes_quick(ctx: click.Context, text: str, dry_run: bool) -> None:
     if len(title) < len(text):
         title = title.rstrip(".") + "..."
 
+    agent, _ = detect_agent_tool()
     body = {
         "card_type": "note",
         "title": title,
         "description": text,
+        "tags": [f"{sn.AGENT_TAG_PREFIX}{agent}"],
         "enrich": True,
     }
 

--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -3,6 +3,7 @@
 Notes are a special case of context cards with type="note".
 The +quick helper creates a note from a single text argument.
 The index command triggers entity extraction on notes not yet processed.
+The session-* commands maintain a rolling note for one agent session (DV-449).
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ from typing import Any
 
 import click
 
+from deepvista_cli import session_note as sn
 from deepvista_cli.client.http import DeepVistaClient
 from deepvista_cli.commands import resolve_content
 from deepvista_cli.output.formatter import format_output, output_error
@@ -251,6 +253,354 @@ def notes_index(
         data,
         ctx.obj.output_format,
         title="Indexed Notes",
+        entity_type="note",
+        base_url=ctx.obj.auth_url,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Session-scoped notes (DV-449)
+#
+# One rolling note per agent session. `session-init` creates-or-gets the note
+# keyed by (agent, session_id). `session-tick` parses the transcript, extracts
+# the newest turn, appends a summary block, and bumps the version counter.
+# `session-finalize` marks the note complete and queues enrichment.
+# ---------------------------------------------------------------------------
+
+
+def _find_session_note(client: DeepVistaClient, session_id: str) -> dict[str, Any] | None:
+    """Find a note by its cc-session:<id> tag using server-side tag_contains filter."""
+    tag = f"{sn.SESSION_TAG_PREFIX}{session_id}"
+    data = client.post(
+        "/get_context_cards",
+        {
+            "card_type": "note",
+            "tag_contains": [tag],
+            "limit": 1,
+            "page_number": 1,
+            "order_by": "updated_at",
+            "order_direction": "desc",
+        },
+    )
+    cards = data.get("cards") or []
+    return cards[0] if cards else None
+
+
+@notes_group.command("session-init")
+@click.option("--session-id", required=True, help="Agent session ID (Claude Code session_id).")
+@click.option("--transcript", required=True, help="Path to the transcript JSONL.")
+@click.option("--cwd", required=True, help="Project working directory the session is running in.")
+@click.option("--agent", default=sn.DEFAULT_AGENT, help=f"Agent type (default: {sn.DEFAULT_AGENT}).")
+@click.option("--agent-version", default=None, help="Agent version string.")
+@click.option("--dry-run", is_flag=True, default=False, help="Preview what would happen without making any changes.")
+@click.pass_context
+def notes_session_init(
+    ctx: click.Context,
+    session_id: str,
+    transcript: str,
+    cwd: str,
+    agent: str,
+    agent_version: str | None,
+    dry_run: bool,
+) -> None:
+    """Create-or-get a rolling session note for the given session_id.
+
+    Idempotent — safe to call on every SessionStart hook fire.
+
+    > [!CAUTION] This is a write command (creates a note on first call).
+    """
+    state = sn.load_state(session_id)
+    note_id = state.get("note_id")
+    if not note_id:
+        existing = _find_session_note(_client(ctx), session_id)
+        if existing:
+            note_id = existing.get("id")
+
+    if note_id:
+        state.update({"note_id": note_id, "session_id": session_id})
+        sn.save_state(session_id, state)
+        format_output(
+            {"note_id": note_id, "session_id": session_id, "created": False},
+            ctx.obj.output_format,
+            title="Session note (existing)",
+            entity_type="note",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    fm = sn.seed_frontmatter(session_id, cwd, transcript, agent=agent, agent_version=agent_version)
+    body = sn.build_initial_body(fm)
+    payload = {
+        "card_type": "note",
+        "title": sn.default_title(session_id, cwd),
+        "description": body,
+        "tags": sn.session_tags(session_id, agent, cwd),
+        "enrich": False,
+    }
+
+    if dry_run:
+        format_output(
+            {"dry_run": True, "would": "create session note", "payload": payload},
+            ctx.obj.output_format,
+            entity_type="note",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    data = _client(ctx).post("/create_context_card", payload)
+    new_id = (data.get("card") or data).get("id") if isinstance(data, dict) else None
+    if new_id:
+        state.update({"note_id": new_id, "session_id": session_id, "last_turn_index": 0})
+        sn.save_state(session_id, state)
+    format_output(
+        {"note_id": new_id, "session_id": session_id, "created": True, "response": data},
+        ctx.obj.output_format,
+        title="Session note (created)",
+        entity_type="note",
+        base_url=ctx.obj.auth_url,
+    )
+
+
+@notes_group.command("session-tick")
+@click.option("--session-id", required=True, help="Agent session ID.")
+@click.option("--transcript", required=True, help="Path to the transcript JSONL.")
+@click.option("--dry-run", is_flag=True, default=False, help="Preview what would happen without making any changes.")
+@click.pass_context
+def notes_session_tick(ctx: click.Context, session_id: str, transcript: str, dry_run: bool) -> None:
+    """Append the newest turn(s) from the transcript into the session note.
+
+    Idempotent per turn — uses ``last_turn_index`` in the state cache to skip
+    turns already persisted. Safe to call on every Stop hook fire.
+
+    > [!CAUTION] This is a write command.
+    """
+    state = sn.load_state(session_id)
+    note_id = state.get("note_id")
+    if not note_id:
+        output_error(3, "Unknown session", f"No session note cached for {session_id}. Run session-init first.")
+        return
+
+    turns = sn.parse_transcript(transcript)
+    last_idx = int(state.get("last_turn_index") or 0)
+    new_turns = turns[last_idx:]
+    if not new_turns:
+        format_output(
+            {"note_id": note_id, "session_id": session_id, "appended": 0, "turn_count": last_idx},
+            ctx.obj.output_format,
+            title="Session tick (no-op)",
+            entity_type="note",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    card = _client(ctx).post("/get_context_card", {"card_id": note_id, "card_type": "note"})
+    body = (card.get("card") or card).get("description") or sn.build_initial_body({})
+    fm, _ = sn.parse_frontmatter(body)
+
+    for offset, turn in enumerate(new_turns):
+        turn_num = last_idx + offset + 1
+        block = sn.summarize_turn(turn, turn_num)
+        updates = {
+            "updated_at": sn.now_iso(),
+            "turn_count": turn_num,
+            "version": turn_num,
+        }
+        existing_tools = _parse_counter(fm.get("tools_used"))
+        for name, count in turn.tool_counts.items():
+            existing_tools[name] = existing_tools.get(name, 0) + count
+        if existing_tools:
+            updates["tools_used"] = dict(sorted(existing_tools.items()))
+        body = sn.append_turn(body, block, updates)
+        fm, _ = sn.parse_frontmatter(body)
+
+    payload = {"card_id": note_id, "description": body, "reason": "session-tick"}
+
+    if dry_run:
+        format_output(
+            {
+                "dry_run": True,
+                "would": "update session note",
+                "note_id": note_id,
+                "appended": len(new_turns),
+                "new_turn_count": last_idx + len(new_turns),
+            },
+            ctx.obj.output_format,
+            entity_type="note",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    data = _client(ctx).post("/update_context_card", payload)
+    state["last_turn_index"] = last_idx + len(new_turns)
+    sn.save_state(session_id, state)
+    format_output(
+        {
+            "note_id": note_id,
+            "session_id": session_id,
+            "appended": len(new_turns),
+            "turn_count": state["last_turn_index"],
+            "response": data,
+        },
+        ctx.obj.output_format,
+        title="Session tick",
+        entity_type="note",
+        base_url=ctx.obj.auth_url,
+    )
+
+
+def _parse_counter(raw: Any) -> dict[str, int]:
+    if isinstance(raw, dict):
+        return {str(k): int(v) for k, v in raw.items() if isinstance(v, int | float)}
+    if isinstance(raw, str) and raw.strip().startswith("{"):
+        try:
+            loaded = _json.loads(raw)
+            if isinstance(loaded, dict):
+                return {str(k): int(v) for k, v in loaded.items() if isinstance(v, int | float)}
+        except _json.JSONDecodeError:
+            return {}
+    return {}
+
+
+@notes_group.command("session-finalize")
+@click.option("--session-id", required=True, help="Agent session ID.")
+@click.option("--transcript", default=None, help="Transcript path (final flush). Optional.")
+@click.option(
+    "--no-enrich", is_flag=True, default=False, help="Skip the notes-index enrich call (useful in tests/offline)."
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Preview what would happen without making any changes.")
+@click.pass_context
+def notes_session_finalize(
+    ctx: click.Context, session_id: str, transcript: str | None, no_enrich: bool, dry_run: bool
+) -> None:
+    """Mark a session note complete and queue enrichment.
+
+    If ``--transcript`` is given, runs a final session-tick first. M3 will add
+    the LLM roll-up into ``## Session summary``; for M1 we just flip the
+    frontmatter ``status`` field and trigger /index_notes.
+
+    > [!CAUTION] This is a write command.
+    """
+    state = sn.load_state(session_id)
+    note_id = state.get("note_id")
+    if not note_id:
+        output_error(3, "Unknown session", f"No session note cached for {session_id}.")
+        return
+
+    if transcript:
+        ctx.invoke(notes_session_tick, session_id=session_id, transcript=transcript, dry_run=dry_run)
+
+    card = _client(ctx).post("/get_context_card", {"card_id": note_id, "card_type": "note"})
+    body = (card.get("card") or card).get("description") or ""
+    body = sn.append_turn(body, "", {"status": "complete", "updated_at": sn.now_iso()})
+    payload = {"card_id": note_id, "description": body, "reason": "session-finalize"}
+
+    if dry_run:
+        format_output(
+            {"dry_run": True, "would": "finalize session note", "note_id": note_id},
+            ctx.obj.output_format,
+            entity_type="note",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    _client(ctx).post("/update_context_card", payload)
+    enrich_result: Any = None
+    if not no_enrich:
+        enrich_result = _client(ctx).post("/index_notes", {"card_ids": [note_id], "only_unenriched": False})
+    format_output(
+        {"note_id": note_id, "session_id": session_id, "status": "complete", "enrich": enrich_result},
+        ctx.obj.output_format,
+        title="Session finalized",
+        entity_type="note",
+        base_url=ctx.obj.auth_url,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Version history (DV-449 M2)
+# ---------------------------------------------------------------------------
+
+
+@notes_group.command("history")
+@click.argument("note_id")
+@click.option("--limit", type=click.IntRange(1, 500), default=50, help="Max versions to list (default 50).")
+@click.pass_context
+def notes_history(ctx: click.Context, note_id: str, limit: int) -> None:
+    """List prior versions of a note (newest first).
+
+    Read-only.
+    """
+    data = _client(ctx).post("/get_context_card_history", {"card_id": note_id, "limit": limit})
+    versions = data.get("versions") or []
+    format_output(
+        {"note_id": note_id, "versions": versions, "count": len(versions)},
+        ctx.obj.output_format,
+        columns=["version", "reason", "changed_by", "created_at"],
+        title=f"History: {note_id}",
+        entity_type="note",
+        base_url=ctx.obj.auth_url,
+    )
+
+
+@notes_group.command("diff")
+@click.argument("note_id")
+@click.argument("version_a", type=int)
+@click.argument("version_b", type=int)
+@click.pass_context
+def notes_diff(ctx: click.Context, note_id: str, version_a: int, version_b: int) -> None:
+    """Unified diff between two versions of a note.
+
+    Read-only.
+    """
+    import difflib
+
+    a = _client(ctx).post("/get_context_card_version", {"card_id": note_id, "version": version_a})
+    b = _client(ctx).post("/get_context_card_version", {"card_id": note_id, "version": version_b})
+    a_text = (a.get("description") or "").splitlines(keepends=True)
+    b_text = (b.get("description") or "").splitlines(keepends=True)
+    diff = "".join(difflib.unified_diff(a_text, b_text, fromfile=f"v{version_a}", tofile=f"v{version_b}", lineterm=""))
+    if ctx.obj.output_format == "json":
+        format_output(
+            {"note_id": note_id, "from": version_a, "to": version_b, "diff": diff},
+            ctx.obj.output_format,
+            entity_type="note",
+            base_url=ctx.obj.auth_url,
+        )
+    else:
+        click.echo(diff or "(no differences)")
+
+
+@notes_group.command("restore")
+@click.argument("note_id")
+@click.argument("version", type=int)
+@click.option("--yes", "-y", is_flag=True, default=False, help="Skip confirmation.")
+@click.option("--dry-run", is_flag=True, default=False, help="Preview what would happen without making any changes.")
+@click.pass_context
+def notes_restore(ctx: click.Context, note_id: str, version: int, yes: bool, dry_run: bool) -> None:
+    """Roll a note back to a previous version.
+
+    The current state is saved as a new version first, so restore is reversible.
+
+    > [!CAUTION] This is a write command — confirm before executing.
+    """
+    if dry_run:
+        format_output(
+            {"dry_run": True, "would": "restore note", "note_id": note_id, "version": version},
+            ctx.obj.output_format,
+            entity_type="note",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    if not yes and not click.confirm(f"Restore note {note_id} to version {version}?", default=False):
+        output_error(3, "Aborted", "User declined restore.")
+        return
+
+    data = _client(ctx).post("/restore_context_card_version", {"card_id": note_id, "version": version})
+    format_output(
+        {"note_id": note_id, "restored_to": version, "card": data},
+        ctx.obj.output_format,
+        title=f"Restored: {note_id} → v{version}",
         entity_type="note",
         base_url=ctx.obj.auth_url,
     )

--- a/deepvista_cli/session_note.py
+++ b/deepvista_cli/session_note.py
@@ -1,0 +1,396 @@
+"""Session-scoped conversation notes.
+
+One DeepVista note per Claude Code (or equivalent) session. A note's body is
+YAML-ish frontmatter plus an append-only list of turn blocks; each `session-tick`
+re-parses the transcript JSONL, extracts the newest turn(s), and rewrites the
+body with an incremented ``turn_count`` / ``version``.
+
+Design is deliberately minimal for M1:
+  - No backend schema change: versions are implicit in ``turn_count`` + body
+    history lines. Server-side audit table comes in M2 (DV-449 §5).
+  - Session → note mapping is cached at ``$XDG_STATE_HOME/deepvista/sessions/``.
+    On cache miss we fall back to listing recent notes and client-side matching
+    on the ``cc-session:<id>`` tag.
+
+See DV-449 for the full design.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SESSION_TAG_PREFIX = "cc-session:"
+AGENT_TAG_PREFIX = "agent:"
+PROJECT_TAG_PREFIX = "project:"
+DEFAULT_AGENT = "claude-code"
+FRONTMATTER_FENCE = "---"
+TURN_HEADING_RE = re.compile(r"^### Turn (\d+) · ")
+SUMMARY_CHAR_LIMIT = 400
+BODY_SIZE_CAP_BYTES = 50_000
+
+
+# ---------------------------------------------------------------------------
+# State cache — maps session_id to note_id + last-processed turn index
+# ---------------------------------------------------------------------------
+
+
+def _state_dir() -> Path:
+    base = os.environ.get("XDG_STATE_HOME") or str(Path.home() / ".local" / "state")
+    return Path(base) / "deepvista" / "sessions"
+
+
+def state_path(session_id: str) -> Path:
+    return _state_dir() / f"{session_id}.json"
+
+
+def load_state(session_id: str) -> dict[str, Any]:
+    path = state_path(session_id)
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def save_state(session_id: str, state: dict[str, Any]) -> None:
+    path = state_path(session_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter (YAML-ish, but we parse only a flat key/value subset)
+# ---------------------------------------------------------------------------
+
+
+def parse_frontmatter(body: str) -> tuple[dict[str, Any], str]:
+    """Split a body into (frontmatter dict, remaining markdown).
+
+    Supports a flat ``key: value`` subset. Lists and nested maps are kept as
+    raw strings — we only round-trip what we write, and we write scalars +
+    JSON-encoded dicts.
+    """
+    if not body.startswith(FRONTMATTER_FENCE + "\n"):
+        return {}, body
+    try:
+        _, fm, rest = body.split(FRONTMATTER_FENCE + "\n", 2)
+    except ValueError:
+        return {}, body
+    data: dict[str, Any] = {}
+    for line in fm.splitlines():
+        if not line.strip() or ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        data[key.strip()] = value.strip()
+    return data, rest.lstrip("\n")
+
+
+def serialize_frontmatter(fm: dict[str, Any], rest: str) -> str:
+    ordered_keys = [
+        "agent",
+        "agent_version",
+        "cc_session_id",
+        "project_dir",
+        "git_branch",
+        "git_commit",
+        "git_dirty",
+        "started_at",
+        "updated_at",
+        "turn_count",
+        "version",
+        "transcript_path",
+        "tools_used",
+        "status",
+    ]
+    lines = [FRONTMATTER_FENCE]
+    seen: set[str] = set()
+    for key in ordered_keys:
+        if key in fm:
+            lines.append(f"{key}: {_fmt_value(fm[key])}")
+            seen.add(key)
+    for key, value in fm.items():
+        if key not in seen:
+            lines.append(f"{key}: {_fmt_value(value)}")
+    lines.append(FRONTMATTER_FENCE)
+    lines.append("")
+    return "\n".join(lines) + rest
+
+
+def _fmt_value(value: Any) -> str:
+    if isinstance(value, dict | list):
+        return json.dumps(value, separators=(",", ":"), sort_keys=isinstance(value, dict))
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+# ---------------------------------------------------------------------------
+# Transcript parsing — extract turns from Claude Code JSONL
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Turn:
+    """One user→assistant turn pulled from the transcript."""
+
+    user_text: str = ""
+    assistant_text: str = ""
+    tool_counts: Counter[str] = field(default_factory=Counter)
+    files_touched: list[str] = field(default_factory=list)
+
+
+def _extract_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "text" and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+        return " ".join(p for p in parts if p).strip()
+    return ""
+
+
+def _tool_use(content: Any) -> list[tuple[str, dict]]:
+    """Extract (tool_name, tool_input) pairs from an assistant content list."""
+    out: list[tuple[str, dict]] = []
+    if not isinstance(content, list):
+        return out
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "tool_use":
+            name = block.get("name") or "unknown"
+            tin = block.get("input") or {}
+            out.append((name, tin if isinstance(tin, dict) else {}))
+    return out
+
+
+def parse_transcript(path: str | Path) -> list[Turn]:
+    """Parse a Claude Code JSONL transcript into Turn records.
+
+    A new Turn starts on each user message. Subsequent assistant messages +
+    their tool_use blocks are attached to that turn until the next user
+    message.
+    """
+    turns: list[Turn] = []
+    current: Turn | None = None
+    try:
+        with open(path) as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                role = entry.get("role")
+                content_raw = entry.get("content")
+                if not role:
+                    msg = entry.get("message") or {}
+                    role = msg.get("role")
+                    content_raw = msg.get("content")
+                if not role:
+                    continue
+                if role == "user":
+                    text = _extract_text(content_raw)
+                    if not text:
+                        continue
+                    current = Turn(user_text=text)
+                    turns.append(current)
+                elif role == "assistant" and current is not None:
+                    current.assistant_text = (
+                        (current.assistant_text + "\n" + _extract_text(content_raw)).strip()
+                        if current.assistant_text
+                        else _extract_text(content_raw)
+                    )
+                    for name, tin in _tool_use(content_raw):
+                        current.tool_counts[name] += 1
+                        fp = _file_from_tool_input(name, tin)
+                        if fp and fp not in current.files_touched:
+                            current.files_touched.append(fp)
+    except OSError:
+        pass
+    return turns
+
+
+def _file_from_tool_input(name: str, tin: dict) -> str | None:
+    if name in {"Read", "Edit", "Write", "NotebookEdit"}:
+        fp = tin.get("file_path") or tin.get("path")
+        if isinstance(fp, str):
+            return fp
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Heuristic turn summary
+# ---------------------------------------------------------------------------
+
+
+def summarize_turn(turn: Turn, index: int, now: datetime | None = None) -> str:
+    ts = (now or datetime.now(UTC)).isoformat(timespec="seconds")
+    user = _truncate(turn.user_text, SUMMARY_CHAR_LIMIT)
+    assistant = _truncate(turn.assistant_text, SUMMARY_CHAR_LIMIT) or "_(no assistant output)_"
+    tool_pairs = (
+        turn.tool_counts.most_common()
+        if isinstance(turn.tool_counts, Counter)
+        else sorted(turn.tool_counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    )
+    tools = ", ".join(f"{k}({v})" for k, v in tool_pairs) or "_(none)_"
+    files = ", ".join(f"`{p}`" for p in turn.files_touched[:8]) or "_(none)_"
+    return (
+        f"### Turn {index} · {ts}\n"
+        f"**User:** {user}\n\n"
+        f"**Assistant:** {assistant}\n\n"
+        f"**Tools:** {tools}\n\n"
+        f"**Files touched:** {files}\n"
+    )
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = text.strip().replace("\n", " ")
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+# ---------------------------------------------------------------------------
+# Body building
+# ---------------------------------------------------------------------------
+
+
+def _body_skeleton() -> str:
+    return "## Session summary\n\n_(pending — filled at session-finalize)_\n\n## Turns\n\n"
+
+
+def build_initial_body(fm: dict[str, Any]) -> str:
+    return serialize_frontmatter(fm, _body_skeleton())
+
+
+def append_turn(existing_body: str, turn_block: str, new_fm_updates: dict[str, Any]) -> str:
+    """Merge a new turn into an existing body, returning the rewritten body.
+
+    Frontmatter is updated in-place with ``new_fm_updates``. The turn block is
+    prepended inside ``## Turns`` so newest turn is first.
+    """
+    fm, rest = parse_frontmatter(existing_body)
+    fm.update(new_fm_updates)
+
+    if "## Turns" not in rest:
+        rest = rest.rstrip() + "\n\n## Turns\n\n" + turn_block.strip() + "\n"
+    else:
+        head, _, tail = rest.partition("## Turns")
+        tail_body = tail.split("\n", 1)[1] if "\n" in tail else ""
+        rest = f"{head}## Turns\n\n{turn_block.strip()}\n\n{tail_body.lstrip()}"
+
+    body = serialize_frontmatter(fm, rest)
+    return _cap_body_size(body)
+
+
+def _cap_body_size(body: str) -> str:
+    if len(body.encode("utf-8")) <= BODY_SIZE_CAP_BYTES:
+        return body
+    fm, rest = parse_frontmatter(body)
+    head, _, tail = rest.partition("## Turns")
+    tail = tail.split("\n", 1)[1] if "\n" in tail else ""
+    turn_blocks = re.split(r"(?=^### Turn \d+ · )", tail, flags=re.MULTILINE)
+    turn_blocks = [b for b in turn_blocks if b.strip()]
+    kept: list[str] = []
+    size = len(serialize_frontmatter(fm, head + "## Turns\n\n").encode("utf-8"))
+    for block in turn_blocks:
+        if size + len(block.encode("utf-8")) > BODY_SIZE_CAP_BYTES:
+            break
+        kept.append(block)
+        size += len(block.encode("utf-8"))
+    new_rest = head + "## Turns\n\n" + "".join(kept)
+    return serialize_frontmatter(fm, new_rest)
+
+
+# ---------------------------------------------------------------------------
+# Environment probe — git branch/commit, project dir
+# ---------------------------------------------------------------------------
+
+
+def probe_git(cwd: str | Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for key, args in (
+        ("git_branch", ["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+        ("git_commit", ["git", "rev-parse", "--short", "HEAD"]),
+    ):
+        try:
+            result = subprocess.run(  # noqa: S603
+                args, cwd=str(cwd), capture_output=True, text=True, timeout=2, check=False
+            )
+            if result.returncode == 0:
+                out[key] = result.stdout.strip()
+        except (OSError, subprocess.SubprocessError):
+            continue
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["git", "status", "--porcelain"], cwd=str(cwd), capture_output=True, text=True, timeout=2, check=False
+        )
+        if result.returncode == 0:
+            out["git_dirty"] = "true" if result.stdout.strip() else "false"
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return out
+
+
+def now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def seed_frontmatter(
+    session_id: str,
+    cwd: str,
+    transcript: str,
+    agent: str = DEFAULT_AGENT,
+    agent_version: str | None = None,
+) -> dict[str, Any]:
+    fm: dict[str, Any] = {
+        "agent": agent,
+        "cc_session_id": session_id,
+        "project_dir": cwd,
+        "started_at": now_iso(),
+        "updated_at": now_iso(),
+        "turn_count": 0,
+        "version": 1,
+        "transcript_path": transcript,
+        "status": "active",
+    }
+    if agent_version:
+        fm["agent_version"] = agent_version
+    fm.update(probe_git(cwd))
+    return fm
+
+
+def session_tags(session_id: str, agent: str, cwd: str) -> list[str]:
+    project = Path(cwd).name
+    return [
+        f"{SESSION_TAG_PREFIX}{session_id}",
+        f"{AGENT_TAG_PREFIX}{agent}",
+        f"{PROJECT_TAG_PREFIX}{project}",
+        "session-note",
+    ]
+
+
+def default_title(session_id: str, cwd: str) -> str:
+    project = Path(cwd).name or "session"
+    return f"{project} · {session_id[:8]}"

--- a/hooks/deepvista-autocapture.sh
+++ b/hooks/deepvista-autocapture.sh
@@ -50,13 +50,19 @@ try:
             if role != "user" or not content_raw:
                 continue
             if isinstance(content_raw, str):
-                last_text = content_raw
+                if content_raw.strip():
+                    last_text = content_raw
             elif isinstance(content_raw, list):
                 parts = [
-                    b.get("text", "") if isinstance(b, dict) and b.get("type") == "text" else ""
+                    b.get("text", "")
                     for b in content_raw
+                    if isinstance(b, dict) and b.get("type") == "text"
                 ]
-                last_text = " ".join(p for p in parts if p).strip()
+                text = " ".join(p for p in parts if p).strip()
+                # Skip tool_result / empty entries so they don't wipe a real
+                # user message that came earlier in the transcript.
+                if text:
+                    last_text = text
 except Exception:
     pass
 
@@ -69,10 +75,11 @@ PYEOF
 [ -z "$LAST_USER" ] || [ "${#LAST_USER}" -lt 20 ] && exit 0
 
 # Only save messages that contain factual statements about the user, their work,
-# decisions, or plans — skip pure questions and commands
+# decisions, or plans — skip pure questions and commands. Word-boundaries
+# (\b) prevent substring false positives like "your" matching "our ".
 LOWER=$(printf '%s' "$LAST_USER" | tr '[:upper:]' '[:lower:]')
 printf '%s' "$LOWER" | grep -qE \
-  "(i am|i'm |we are|we're |my |our |i have|we have|i don't|i do not|i like|i love|i hate|i prefer|decided|planning|going to|working on|we built|i built|the tool|the product|the company|we('re| are) building|i want to|we want to|it is |it's )" \
+  "\b(i am|i'm|we are|we're|my|our|i have|we have|i don't|i do not|i like|i love|i hate|i prefer|decided|planning|going to|working on|we built|i built|the tool|the product|the company|we('re| are) building|i want to|we want to|it is|it's|this is|here is|here's|note:)\b" \
   || exit 0
 
 # Save to DeepVista in background — non-blocking so Claude isn't delayed

--- a/hooks/deepvista-session-end.sh
+++ b/hooks/deepvista-session-end.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# DeepVista session note — Claude Code SessionEnd hook.
+# Marks the session note complete and queues enrichment.
+# Install: referenced in ~/.claude/settings.json under hooks.SessionEnd.
+
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:$PATH"
+
+command -v deepvista >/dev/null 2>&1 || exit 0
+
+PAYLOAD=$(cat)
+
+read -r SESSION_ID TRANSCRIPT <<<"$(
+  printf '%s' "$PAYLOAD" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print(d.get('session_id', ''), d.get('transcript_path', ''))
+" 2>/dev/null || true)"
+
+[ -z "$SESSION_ID" ] && exit 0
+
+TRANSCRIPT_FLAG=()
+[ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ] && TRANSCRIPT_FLAG=(--transcript "$TRANSCRIPT")
+
+deepvista notes session-finalize \
+  --session-id "$SESSION_ID" \
+  "${TRANSCRIPT_FLAG[@]}" \
+  >/dev/null 2>&1 &
+
+exit 0

--- a/hooks/deepvista-session-start.sh
+++ b/hooks/deepvista-session-start.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
-# DeepVista session note — Claude Code SessionStart hook.
+# DeepVista session note — SessionStart hook.
 # Creates-or-gets a rolling DeepVista note keyed by session_id.
+# Agent type + version are auto-detected by the CLI from env / process tree
+# (Claude Code, Cursor, Windsurf, etc. — see deepvista_cli.client.origin).
 # Install: referenced in ~/.claude/settings.json under hooks.SessionStart.
 
 export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:$PATH"
@@ -33,7 +35,6 @@ deepvista notes session-init \
   --session-id "$SESSION_ID" \
   --transcript "$TRANSCRIPT" \
   --cwd "$CWD" \
-  --agent claude-code \
   "${AGENT_VERSION_FLAG[@]}" \
   >/dev/null 2>&1 &
 

--- a/hooks/deepvista-session-start.sh
+++ b/hooks/deepvista-session-start.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# DeepVista session note — Claude Code SessionStart hook.
+# Creates-or-gets a rolling DeepVista note keyed by session_id.
+# Install: referenced in ~/.claude/settings.json under hooks.SessionStart.
+
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:$PATH"
+
+command -v deepvista >/dev/null 2>&1 || exit 0
+
+PAYLOAD=$(cat)
+
+read -r SESSION_ID TRANSCRIPT CWD AGENT_VERSION <<<"$(
+  printf '%s' "$PAYLOAD" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print(
+    d.get('session_id', ''),
+    d.get('transcript_path', ''),
+    d.get('cwd', ''),
+    (d.get('client') or {}).get('version', ''),
+)
+" 2>/dev/null || true)"
+
+[ -z "$SESSION_ID" ] || [ -z "$CWD" ] && exit 0
+
+AGENT_VERSION_FLAG=()
+[ -n "$AGENT_VERSION" ] && AGENT_VERSION_FLAG=(--agent-version "$AGENT_VERSION")
+
+deepvista notes session-init \
+  --session-id "$SESSION_ID" \
+  --transcript "$TRANSCRIPT" \
+  --cwd "$CWD" \
+  --agent claude-code \
+  "${AGENT_VERSION_FLAG[@]}" \
+  >/dev/null 2>&1 &
+
+exit 0

--- a/hooks/deepvista-session-turn.sh
+++ b/hooks/deepvista-session-turn.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# DeepVista session note — Claude Code Stop hook.
+# Appends the newest transcript turn(s) as a versioned block on the session note.
+# Install: referenced in ~/.claude/settings.json under hooks.Stop.
+
+export PATH="$HOME/.local/bin:$HOME/.cargo/bin:/usr/local/bin:$PATH"
+
+command -v deepvista >/dev/null 2>&1 || exit 0
+
+PAYLOAD=$(cat)
+
+read -r SESSION_ID TRANSCRIPT <<<"$(
+  printf '%s' "$PAYLOAD" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+print(d.get('session_id', ''), d.get('transcript_path', ''))
+" 2>/dev/null || true)"
+
+[ -z "$SESSION_ID" ] || [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ] && exit 0
+
+deepvista notes session-tick \
+  --session-id "$SESSION_ID" \
+  --transcript "$TRANSCRIPT" \
+  >/dev/null 2>&1 &
+
+exit 0

--- a/skills/deepvista/reference/notes.md
+++ b/skills/deepvista/reference/notes.md
@@ -82,6 +82,110 @@ bulk-importing notes, after a long offline period, or when entities appear
 missing from the graph. Pair with `deepvista lint --check missing-refs` to
 find concepts that still need their own card.
 
+### `session-init` — write
+
+> [!CAUTION] Creates a rolling note on first call per `session-id`. Meant
+> for agent SessionStart hooks; confirm before running by hand.
+
+```bash
+deepvista notes session-init \
+  --session-id <id> \
+  --transcript <path> \
+  --cwd <dir> \
+  [--agent claude-code] [--agent-version X.Y.Z] [--dry-run]
+```
+
+Idempotent. Looks up an existing session note by `cc-session:<id>` tag; if
+none, creates one with seeded frontmatter (agent, project_dir, git branch/commit,
+started_at, status=active). Caches the resolved `note_id` at
+`$XDG_STATE_HOME/deepvista/sessions/<session-id>.json` so every subsequent
+`session-tick` is a single HTTP call.
+
+### `session-tick` — write
+
+> [!CAUTION] Appends a new turn block and bumps the note's version.
+
+```bash
+deepvista notes session-tick \
+  --session-id <id> \
+  --transcript <path> \
+  [--dry-run]
+```
+
+Parses the transcript JSONL, extracts turns newer than `last_turn_index`
+from the cache, renders a heuristic summary per turn (first ~400 chars of
+user/assistant + tool counts + files touched), prepends it inside
+`## Turns`, and updates `turn_count` / `version` / `updated_at` in the
+frontmatter. Body capped at ~50 KB — oldest turns are dropped first.
+
+### `session-finalize` — write
+
+> [!CAUTION] Flips status to `complete` and queues enrichment.
+
+```bash
+deepvista notes session-finalize \
+  --session-id <id> \
+  [--transcript <path>] \
+  [--no-enrich] [--dry-run]
+```
+
+Marks the frontmatter `status: complete` and calls `/index_notes` on the
+session note. Pass `--transcript` to flush any remaining turns first.
+
+### `history` — read-only
+
+```bash
+deepvista notes history <note_id> [--limit N]
+```
+
+List prior versions of a note (newest first). Returns `version`, `reason`,
+`changed_by`, `created_at`. Backed by `/get_context_card_history`.
+
+### `diff` — read-only
+
+```bash
+deepvista notes diff <note_id> <from_version> <to_version>
+```
+
+Unified diff between two versions of a note. In `--format table` mode the
+diff is printed directly; in `--format json` it is returned under `.diff`.
+
+### `restore` — write (reversible)
+
+> [!CAUTION] Rolls the note back. Current state is captured as a new
+> version first so restore itself is reversible.
+
+```bash
+deepvista notes restore <note_id> <version> [--yes] [--dry-run]
+```
+
+Backed by `/restore_context_card_version`. The server's UPDATE trigger
+captures the pre-restore state, so you can always `restore` again to the
+prior `version`.
+
+### Hook installation (Claude Code)
+
+```json
+// ~/.claude/settings.json
+{
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [{ "type": "command", "command": "$DEEPVISTA_HOME/hooks/deepvista-session-start.sh" }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": "$DEEPVISTA_HOME/hooks/deepvista-session-turn.sh" }] }
+    ],
+    "SessionEnd": [
+      { "hooks": [{ "type": "command", "command": "$DEEPVISTA_HOME/hooks/deepvista-session-end.sh" }] }
+    ]
+  }
+}
+```
+
+Every script is non-blocking (`&` background) so Claude Code latency is
+unaffected. Scripts silently no-op if `deepvista` is not on `PATH` or
+auth is missing.
+
 ### `+quick` — write
 
 > [!CAUTION] Writes a new note. Confirm first (or skip confirmation if the agent is

--- a/tests/test_session_note.py
+++ b/tests/test_session_note.py
@@ -1,0 +1,155 @@
+"""Unit tests for deepvista_cli.session_note (DV-449).
+
+Run with: ``uv run python -m unittest tests.test_session_note``.
+
+Tests cover:
+- Frontmatter round-trip (parse → serialize).
+- Transcript JSONL parser (flat {role, content} and nested {message: {…}} formats).
+- Turn summary rendering.
+- Body append ordering (newest turn first).
+- State cache read/write isolation via ``XDG_STATE_HOME`` override.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from collections import Counter
+from pathlib import Path
+
+from deepvista_cli import session_note as sn
+
+
+class FrontmatterTests(unittest.TestCase):
+    def test_round_trip_scalar_and_dict(self) -> None:
+        fm = {
+            "agent": "claude-code",
+            "cc_session_id": "abc-123",
+            "turn_count": 3,
+            "tools_used": {"Read": 2, "Edit": 1},
+            "git_dirty": True,
+        }
+        rest = "## Session summary\n\nbody\n"
+        body = sn.serialize_frontmatter(fm, rest)
+        parsed, tail = sn.parse_frontmatter(body)
+        self.assertEqual(parsed["agent"], "claude-code")
+        self.assertEqual(parsed["cc_session_id"], "abc-123")
+        self.assertEqual(parsed["turn_count"], "3")  # flat string parse — caller re-casts
+        self.assertEqual(parsed["git_dirty"], "true")
+        self.assertEqual(json.loads(parsed["tools_used"]), {"Edit": 1, "Read": 2})
+        self.assertEqual(tail, rest)
+
+    def test_parse_body_with_no_frontmatter(self) -> None:
+        fm, rest = sn.parse_frontmatter("# hello\nbody\n")
+        self.assertEqual(fm, {})
+        self.assertEqual(rest, "# hello\nbody\n")
+
+
+class TranscriptParseTests(unittest.TestCase):
+    def _write_jsonl(self, entries: list[dict]) -> str:
+        fd, path = tempfile.mkstemp(suffix=".jsonl")
+        with os.fdopen(fd, "w") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+        return path
+
+    def test_flat_format(self) -> None:
+        path = self._write_jsonl(
+            [
+                {"role": "user", "content": "hi there"},
+                {"role": "assistant", "content": "hello"},
+                {"role": "user", "content": "second turn"},
+                {"role": "assistant", "content": "response 2"},
+            ]
+        )
+        turns = sn.parse_transcript(path)
+        self.assertEqual(len(turns), 2)
+        self.assertEqual(turns[0].user_text, "hi there")
+        self.assertEqual(turns[0].assistant_text, "hello")
+        self.assertEqual(turns[1].user_text, "second turn")
+        Path(path).unlink()
+
+    def test_nested_format_with_tool_use(self) -> None:
+        path = self._write_jsonl(
+            [
+                {"message": {"role": "user", "content": [{"type": "text", "text": "edit foo.py"}]}},
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {"type": "text", "text": "on it"},
+                            {"type": "tool_use", "name": "Edit", "input": {"file_path": "/repo/foo.py"}},
+                            {"type": "tool_use", "name": "Edit", "input": {"file_path": "/repo/foo.py"}},
+                            {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}},
+                        ],
+                    }
+                },
+            ]
+        )
+        turns = sn.parse_transcript(path)
+        self.assertEqual(len(turns), 1)
+        self.assertEqual(turns[0].user_text, "edit foo.py")
+        self.assertEqual(turns[0].assistant_text, "on it")
+        self.assertEqual(turns[0].tool_counts["Edit"], 2)
+        self.assertEqual(turns[0].tool_counts["Bash"], 1)
+        self.assertEqual(turns[0].files_touched, ["/repo/foo.py"])
+        Path(path).unlink()
+
+    def test_missing_file_returns_empty(self) -> None:
+        self.assertEqual(sn.parse_transcript("/nonexistent/path.jsonl"), [])
+
+
+class SummarizeTurnTests(unittest.TestCase):
+    def test_renders_all_sections(self) -> None:
+        turn = sn.Turn(user_text="hello world", assistant_text="hi", tool_counts=Counter({"Read": 2}))
+        turn.files_touched = ["/repo/a.py"]
+        out = sn.summarize_turn(turn, index=1)
+        self.assertIn("### Turn 1 ·", out)
+        self.assertIn("**User:** hello world", out)
+        self.assertIn("**Assistant:** hi", out)
+        self.assertIn("Read(2)", out)
+        self.assertIn("`/repo/a.py`", out)
+
+    def test_truncates_long_text(self) -> None:
+        turn = sn.Turn(user_text="x" * 10_000, assistant_text="y" * 10_000)
+        out = sn.summarize_turn(turn, index=2)
+        self.assertIn("…", out)
+
+
+class BodyAppendTests(unittest.TestCase):
+    def test_appends_turn_newest_first(self) -> None:
+        body = sn.build_initial_body({"agent": "claude-code", "turn_count": 0})
+        body = sn.append_turn(body, "### Turn 1 · 2026-04-23T00:00:00+00:00\n**User:** a\n", {"turn_count": 1})
+        body = sn.append_turn(body, "### Turn 2 · 2026-04-23T00:01:00+00:00\n**User:** b\n", {"turn_count": 2})
+        t2 = body.index("### Turn 2")
+        t1 = body.index("### Turn 1")
+        self.assertLess(t2, t1, "newest turn should appear first under ## Turns")
+        fm, _ = sn.parse_frontmatter(body)
+        self.assertEqual(fm["turn_count"], "2")
+
+
+class StateCacheTests(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            os.environ["XDG_STATE_HOME"] = d
+            try:
+                sn.save_state("sess-1", {"note_id": "n1", "last_turn_index": 3})
+                self.assertEqual(sn.load_state("sess-1"), {"note_id": "n1", "last_turn_index": 3})
+                self.assertEqual(sn.load_state("sess-missing"), {})
+            finally:
+                del os.environ["XDG_STATE_HOME"]
+
+
+class SeedFrontmatterTests(unittest.TestCase):
+    def test_has_required_keys(self) -> None:
+        fm = sn.seed_frontmatter("sess-x", "/tmp/proj", "/tmp/t.jsonl")
+        for key in ("agent", "cc_session_id", "project_dir", "started_at", "turn_count", "version", "status"):
+            self.assertIn(key, fm)
+        self.assertEqual(fm["cc_session_id"], "sess-x")
+        self.assertEqual(fm["status"], "active")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds per-session rolling notes driven by Claude Code hooks, plus version
history / diff / restore subcommands backed by the new server audit table
(see companion PR in DeepVista-AI/deepvista for the migration, endpoints,
and frontend agent filter).

## Highlights

- **`deepvista notes session-init / session-tick / session-finalize`** —
  idempotent, transcript-driven, heuristic per-turn summary, non-blocking
  shell hooks in `hooks/deepvista-session-{start,turn,end}.sh`.
- **`deepvista notes history / diff / restore`** — read-only history list,
  unified diff between two versions, reversible rollback.
- **Session note lookup** now uses server-side `tag_contains` — O(1)
  instead of paginated client-side scan.
- Frontmatter captures `agent`, `agent_version`, `cc_session_id`,
  `project_dir`, `git_branch`, `git_commit`, `turn_count`, `version`,
  `transcript_path`.

## Test plan

- [x] `uv run python -m unittest tests.test_session_note` — 10/10 pass
- [x] `uv run pre-commit run --files …` — ruff, ruff-format, pyright,
      gitleaks all green
- [x] `uv run deepvista --dry-run notes session-init …` — wiring
      verified against backend route
- [ ] End-to-end: install hook in `~/.claude/settings.json` once the
      server PR lands (versioning requires migration 39) and confirm a
      single session produces one rolling note

## Links

- Linear: [DV-449](https://linear.app/deepvista/issue/DV-449/improve-the-note-taking-behavior)
- Companion PR: DeepVista-AI/deepvista `feat/DV-449-note-versions`