### PR TITLE
fix(skill): use human-readable title when saving created skills

### DIFF
--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -502,8 +502,14 @@ def _build_create_from_note_prompt(notes: list[tuple[str, str]], kinds: tuple[st
     )
     lines.append("")
     lines.append(
-        "For each `upsert_context_card` call: set `title` to the skill name "
-        "(matching the frontmatter `name`); put the full SKILL.md body — "
+        "For each `upsert_context_card` call: set `title` to a human-readable "
+        "display name — convert the skill slug to a natural phrase by replacing "
+        "hyphens with spaces and capitalising the first letter of each word "
+        '(e.g. `workflow-b2b-positioning` → "B2B Positioning Workflow", '
+        '`persona-april-dunford` → "April Dunford Persona"). '
+        "The frontmatter `name` field keeps the slug; only the `title` argument "
+        "to `upsert_context_card` uses the human-readable form. "
+        "Put the full SKILL.md body — "
         "**starting with the YAML frontmatter block** — in `description`; "
         "add relevant `tags` including the kind (`persona` or `workflow`); "
         f"and link every source note via "


### PR DESCRIPTION
## Summary

- Skills created via `create-from-note` were saved with slug-style titles like `workflow-b2b-positioning` because the prompt instructed the agent to set `title` to match the frontmatter `name`
- Fix separates the two: the `name` frontmatter field keeps the slug (for routing/lookup), while the `title` passed to `upsert_context_card` is a human-readable phrase with hyphens replaced by spaces and each word capitalised
- Example: `workflow-b2b-positioning` → **"B2B Positioning Workflow"**, `persona-april-dunford` → **"April Dunford Persona"**

## Test plan

- [ ] Run `deepvista skill create-from-note <note-id>` and verify the saved skill card title is a natural phrase (no dashes, first letter of each word capitalised)
- [ ] Verify the frontmatter `name` field inside the skill body still contains the slug
- [ ] Confirm persona and workflow kinds both get human-readable titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)