### PR TITLE
feat(skill): add +catalog command and broaden skill trigger (DV-276)

### DIFF
--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -68,6 +68,47 @@ def skill_list(ctx: click.Context, limit: int, page_number: int) -> None:
     )
 
 
+@skill_group.command("+catalog")
+@click.option("--limit", default=50, help="Max skills to return (default 50).")
+@click.pass_context
+def skill_catalog(ctx: click.Context, limit: int) -> None:
+    """List all Skills as compact catalog entries (id · title · snippet).
+
+    Designed to be called by agents at startup so that all installed Skills
+    are available in context without the user having to mention them explicitly.
+    Each entry includes only the fields needed for an agent to decide whether
+    a Skill is relevant: ``id``, ``title``, and a short ``snippet``.
+
+    Read-only — never modifies your Skills.
+    """
+    data = _client(ctx).post(
+        "/get_context_cards",
+        {
+            "card_type": "vistabook",
+            "limit": limit,
+            "page_number": 1,
+        },
+    )
+    cards = data.get("cards", [])
+    catalog = [
+        {
+            "id": c.get("id", ""),
+            "title": c.get("title", ""),
+            "snippet": c.get("snippet", ""),
+        }
+        for c in cards
+    ]
+    result = {"catalog": catalog, "count": len(catalog), "has_more": data.get("has_more", False)}
+    format_output(
+        result,
+        ctx.obj.output_format,
+        columns=["id", "title", "snippet"],
+        title="Skill Catalog",
+        entity_type="skill",
+        base_url=ctx.obj.auth_url,
+    )
+
+
 @skill_group.command("get")
 @click.argument("skill_id")
 @click.pass_context

--- a/skills/deepvista/SKILL.md
+++ b/skills/deepvista/SKILL.md
@@ -3,16 +3,20 @@ license: Apache-2.0
 name: deepvista
 description: |
   DeepVista CLI — knowledge base, notes, chat, skills, and memory from the terminal.
-  One skill for the full `deepvista` CLI. Load when the user wants to: take a note, jot
-  this down, save a fact, or list and edit notes; create, search, pin, archive, edit,
-  or grep knowledge-base cards of any type (person, topic, file, note, todo…); view or
-  semantic-search implicit memory ("vistabase" / "memory"); chat with the AI agent or
-  manage sessions; list, run, export, install, or discover Skills; research then run a
-  Skill with synthesized context; analyze / summarize notes; import a folder as file
-  cards; run a knowledge-worker daily loop; auto-capture facts (OpenClaw); periodically
-  lint the vistabase for duplicates / contradictions / stale claims / orphans / missing
-  refs / gaps; or re-index notes to trigger entity extraction. Pick the matching
-  reference file in `reference/` for the subcommand.
+  One skill for the full `deepvista` CLI. Load whenever the user is working, asking
+  for help, planning a task, or referring to anything they may have previously saved,
+  noted, or recorded — DeepVista is the user's long-term memory and playbook library.
+  Use it to: take a note, jot this down, save a fact, or list and edit notes; create,
+  search, pin, archive, edit, or grep knowledge-base cards of any type (person, topic,
+  file, note, todo, organization…); view or semantic-search implicit memory
+  ("vistabase" / "memory"); chat with the AI agent or manage sessions; list, run,
+  export, install, or discover Skills; load the full Skill catalog at startup
+  (`deepvista skill +catalog`) so installed Skills are available without being named
+  explicitly; research then run a Skill with synthesized context; analyze / summarize
+  notes; import a folder as file cards; run a knowledge-worker daily loop; auto-capture
+  facts (OpenClaw); periodically lint the vistabase for duplicates / contradictions /
+  stale claims / orphans / missing refs / gaps; or re-index notes to trigger entity
+  extraction. Pick the matching reference file in `reference/` for the subcommand.
 metadata:
   openclaw:
     category: service
@@ -48,7 +52,7 @@ other reference file assumes you know it.
 | `deepvista card` | creating / searching / pinning / archiving / grepping knowledge base cards across any type (person, topic, file, note, todo, etc.) | [vistabase-card.md](reference/vistabase-card.md) |
 | `deepvista vistabase` (alias: `memory`) | viewing or semantic-searching implicit memory accumulated from chat | [vistabase.md](reference/vistabase.md) · [memory.md](reference/memory.md) |
 | `deepvista chat` | sending a message to the AI agent, listing / deleting chat sessions, continuing a conversation | [chat.md](reference/chat.md) |
-| `deepvista skill` | listing, running, exporting, installing, or discovering structured Skill workflows | [skill.md](reference/skill.md) |
+| `deepvista skill` | listing, running, exporting, installing, discovering Skills; loading the full Skill catalog at startup with `+catalog` | [skill.md](reference/skill.md) |
 | — analyze notes | searching → reading → synthesizing notes to surface themes / patterns | [skill-analyze-notes.md](reference/skill-analyze-notes.md) |
 | — research → run | finding context in the knowledge base, then running a Skill with synthesized input | [skill-research-to-skill.md](reference/skill-research-to-skill.md) |
 | — export | exporting a DeepVista Skill as a portable `SKILL.md` file for another agent | [skill-export-knowledge.md](reference/skill-export-knowledge.md) |
@@ -57,21 +61,28 @@ other reference file assumes you know it.
 | persona: knowledge worker | daily workflow — check pinned cards, capture insights, run a Skill, ask the agent to synthesize | [persona-knowledge-worker.md](reference/persona-knowledge-worker.md) |
 | auto-capture for OpenClaw | automatically saving notable facts from conversations without confirmation | [openclaw.md](reference/openclaw.md) |
 
-## On load — update check
+## On load — update check + skill catalog
 
-Silently run this once when the skill is loaded:
+Silently run **both** of these once when the skill is loaded:
 
 ```bash
 deepvista upgrade check 2>/dev/null || true
+deepvista skill +catalog 2>/dev/null || true
 ```
 
-The command is cached (~1 hour TTL) so repeated invocations are cheap.
+Both commands are cheap (upgrade is cached ~1 hour; catalog is a single list call).
+
+**`upgrade check` output:**
 
 | stdout | Exit | What to do |
 |---|---|---|
 | *(empty)* | 0 | Up to date, snoozed, disabled, or network unreachable — say nothing. |
 | `JUST_UPGRADED <old> <new>` | 0 | Briefly confirm: "deepvista-cli upgraded to `<new>`." |
 | `UPGRADE_AVAILABLE <old> <new>` | 1 | Tell the user and offer `deepvista upgrade` — it fetches the changelog between `<old>` and `<new>` and prompts before installing. Snooze with `deepvista upgrade snooze`; disable with `deepvista upgrade disable`. |
+
+**`skill +catalog` output:** a JSON list of every installed Skill (`id`, `title`, `snippet`). Keep
+this catalog in context for the rest of the conversation. When the user's request
+matches a Skill title or topic, prefer running that Skill over writing ad-hoc code.
 
 If `deepvista` is not on `PATH`, skip silently — do not attempt to install it automatically.
 
@@ -104,8 +115,8 @@ Full instructions: [reference/shared.md](reference/shared.md).
 3. **Use `--content-file` for non-trivial content.** Never paste large content,
    files, or URLs inline — pass `--content-file <absolute-path>` (or `--content-file -`
    to read from stdin) so the exact bytes are stored.
-4. **Read-only commands are safe.** `list`, `get`, `+search`, `+grep`, `+similar`,
-   `show`, `discover`, `export`, `status` — run without confirmation.
+4. **Read-only commands are safe.** `list`, `get`, `+catalog`, `+search`, `+grep`,
+   `+similar`, `show`, `discover`, `export`, `status` — run without confirmation.
 
 ## See also
 

--- a/skills/deepvista/reference/skill.md
+++ b/skills/deepvista/reference/skill.md
@@ -6,6 +6,26 @@ Skill run so you can continue it like a regular conversation.
 
 ## Commands
 
+### `+catalog` — read-only (agent startup)
+
+```bash
+deepvista skill +catalog [--limit N]
+```
+
+Returns a compact list of every installed Skill — just `id`, `title`, and `snippet`.
+**Call this at the start of any conversation** to load the user's full Skill library
+into context so you can suggest or run the right Skill without the user having to
+name it explicitly.
+
+```json
+{
+  "catalog": [
+    {"id": "uuid-…", "title": "Weekly Review", "snippet": "Summarise the week…"},
+    {"id": "uuid-…", "title": "Hiring pipeline", "snippet": "Screen → interview…"}
+  ]
+}
+```
+
 ### `list` — read-only
 
 ```bash
@@ -81,6 +101,7 @@ deepvista skill install <skill_id>
 ## Examples
 
 ```bash
+deepvista skill +catalog                           # load all Skills at startup
 deepvista skill list
 deepvista skill run vb_abc123 --input "Focus on Q4 objectives"
 deepvista skill status chat_xyz789


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

DeepVista agents rarely use the knowledge base unless the user explicitly says "use DeepVista context." This is especially painful because most user playbooks and workflows are stored as `vistabook` context cards — the agent should reach for them proactively.

Two root causes identified in DV-276:
1. **No lightweight way to list Skills at startup** — so agents have no idea what Skills are installed.
2. **SKILL.md description too narrow** — only triggers when the user explicitly mentions DeepVista.

## Changes

### `deepvista_cli/commands/skill.py`
- Add `deepvista skill +catalog` command: returns a compact `{id, title, snippet}` list of every installed `vistabook` card. Default limit 50. Follows the existing `+` helper naming convention. Read-only — no confirmation needed.

### `skills/deepvista/SKILL.md`
- **Broaden description**: now reads _"Load whenever the user is working, asking for help, planning a task, or referring to anything they may have previously saved, noted, or recorded"_ — this increases the likelihood the skill is triggered without an explicit "use DeepVista" prompt.
- **On-load section**: agents now run **both** `deepvista upgrade check` and `deepvista skill +catalog` on load. The catalog result is kept in context for the whole conversation so the agent can suggest or run matching Skills automatically.
- Update subcommand index and read-only safe-commands list to include `+catalog`.

### `skills/deepvista/reference/skill.md`
- Document `+catalog` with example output and agent guidance ("prefer running a matching Skill over writing ad-hoc code").
- Add `+catalog` to examples block.

## Testing

- `uv run ruff check --fix` + `uv run ruff format` pass cleanly on `skill.py`.
- Command is wired to the existing `skill_group` Click group — no changes to `main.py` needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DV-276](https://linear.app/deepvista/issue/DV-276/increase-the-trigger-frequency)

<div><a href="https://cursor.com/agents/bc-4e879c46-ee3b-4fd1-b11f-aff704e627fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4e879c46-ee3b-4fd1-b11f-aff704e627fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

