### PR TITLE
release: v0.1.9

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepvista",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Remote-managed skill catalog from DeepVista. Auto-syncs thin stubs into the plugin's skills dir on SessionStart; full bodies are lazy-loaded at invocation time.",
   "author": {
     "name": "DeepVista AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.8"
+version = "0.1.9"
 description = "CLI for DeepVista — chat, notes, skills, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.8"
+version = "0.1.9"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Bump version to `0.1.9` in `pyproject.toml`, `uv.lock`, and `plugins/claude-code/.claude-plugin/plugin.json`

## Changes since v0.1.8

- fix(skill): enforce 1:1 alignment between mermaid nodes and Phases accordions in `create-from-note` workflow prompt
- fix(skill): use human-readable title when saving created skills (no dashes, first letter capitalised)

## After merge

```bash
git checkout main && git pull
git tag v0.1.9
git push origin v0.1.9
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)