### PR TITLE
release: v0.1.6

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepvista",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Remote-managed skill catalog from DeepVista. Auto-syncs thin stubs into the plugin's skills dir on SessionStart; full bodies are lazy-loaded at invocation time.",
   "author": {
     "name": "DeepVista AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.5"
+version = "0.1.6"
 description = "CLI for DeepVista — chat, notes, skills, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Release v0.1.6 — ships the vistabook → skill rename ([#100](https://github.com/DeepVista-AI/deepvista-cli/pull/100), [DV-507](https://linear.app/deepvista/issue/DV-507/cli-rename-vistabook-skill-sync-with-backend-dv-382)) so the CLI mirrors backend [DeepVista-AI/deepvista#1778](https://github.com/DeepVista-AI/deepvista/pull/1778) (DV-382).

## Changes since v0.1.5

- `card_type` / `cardType` queries renamed `vistabook` → `skill`, `vistabook_run` → `skill_run`
- `skill export` subcommand removed (backend endpoint deleted)
- Orphaned `commands/vistabook.py` deleted
- `--type` choices for `card list` / `vistabase list` updated
- Reference docs updated, `skill-export-knowledge.md` removed

## Test plan

- [x] `pytest`: 26 passed
- [x] `ruff check` / `ruff format`: clean
- [x] Production smoke test of every `skill` and `card` subcommand against `crew@deepvista.ai`
- [ ] CI green
- [ ] PyPI publishes on `v0.1.6` tag (after merge)