### PR TITLE
feat(DV-694): host-mode workflow execution for skill run

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,9 +280,16 @@ Card types: `person` · `organization` · `message` · `todo` · `topic` · `key
 ```bash
 deepvista skill list [--limit N]
 deepvista skill get <skill_id>
-deepvista skill run <skill_id> [--input "context"]     # streams NDJSON
+deepvista skill run <skill_id> [--mode host|deepvista|auto] [--input "context"]
+deepvista skill phase open <skill_id> "Phase N: <title>"
+deepvista skill phase done <skill_id> "Phase N: <title>" [--artifact-card-id ID]... [--next-phase "Phase N+1: …"]
+deepvista skill phase pause <skill_id> --reason "<short sentence>"
+deepvista skill phase run-on-deepvista <skill_id> "Phase N: <title>"
+deepvista skill complete <skill_id> --review "<retrospective bullets>"
 deepvista skill status <run_chat_id>
 ```
+
+`skill run` defaults to **host mode** — it prints a JSON header + the workflow's SKILL.md body + a host runtime contract on stdout, and the host agent (Claude Code / OpenClaw / Cursor) drives the run via the `phase` shims and `complete`. Use `--mode deepvista` to keep the legacy behaviour (server agent drives the whole run, NDJSON streamed back). `--mode auto` decides per phase by inspecting each phase's `tool_plan`.
 
 ### vistabase — Implicit context
 

--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import re
 import sys
+from importlib import resources
 from pathlib import Path
 from typing import Any
 
@@ -19,6 +20,18 @@ import click
 from deepvista_cli import skill_catalog
 from deepvista_cli.client.http import DeepVistaClient
 from deepvista_cli.output.formatter import format_output, output_error
+from deepvista_cli.workflow_doc import (
+    PhaseNotFoundError,
+    WorkflowDocument,
+    is_phase_server_routable,
+)
+
+# Run modes for `deepvista skill run`. ``host`` is the default — the
+# packet is printed to stdout for the host agent to drive; ``deepvista``
+# forwards to /imagine (legacy behaviour); ``auto`` decides per-phase by
+# inspecting each phase's ``tool_plan``.
+_RUN_MODES = ("host", "deepvista", "auto")
+_DEFAULT_RUN_MODE = "host"
 
 SKILL_COLUMNS = ["id", "title", "display_status", "updated_at"]
 
@@ -100,27 +113,130 @@ def skill_get(ctx: click.Context, skill_id: str) -> None:
 @skill_group.command("run")
 @click.argument("skill_id")
 @click.option("--input", "user_input", default=None, help="Context or instructions for the run.")
+@click.option(
+    "--mode",
+    type=click.Choice(_RUN_MODES, case_sensitive=False),
+    default=_DEFAULT_RUN_MODE,
+    show_default=True,
+    help=(
+        "Where the workflow executes. ``host`` (default) prints a run packet "
+        "for the host agent (Claude Code / OpenClaw) to drive itself via the "
+        "`deepvista skill phase ...` CLI shims. ``deepvista`` forwards to "
+        "/imagine so the DeepVista server agent runs the whole workflow "
+        "(legacy behaviour). ``auto`` decides per-phase from each phase's "
+        "tool_plan."
+    ),
+)
 @click.option("--dry-run", is_flag=True, default=False, help="Preview what would happen without making any changes.")
 @click.pass_context
-def skill_run(ctx: click.Context, skill_id: str, user_input: str | None, dry_run: bool) -> None:
-    """Run a Skill — executes the workflow via the chat agent.
+def skill_run(ctx: click.Context, skill_id: str, user_input: str | None, mode: str, dry_run: bool) -> None:
+    """Run a Skill — host mode by default; ``--mode deepvista`` delegates the whole run server-side.
 
-    > [!CAUTION] This is a write command — it creates a new Skill run and sends
-    > messages to the chat agent. Confirm with the user before executing.
+    > [!CAUTION] This is a write command — host mode acquires the parent
+    > Skill card's run lock (``status="in_progress"``) and prints the run
+    > packet for the agent driving execution. Deepvista mode creates a new
+    > chat session and streams the server agent's response. Confirm with
+    > the user before executing.
 
-    Output is NDJSON (one JSON object per line) as the agent streams its response.
+    Host-mode output is a JSON header + the workflow's SKILL.md body + the
+    host runtime contract — all on stdout, no SSE. The host agent reads it
+    and drives the workflow using ``deepvista skill phase ...`` shims.
+
+    Deepvista-mode output is NDJSON (one JSON object per line) as the
+    server agent streams its response.
     """
     if not _UUID_RE.match(skill_id):
         output_error(3, "Invalid skill ID", f"Expected UUID format, got: {skill_id!r}")
 
-    instruction = user_input or "Run this skill"
-    body: dict = {
-        "user_instruction": f'<contextCard id="{skill_id}" cardType="skill"></contextCard> {instruction}',
+    mode = mode.lower()
+
+    if mode == "deepvista":
+        _skill_run_deepvista(ctx, skill_id, user_input, dry_run=dry_run)
+        return
+
+    # host / auto: fetch the card, optionally acquire the lock, and emit a
+    # run packet the host agent drives.
+    card = _client(ctx).post("/get_context_card", {"card_id": skill_id, "card_type": "skill"})
+    if not card or not card.get("description"):
+        output_error(3, "Skill not found or has empty description", f"skill_id={skill_id}")
+
+    doc = WorkflowDocument(card["description"])
+    phases = doc.phases()
+    if not phases:
+        output_error(3, "Skill has no <accordion> phases", f"skill_id={skill_id}")
+
+    active = doc.active_phase() or doc.first_pending_phase() or phases[0]
+
+    phase_routes: list[dict[str, str]] = []
+    if mode == "auto":
+        for p in phases:
+            phase_routes.append(
+                {
+                    "phase": p.title,
+                    "route": "deepvista" if is_phase_server_routable(p) else "host",
+                }
+            )
+    else:
+        for p in phases:
+            phase_routes.append({"phase": p.title, "route": "host"})
+
+    run_header = {
+        "type": "skill_run_packet",
+        "mode": mode,
+        "skill_id": skill_id,
+        "skill_title": card.get("title", ""),
+        "active_phase": active.title,
+        "phases": [{"index": p.index, "title": p.title, "state": p.state} for p in phases],
+        "phase_routes": phase_routes,
+        "user_input": user_input or "",
+        "skill_status": card.get("status", ""),
     }
 
     if dry_run:
         format_output(
-            {"dry_run": True, "would": "start Skill run", "skill_id": skill_id, "instruction": instruction},
+            {"dry_run": True, "would": f"emit host-mode run packet ({mode})", **run_header},
+            ctx.obj.output_format,
+            entity_type="skill",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    # Acquire / refresh the run lock. Idempotent: re-runs while already
+    # ``in_progress`` are accepted as resume (the host agent is the lock
+    # owner in host mode, not a chat session).
+    _client(ctx).post(
+        "/update_context_card",
+        {"card_id": skill_id, "status": "in_progress", "reason": "skill-run-host-mode"},
+    )
+
+    click.echo(json.dumps(run_header, default=str))
+    click.echo()  # blank line so agents can split header from body cheaply
+    click.echo(card["description"])
+    click.echo()
+    click.echo("---")
+    click.echo()
+    click.echo(_load_host_runtime_contract())
+
+
+def _skill_run_deepvista(
+    ctx: click.Context, skill_id: str, user_input: str | None, *, dry_run: bool, force: bool = False
+) -> None:
+    """Forward the run to the DeepVista server agent via /imagine."""
+    instruction = user_input or "Run this skill"
+    body: dict[str, Any] = {
+        "user_instruction": f'<contextCard id="{skill_id}" cardType="skill"></contextCard> {instruction}',
+    }
+    if force:
+        body["force"] = True
+
+    if dry_run:
+        format_output(
+            {
+                "dry_run": True,
+                "would": "start DeepVista server-agent Skill run",
+                "skill_id": skill_id,
+                "instruction": instruction,
+            },
             ctx.obj.output_format,
             entity_type="skill",
             base_url=ctx.obj.auth_url,
@@ -129,6 +245,303 @@ def skill_run(ctx: click.Context, skill_id: str, user_input: str | None, dry_run
 
     for event in _client(ctx).stream_sse("/imagine", body):
         click.echo(json.dumps(event, default=str))
+
+
+def _load_host_runtime_contract() -> str:
+    """Return the embedded host-mode runtime contract markdown."""
+    return resources.files("deepvista_cli.resources").joinpath("workflow_host_runtime.md").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Phase mutators — used by host agents driving the workflow themselves
+# ---------------------------------------------------------------------------
+
+
+@skill_group.group("phase")
+def skill_phase_group() -> None:
+    """Phase-level operations on an in-progress workflow Skill run.
+
+    Used by host agents (Claude Code / OpenClaw / Cursor) that drove
+    ``deepvista skill run --mode host`` and are now advancing the
+    workflow themselves. Each command parses the skill card's
+    description, mutates the accordion + mermaid markers for the
+    target phase, and persists the result via /update_context_card.
+    """
+
+
+def _load_skill_doc(ctx: click.Context, skill_id: str) -> tuple[dict, WorkflowDocument]:
+    """Fetch the parent Skill card and return ``(card, WorkflowDocument)``."""
+    if not _UUID_RE.match(skill_id):
+        output_error(3, "Invalid skill ID", f"Expected UUID format, got: {skill_id!r}")
+    card = _client(ctx).post("/get_context_card", {"card_id": skill_id, "card_type": "skill"})
+    if not card or not card.get("description"):
+        output_error(3, "Skill not found or empty description", f"skill_id={skill_id}")
+    return card, WorkflowDocument(card["description"])
+
+
+def _persist_doc(
+    ctx: click.Context,
+    skill_id: str,
+    doc: WorkflowDocument,
+    *,
+    reason: str,
+    status: str | None = None,
+) -> dict:
+    """Save mutated body back via /update_context_card.
+
+    ``status`` is only set when the caller explicitly wants to acquire or
+    release the lock — phase opens / dones leave it untouched.
+    """
+    body: dict[str, Any] = {
+        "card_id": skill_id,
+        "description": doc.body,
+        "reason": reason,
+    }
+    if status is not None:
+        body["status"] = status
+    return _client(ctx).post("/update_context_card", body)
+
+
+@skill_phase_group.command("open")
+@click.argument("skill_id")
+@click.argument("phase_label")
+@click.option("--dry-run", is_flag=True, default=False, help="Preview without writing.")
+@click.pass_context
+def skill_phase_open(ctx: click.Context, skill_id: str, phase_label: str, dry_run: bool) -> None:
+    """Mark a phase as active (accordion open, mermaid ``:::dvActive``).
+
+    Idempotent — re-opening the already-active phase is a no-op write.
+    """
+    card, doc = _load_skill_doc(ctx, skill_id)
+    try:
+        doc.open_phase(phase_label)
+    except PhaseNotFoundError as exc:
+        output_error(3, "Phase not found", str(exc))
+
+    if dry_run:
+        format_output(
+            {"dry_run": True, "would": "open phase", "skill_id": skill_id, "phase": phase_label},
+            ctx.obj.output_format,
+            entity_type="skill",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    _persist_doc(ctx, skill_id, doc, reason="host-phase-open")
+    format_output(
+        {"ok": True, "skill_id": skill_id, "active_phase": phase_label, "title": card.get("title", "")},
+        ctx.obj.output_format,
+        entity_type="skill",
+        base_url=ctx.obj.auth_url,
+    )
+
+
+@skill_phase_group.command("done")
+@click.argument("skill_id")
+@click.argument("phase_label")
+@click.option(
+    "--artifact-card-id",
+    "artifact_card_ids",
+    multiple=True,
+    help="Card ID to attach as an artifact for this phase. Repeatable.",
+)
+@click.option(
+    "--next-phase",
+    default=None,
+    help="If set, also open this phase immediately after marking the current one done.",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Preview without writing.")
+@click.pass_context
+def skill_phase_done(
+    ctx: click.Context,
+    skill_id: str,
+    phase_label: str,
+    artifact_card_ids: tuple[str, ...],
+    next_phase: str | None,
+    dry_run: bool,
+) -> None:
+    """Mark a phase complete and optionally advance to the next phase.
+
+    Each ``--artifact-card-id`` is embedded as a ``<contextCardBlock>``
+    under the phase's accordion. Pass ``--next-phase`` to open the
+    following phase in the same write (cheaper than two round-trips).
+    """
+    card, doc = _load_skill_doc(ctx, skill_id)
+    try:
+        doc.mark_phase_done(phase_label)
+    except PhaseNotFoundError as exc:
+        output_error(3, "Phase not found", str(exc))
+
+    # Resolve artifact card titles so the <contextCardBlock> has readable
+    # content. Each artifact card is fetched once — fine for the small
+    # number of artifacts per phase in practice.
+    for art_id in artifact_card_ids:
+        if not _UUID_RE.match(art_id):
+            output_error(3, "Invalid artifact card ID", f"Expected UUID, got: {art_id!r}")
+        art_card = _client(ctx).post("/get_context_card", {"card_id": art_id})
+        title = art_card.get("title", "") or "Artifact"
+        snippet = (art_card.get("snippet") or "").strip() or (art_card.get("description") or "").strip()
+        if len(snippet) > 200:
+            snippet = snippet[:197].rstrip() + "…"
+        doc.append_artifact_block(
+            label=phase_label,
+            card_id=art_id,
+            card_type=art_card.get("type", "note"),
+            title=title,
+            summary=snippet or "(no summary)",
+        )
+
+    if next_phase:
+        try:
+            doc.open_phase(next_phase)
+        except PhaseNotFoundError as exc:
+            output_error(3, "Next phase not found", str(exc))
+
+    if dry_run:
+        format_output(
+            {
+                "dry_run": True,
+                "would": "mark phase done",
+                "skill_id": skill_id,
+                "phase": phase_label,
+                "artifacts": list(artifact_card_ids),
+                "next_phase": next_phase,
+            },
+            ctx.obj.output_format,
+            entity_type="skill",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    _persist_doc(ctx, skill_id, doc, reason="host-phase-done")
+    format_output(
+        {
+            "ok": True,
+            "skill_id": skill_id,
+            "completed_phase": phase_label,
+            "next_phase": next_phase,
+            "artifacts": list(artifact_card_ids),
+            "title": card.get("title", ""),
+        },
+        ctx.obj.output_format,
+        entity_type="skill",
+        base_url=ctx.obj.auth_url,
+    )
+
+
+@skill_phase_group.command("pause")
+@click.argument("skill_id")
+@click.option("--reason", required=True, help="Short sentence explaining what's blocking the run.")
+@click.pass_context
+def skill_phase_pause(ctx: click.Context, skill_id: str, reason: str) -> None:
+    """Pause the run (lock held). Exits non-zero so wrapping scripts notice.
+
+    Does NOT change the card's ``status`` — the run lock stays held so a
+    re-run resumes the same phase. The user resumes by re-invoking
+    ``deepvista skill run --mode host <skill_id>``.
+    """
+    card, doc = _load_skill_doc(ctx, skill_id)
+    active = doc.active_phase()
+    out = {
+        "ok": False,
+        "paused": True,
+        "skill_id": skill_id,
+        "title": card.get("title", ""),
+        "active_phase": active.title if active else None,
+        "reason": reason,
+        "resume_with": f"deepvista skill run --mode host {skill_id}",
+    }
+    format_output(out, ctx.obj.output_format, entity_type="skill", base_url=ctx.obj.auth_url)
+    sys.exit(2)
+
+
+@skill_phase_group.command("run-on-deepvista")
+@click.argument("skill_id")
+@click.argument("phase_label")
+@click.option(
+    "--input",
+    "user_input",
+    default=None,
+    help="Extra context for the DeepVista agent on top of the phase-scoped instruction.",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Preview without calling /imagine.")
+@click.pass_context
+def skill_phase_run_on_deepvista(
+    ctx: click.Context, skill_id: str, phase_label: str, user_input: str | None, dry_run: bool
+) -> None:
+    """Delegate a single phase to the DeepVista server agent and return.
+
+    Used by ``--mode auto`` runs (and by the host agent on demand) when
+    the active phase's ``tool_plan`` is entirely server-side tools. The
+    server agent runs only that phase — it should mark the accordion
+    ``checked="true"`` and the mermaid node ``:::dvDone`` but NOT
+    advance further or set ``status="completed"``. Control returns to
+    the host once the server agent emits ``done: true`` for the phase.
+    """
+    # Validate phase exists locally before paying for an /imagine call.
+    _, doc = _load_skill_doc(ctx, skill_id)
+    if not any(p.title == phase_label for p in doc.phases()):
+        output_error(3, "Phase not found", f"No accordion titled {phase_label!r}")
+
+    extra = f" Extra context from the host: {user_input}" if user_input else ""
+    instruction = (
+        f'<contextCard id="{skill_id}" cardType="skill"></contextCard> '
+        f'Run ONLY the phase "{phase_label}". After completing it '
+        '(accordion checked="true", mermaid node :::dvDone), STOP. '
+        "Do NOT advance to any subsequent phase. Do NOT set "
+        'status="completed" — the host agent is driving the rest of the workflow.' + extra
+    )
+    body: dict[str, Any] = {"user_instruction": instruction, "force": True}
+
+    if dry_run:
+        format_output(
+            {
+                "dry_run": True,
+                "would": "delegate one phase to DeepVista server agent via /imagine",
+                "skill_id": skill_id,
+                "phase": phase_label,
+                "payload": body,
+            },
+            ctx.obj.output_format,
+            entity_type="skill",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    for event in _client(ctx).stream_sse("/imagine", body):
+        click.echo(json.dumps(event, default=str))
+
+
+@skill_group.command("complete")
+@click.argument("skill_id")
+@click.option(
+    "--review",
+    required=True,
+    help="3–6 retrospective bullets to append as the final ``## Review`` section.",
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Preview without writing.")
+@click.pass_context
+def skill_complete(ctx: click.Context, skill_id: str, review: str, dry_run: bool) -> None:
+    """Finalize a host-mode workflow run.
+
+    Appends the ``## Review`` section, sets ``status="completed"``
+    (releasing the run lock so the skill can be run again), and emits
+    ``<json>{"done": true}</json>`` for the host agent's output channel.
+    """
+    card, doc = _load_skill_doc(ctx, skill_id)
+    doc.append_review(review)
+
+    if dry_run:
+        format_output(
+            {"dry_run": True, "would": "append Review + release run lock", "skill_id": skill_id, "review": review},
+            ctx.obj.output_format,
+            entity_type="skill",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    _persist_doc(ctx, skill_id, doc, reason="host-skill-complete", status="completed")
+    click.echo(json.dumps({"done": True, "skill_id": skill_id, "title": card.get("title", "")}, default=str))
 
 
 @skill_group.command("status")

--- a/deepvista_cli/resources/__init__.py
+++ b/deepvista_cli/resources/__init__.py
@@ -1,0 +1,6 @@
+"""Package resources bundled with deepvista-cli.
+
+Currently:
+- ``workflow_host_runtime.md`` — host-mode runtime contract emitted by
+  ``deepvista skill run --mode host`` for the host agent to follow.
+"""

--- a/deepvista_cli/resources/workflow_host_runtime.md
+++ b/deepvista_cli/resources/workflow_host_runtime.md
@@ -1,0 +1,189 @@
+---
+name: deepvista-skill-workflow-host
+type: workflow
+execution: stateful
+description: "Host-agent runtime contract for executing a DeepVista workflow Skill via the `deepvista` CLI. Sibling to `deepvista-skill-workflow` (DeepVista server-agent contract). Trigger when `deepvista skill run --mode host <id>` returns a run packet."
+---
+
+# Workflow Host Runtime
+
+You (the host agent: Claude Code / OpenClaw / Cursor / …) are driving a
+DeepVista workflow Skill yourself. Use your **own tools** (Bash, Edit,
+Write, Read, MCPs, …) to execute each phase, and use the `deepvista` CLI
+to persist phase progress and artifacts back to DeepVista.
+
+This contract mirrors the DeepVista server agent's run-time contract
+(`deepvista-skill-workflow/SKILL.md`) but every primitive is something you
+already have. **Do not** call `/imagine` to delegate the whole run — that
+defeats the purpose of host-mode. You may delegate a single phase via
+`deepvista skill phase run-on-deepvista` when the phase's `tool_plan` is
+entirely DeepVista-server-only tools.
+
+## Run packet you just received
+
+`deepvista skill run --mode host <skill_id>` printed a JSON header followed
+by the skill's full SKILL.md body. The header contains:
+
+- `skill_id`: the parent workflow card id you'll be mutating.
+- `active_phase`: the phase you should resume from (the first
+  `<accordion>` with `open="true"`, or the first phase if none).
+- `phase_routes`: only present when `--mode auto` — a per-phase
+  routing decision (`"host"` or `"deepvista"`) derived from each
+  phase's `tool_plan`. Follow it for `--mode auto` runs; otherwise
+  every phase is `"host"`.
+- `user_input`: optional context the user passed via `--input`.
+
+The body that follows the header is the same SKILL.md the DeepVista server
+agent would read. The accordion / mermaid invariants from
+`deepvista-skill-workflow` apply identically; only the *runner* changes.
+
+## Run workflow (follow strictly)
+
+### 1. Take ownership of the active phase
+
+```
+deepvista skill phase open <skill_id> "Phase N: <title>"
+```
+
+This flips the target accordion to `open="true" checked="false"`, marks
+its mermaid node `:::dvActive`, and drops `open="true"` from every other
+accordion. Idempotent — safe to re-run on resume.
+
+### 2. Execute the phase using your own tools
+
+Work through the accordion's numbered steps with your native tools:
+- Files / code / commands: Bash, Read, Edit, Write, Grep.
+- External services: your installed MCPs (Gmail, Slack, calendar,
+  LinkedIn schedulers, …).
+- Knowledge base reads: `deepvista card +search` / `deepvista vistabase`
+  / `deepvista notes list` are CLI equivalents of the server agent's
+  search tools.
+
+Whenever the user supplies meaningful information (decisions, drafts,
+links, outputs), persist it as a context card so DeepVista keeps the
+artifact:
+
+```
+deepvista notes create --title "..." --content "..." [--tags '["..."]']
+# OR for non-note types:
+deepvista card create --type note --title "..." --content "..." [--tags '["..."]']
+```
+
+Capture the returned card id — you'll attach it to the phase in step 3.
+
+### 3. Advance the phase
+
+When the phase's `done_when` criteria are met:
+
+```
+deepvista skill phase done <skill_id> "Phase N: <title>" \
+    [--artifact-card-id <id>]... \
+    [--next-phase "Phase N+1: <title>"]
+```
+
+This flips the accordion to `checked="true"` (drops `open="true"`), marks
+its mermaid node `:::dvDone`, and embeds a `<contextCardBlock>` for each
+artifact card you produced under the accordion body. If `--next-phase` is
+given, it also runs the equivalent of step 1 on that phase. Otherwise the
+next phase is left pending and you should call `phase open` explicitly
+before starting it.
+
+### 4. Per-phase fallback to DeepVista (optional)
+
+If a phase is entirely knowledge-base-internal (its `tool_plan` is only
+`chat_cypher_search` / `read_context_card` / `exa_search` /
+`upsert_context_card` / `edit_context_card` / `find_similar_cards` /
+`enrich_card_entities` / `load_skill` / `run_skill`), you can delegate it
+to the DeepVista server agent for one turn:
+
+```
+deepvista skill phase run-on-deepvista <skill_id> "Phase N: <title>"
+```
+
+This POSTs to `/imagine` with `"Run only Phase N"` instructions; the
+server agent reads the same card, mutates the same accordion, persists
+artifacts, and returns. You stay in control of every other phase.
+
+In `--mode auto`, follow the `phase_routes` table in the run packet:
+phases marked `"deepvista"` use this command; phases marked `"host"`
+follow steps 1–3.
+
+### 5. Graceful exit when you can't continue
+
+If the current phase requires a tool you don't have (the user is offline,
+an MCP is unavailable, credentials are missing, …):
+
+1. Save whatever partial output you produced as a note card via
+   `deepvista notes create` so DeepVista keeps the artifact.
+2. Run:
+   ```
+   deepvista skill phase pause <skill_id> --reason "<one short sentence>"
+   ```
+   This **keeps the run lock held** (`status` stays `in_progress`),
+   prints the reason for the user, and exits non-zero.
+3. Tell the user in plain language what's missing and how to resume
+   (e.g. "Reconnect Gmail MCP and re-run `deepvista skill run` to
+   continue Phase 3"). Do not pretend the phase succeeded.
+
+When the blocker clears, the user re-runs `deepvista skill run --mode
+host <skill_id>`. The CLI re-emits the packet pointing at the same active
+phase and you resume from step 2.
+
+### 6. Finalize
+
+When the last phase is done:
+
+```
+deepvista skill complete <skill_id> --review "<3–6 retrospective bullets>"
+```
+
+This appends a `## Review` section to the description with the bullets you
+pass, sets `status="completed"` (releasing the run lock so the skill can
+be run again), and emits `<json>{"done": true}</json>`.
+
+## Tools cheat sheet
+
+| What you want | Host command |
+| --- | --- |
+| Open a phase | `deepvista skill phase open <skill_id> "Phase N: …"` |
+| Mark a phase done | `deepvista skill phase done <skill_id> "Phase N: …" [--artifact-card-id ID]…` |
+| Pause (lock held) | `deepvista skill phase pause <skill_id> --reason "…"` |
+| Resume from pause | re-run `deepvista skill run --mode host <skill_id>` |
+| One-phase fallback to DeepVista | `deepvista skill phase run-on-deepvista <skill_id> "Phase N: …"` |
+| Finalize the run | `deepvista skill complete <skill_id> --review "…"` |
+| Save an artifact (note) | `deepvista notes create --title "…" --content "…"` |
+| Search the knowledge base | `deepvista card +search "…"` |
+| Inspect current state | `deepvista skill get <skill_id>` |
+
+## Rules
+
+- **One** `phase open` ⇒ **one** `phase done` per phase. Don't open
+  Phase N+1 before closing Phase N (the CLI tolerates it but the
+  workflow card will show inconsistent state).
+- Don't write the SKILL.md body to disk. Don't paste it back in chat.
+  All mutation happens through the CLI shims so the server-side schema
+  stays canonical.
+- Don't call `/imagine` directly. The only allowed route to the server
+  agent is `deepvista skill phase run-on-deepvista` (per-phase) or
+  `deepvista skill run --mode deepvista` (whole run).
+- Respect the run lock. If `skill phase pause` was the last write, treat
+  the skill as still in progress on the next session.
+
+## Output format
+
+When you finish the run, emit:
+
+```
+<contextCardBlock id="<skill_id>" cardType="skill" view="compact">
+<Title Case Display Name>
+<one-sentence description>
+</contextCardBlock>
+
+<json>{"done": true}</json>
+```
+
+When you pause:
+
+```
+<json>{"done": false, "paused": true, "reason": "<your reason>"}</json>
+```

--- a/deepvista_cli/workflow_doc.py
+++ b/deepvista_cli/workflow_doc.py
@@ -1,0 +1,501 @@
+"""Parse and mutate a workflow Skill's SKILL.md body (`description`).
+
+A workflow Skill body is a complete SKILL.md: YAML frontmatter, a mermaid
+diagram, one ``<accordion>`` per phase, etc. The DeepVista server agent
+mutates this body in place at run-time to reflect phase progress (see
+``deepvista-skill-workflow/SKILL.md``). When a host agent (Claude Code /
+OpenClaw / Cursor) drives the run via ``deepvista skill run --mode host``,
+the same mutations need to happen client-side via the ``deepvista skill
+phase ...`` CLI shims; this module is the parsing + mutation backbone.
+
+Scope (v1):
+- accordion attributes: open / checked
+- mermaid node class markers: ``:::dvActive`` / ``:::dvDone`` / ``:::dvTodo``
+- phase listing (parse accordion titles)
+- ``phase_contract.tool_plan`` extraction for ``--mode auto`` routing
+  (handles both new frontmatter contracts and legacy inline yaml blocks)
+
+Out of scope (v1):
+- Edge animation directive updates (``eN@{ animation: slow }``). Server-side
+  runs continue to manage these; host-mode runs leave them static and the
+  renderer falls back to a static diagram. The accordion + node-class
+  invariants are sufficient for the frontend to show phase state.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Regexes
+# ---------------------------------------------------------------------------
+
+# Match a full <accordion ...>...</accordion> block, capturing attrs + body.
+# Non-greedy body so multiple accordions in a body each match.
+_ACCORDION_RE = re.compile(
+    r"<accordion(?P<attrs>[^>]*)>(?P<body>.*?)</accordion>",
+    re.DOTALL,
+)
+
+# Inside an accordion body, the phase title is the first non-empty line.
+_PHASE_TITLE_LINE_RE = re.compile(r"^\s*(.+?)\s*$", re.MULTILINE)
+
+# Mermaid class marker: ``...:::dvActive`` / ``:::dvDone`` / ``:::dvTodo`` /
+# ``:::dvError``. We match the node label + the class so we can swap classes.
+_MERMAID_NODE_CLASS_RE = re.compile(
+    r"(?P<label_open>[\[\{\(])"
+    r"(?P<label_text>[^\]\}\)]*?)"
+    r"(?P<label_close>[\]\}\)])"
+    r":::(?P<klass>dvActive|dvDone|dvTodo|dvError)"
+)
+
+# Fenced mermaid block.
+_MERMAID_BLOCK_RE = re.compile(r"```mermaid\n(?P<body>.*?)```", re.DOTALL)
+
+# Inline ```yaml ... ``` block within an accordion body — legacy phase contract.
+_INLINE_YAML_RE = re.compile(r"```yaml\n(?P<body>.*?)```", re.DOTALL)
+
+# YAML frontmatter at the very top of the document (must start with `---`).
+_FRONTMATTER_RE = re.compile(r"\A---\n(?P<body>.*?)\n---\n?", re.DOTALL)
+
+
+# ---------------------------------------------------------------------------
+# Data shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PhaseInfo:
+    """Lightweight per-phase view used by ``--mode auto`` routing.
+
+    Title is the accordion's first non-empty line. ``tool_plan`` is the
+    flattened list of tool names this phase intends to use, drawn from
+    either the document frontmatter's ``phase_contract`` (new spec) or
+    the legacy inline ``\\`\\`\\`yaml`` block inside the accordion.
+    Empty list means "no contract found" — caller decides the routing
+    default.
+    """
+
+    index: int  # 1-based, matching "Phase N:" prose where present
+    title: str
+    state: str  # "pending" | "active" | "done"
+    tool_plan: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Tool names that only the DeepVista server agent has (not the CLI)
+# ---------------------------------------------------------------------------
+# Source: deepvista-skill-workflow/SKILL.md `tool_plan` allowed values.
+# A phase whose tool_plan is a subset of this set can be routed to /imagine;
+# anything else stays host-local.
+SERVER_ONLY_TOOLS: frozenset[str] = frozenset(
+    {
+        "chat_cypher_search",
+        "grep_context_cards",
+        "read_context_card",
+        "find_similar_cards",
+        "exa_search",
+        "upsert_context_card",
+        "edit_context_card",
+        "enrich_card_entities",
+        "load_skill",
+        "run_skill",
+        # NB: ``run_command`` is intentionally NOT here — it requires the
+        # host agent's shell.
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class WorkflowDocument:
+    """Mutable view of a workflow Skill's SKILL.md body."""
+
+    def __init__(self, body: str) -> None:
+        self._body = body
+
+    @property
+    def body(self) -> str:
+        return self._body
+
+    # ------------------------------------------------------------------
+    # Read
+    # ------------------------------------------------------------------
+
+    def phases(self) -> list[PhaseInfo]:
+        """Return one ``PhaseInfo`` per ``<accordion>`` in document order."""
+        result: list[PhaseInfo] = []
+        # Map "Phase N: ..." → tool_plan from doc frontmatter, if any.
+        fm_contracts = _parse_frontmatter_phase_contracts(self._body)
+
+        for idx, match in enumerate(_ACCORDION_RE.finditer(self._body), start=1):
+            attrs = match.group("attrs")
+            body = match.group("body")
+            title = _extract_phase_title(body)
+            state = _state_from_accordion_attrs(attrs)
+
+            tool_plan = _extract_inline_tool_plan(body)
+            if not tool_plan:
+                tool_plan = fm_contracts.get(title, [])
+
+            result.append(PhaseInfo(index=idx, title=title, state=state, tool_plan=tool_plan))
+        return result
+
+    def active_phase(self) -> PhaseInfo | None:
+        for p in self.phases():
+            if p.state == "active":
+                return p
+        return None
+
+    def first_pending_phase(self) -> PhaseInfo | None:
+        for p in self.phases():
+            if p.state == "pending":
+                return p
+        return None
+
+    # ------------------------------------------------------------------
+    # Mutate — accordions
+    # ------------------------------------------------------------------
+
+    def open_phase(self, label: str) -> None:
+        """Mark the accordion matching ``label`` as active (open + unchecked).
+
+        All other accordions lose ``open="true"`` (their ``checked`` attr is
+        preserved). The mermaid node whose label aligns with ``label`` gets
+        its class marker set to ``:::dvActive``; the previously-active node
+        (if any) is downgraded to ``:::dvDone`` — the assumption is that the
+        caller has finished it before advancing. Use ``mark_phase_done``
+        first if you want explicit ``done`` semantics on the prior phase.
+        """
+        if not self._has_phase(label):
+            raise PhaseNotFoundError(label)
+
+        self._body = _mutate_accordions(
+            self._body,
+            target_label=label,
+            target_attrs={"checked": "false", "open": "true"},
+        )
+        # All non-target accordions lose ``open="true"``.
+        self._body = _strip_open_from_other_accordions(self._body, keep_label=label)
+
+        # Mermaid: previous active → dvDone, target → dvActive.
+        self._body = _set_mermaid_class_for_label(self._body, label="*active*", new_klass="dvDone")
+        self._body = _set_mermaid_class_for_label(self._body, label=label, new_klass="dvActive")
+
+    def mark_phase_done(self, label: str) -> None:
+        """Mark a phase complete: accordion checked, mermaid node ``dvDone``."""
+        if not self._has_phase(label):
+            raise PhaseNotFoundError(label)
+        self._body = _mutate_accordions(self._body, target_label=label, target_attrs={"checked": "true"})
+        self._body = _strip_open_from_other_accordions(self._body, keep_label=None)
+        self._body = _set_mermaid_class_for_label(self._body, label=label, new_klass="dvDone")
+
+    def append_artifact_block(self, label: str, card_id: str, card_type: str, title: str, summary: str) -> None:
+        """Embed a ``<contextCardBlock>`` inside the named accordion's body.
+
+        The block is inserted at the end of the accordion body (before the
+        closing tag). Idempotent — calling with the same ``card_id`` again
+        is a no-op.
+        """
+        if not self._has_phase(label):
+            raise PhaseNotFoundError(label)
+        block = (
+            f'<contextCardBlock id="{card_id}" cardType="{card_type}" view="compact">\n'
+            f"{title}\n{summary}\n"
+            "</contextCardBlock>"
+        )
+        self._body = _append_to_accordion(self._body, label=label, block=block, dedupe_marker=f'id="{card_id}"')
+
+    def append_review(self, review_md: str) -> None:
+        """Append a ``## Review`` section to the doc body if not already present.
+
+        Idempotent: if a ``## Review`` heading exists, the new content is
+        appended after the existing section instead of duplicating the
+        heading.
+        """
+        if "## Review" in self._body:
+            # Already has a Review section — append a separator + new content.
+            self._body = self._body.rstrip() + "\n\n" + review_md.strip() + "\n"
+        else:
+            self._body = self._body.rstrip() + "\n\n## Review\n\n" + review_md.strip() + "\n"
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _has_phase(self, label: str) -> bool:
+        return any(p.title == label for p in self.phases())
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class PhaseNotFoundError(ValueError):
+    """Raised when a CLI command names a phase that's not in the workflow body."""
+
+    def __init__(self, label: str) -> None:
+        super().__init__(f"No accordion titled {label!r} found in workflow body")
+        self.label = label
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_phase_title(accordion_body: str) -> str:
+    """Return the first non-empty line of the accordion body (the phase title)."""
+    for raw_line in accordion_body.splitlines():
+        line = raw_line.strip()
+        if line:
+            return line
+    return ""
+
+
+def _state_from_accordion_attrs(attrs: str) -> str:
+    checked = _attr_value(attrs, "checked")
+    is_open = _attr_value(attrs, "open") == "true"
+    if checked == "true":
+        return "done"
+    if is_open:
+        return "active"
+    return "pending"
+
+
+def _attr_value(attrs: str, name: str) -> str | None:
+    """Extract the value of ``name`` from a string like ``checked="false" open="true"``."""
+    m = re.search(rf'{re.escape(name)}\s*=\s*"([^"]*)"', attrs)
+    return m.group(1) if m else None
+
+
+def _mutate_accordions(body: str, target_label: str, target_attrs: dict[str, str]) -> str:
+    """Re-emit accordions, replacing the target accordion's attrs.
+
+    Non-target accordions are left structurally intact; only the target's
+    opening tag is rewritten so the merge between ``target_attrs`` and the
+    existing attrs preserves attributes we don't touch (e.g. custom data-*).
+    """
+
+    def repl(match: re.Match[str]) -> str:
+        attrs = match.group("attrs")
+        body_inner = match.group("body")
+        title = _extract_phase_title(body_inner)
+        if title != target_label:
+            return match.group(0)
+        new_attrs = _merge_attrs(attrs, target_attrs)
+        return f"<accordion{new_attrs}>{body_inner}</accordion>"
+
+    return _ACCORDION_RE.sub(repl, body)
+
+
+def _strip_open_from_other_accordions(body: str, keep_label: str | None) -> str:
+    """Drop ``open="true"`` from every accordion except the one matching ``keep_label``."""
+
+    def repl(match: re.Match[str]) -> str:
+        attrs = match.group("attrs")
+        body_inner = match.group("body")
+        title = _extract_phase_title(body_inner)
+        if keep_label is not None and title == keep_label:
+            return match.group(0)
+        new_attrs = _remove_attr(attrs, "open")
+        return f"<accordion{new_attrs}>{body_inner}</accordion>"
+
+    return _ACCORDION_RE.sub(repl, body)
+
+
+def _merge_attrs(existing: str, updates: dict[str, str]) -> str:
+    """Merge ``updates`` into the attribute string ``existing``.
+
+    Existing attribute values are overwritten by ``updates``; attributes not
+    in ``updates`` are preserved. The returned string starts with a single
+    leading space so it can be re-spliced into ``<accordion{attrs}>``.
+    """
+    parts: list[tuple[str, str]] = []
+    seen: set[str] = set()
+    for m in re.finditer(r'(\w+)\s*=\s*"([^"]*)"', existing):
+        key, val = m.group(1), m.group(2)
+        if key in updates:
+            val = updates[key]
+        seen.add(key)
+        parts.append((key, val))
+    for key, val in updates.items():
+        if key not in seen:
+            parts.append((key, val))
+    if not parts:
+        return ""
+    return " " + " ".join(f'{k}="{v}"' for k, v in parts)
+
+
+def _remove_attr(existing: str, name: str) -> str:
+    """Return ``existing`` with the ``name`` attribute (if any) removed."""
+    cleaned = re.sub(rf'\s*{re.escape(name)}\s*=\s*"[^"]*"', "", existing)
+    cleaned = cleaned.strip()
+    return (" " + cleaned) if cleaned else ""
+
+
+def _set_mermaid_class_for_label(body: str, label: str, new_klass: str) -> str:
+    """Update the ``:::dvX`` class marker on the mermaid node aligned with ``label``.
+
+    ``label`` may be the special sentinel ``"*active*"`` — matches whatever
+    node is currently ``:::dvActive`` (used to demote the prior active node
+    when opening a new phase).
+
+    Matching is structural: the node label text either equals the accordion
+    title or contains the phase prefix (``"Phase N:"`` / ``"Step N:"``).
+    """
+    blocks = list(_MERMAID_BLOCK_RE.finditer(body))
+    if not blocks:
+        return body
+
+    def rewrite_node(node_match: re.Match[str], in_block: str) -> str | None:
+        klass = node_match.group("klass")
+        text = node_match.group("label_text").strip()
+        if label == "*active*":
+            if klass != "dvActive":
+                return None
+        else:
+            if not _labels_align(text, label):
+                return None
+        # Rewrite the class only — keep label punctuation as-is.
+        return (
+            node_match.group("label_open")
+            + node_match.group("label_text")
+            + node_match.group("label_close")
+            + ":::"
+            + new_klass
+        )
+
+    new_body = body
+    # Iterate blocks back-to-front so substring positions don't shift.
+    for block in reversed(blocks):
+        original = block.group("body")
+        rewritten = _MERMAID_NODE_CLASS_RE.sub(
+            lambda nm, original=original: rewrite_node(nm, original) or nm.group(0),
+            original,
+        )
+        if rewritten != original:
+            start, end = block.span("body")
+            new_body = new_body[:start] + rewritten + new_body[end:]
+    return new_body
+
+
+def _labels_align(node_text: str, phase_title: str) -> bool:
+    """Heuristic: does a mermaid node label correspond to a given accordion title?
+
+    True if:
+    - exact string equality after stripping wrapping quotes (case-insensitive), OR
+    - both share the same ``Phase N:`` / ``Step N:`` prefix.
+    """
+    n = node_text.strip().strip('"').strip()
+    p = phase_title.strip().strip('"').strip()
+    if n.lower() == p.lower():
+        return True
+    n_prefix = _phase_prefix(n)
+    p_prefix = _phase_prefix(p)
+    return bool(n_prefix and n_prefix == p_prefix)
+
+
+def _phase_prefix(text: str) -> str:
+    """Return the ``Phase N`` / ``Step N`` / ``N.`` prefix, or empty string."""
+    m = re.match(r"\s*(Phase\s+\d+|Step\s+\d+|\d+\.)\s*[:.]?", text, re.IGNORECASE)
+    if not m:
+        return ""
+    return re.sub(r"\s+", " ", m.group(1)).strip().lower()
+
+
+def _append_to_accordion(body: str, label: str, block: str, dedupe_marker: str) -> str:
+    """Insert ``block`` inside the named accordion's body, idempotently."""
+
+    def repl(match: re.Match[str]) -> str:
+        attrs = match.group("attrs")
+        body_inner = match.group("body")
+        title = _extract_phase_title(body_inner)
+        if title != label:
+            return match.group(0)
+        if dedupe_marker in body_inner:
+            return match.group(0)
+        new_body = body_inner.rstrip() + "\n\n" + block + "\n"
+        return f"<accordion{attrs}>{new_body}</accordion>"
+
+    return _ACCORDION_RE.sub(repl, body)
+
+
+def _extract_inline_tool_plan(accordion_body: str) -> list[str]:
+    """Return the flattened tool names from any inline ```yaml``` block inside an accordion.
+
+    Legacy parent workflows still embed the contract inline; new specs put
+    it in frontmatter. This handles the legacy case.
+    """
+    yaml_match = _INLINE_YAML_RE.search(accordion_body)
+    if not yaml_match:
+        return []
+    return _tool_plan_names_from_yaml_text(yaml_match.group("body"))
+
+
+def _parse_frontmatter_phase_contracts(body: str) -> dict[str, list[str]]:
+    """Parse the doc-level frontmatter and return ``{phase_label: [tool_names]}``.
+
+    For child workflows the frontmatter carries a single ``phase_contract``
+    (not multiple). The contract applies to whatever ``parent_phase`` the
+    child is anchored to — we surface it under that label so a host-mode
+    runner inspecting a child can route by it.
+    """
+    fm = _FRONTMATTER_RE.match(body)
+    if not fm:
+        return {}
+    parent_phase = re.search(r'^\s*parent_phase:\s*"([^"]+)"', fm.group("body"), re.MULTILINE)
+    if not parent_phase:
+        return {}
+    tools = _tool_plan_names_from_yaml_text(fm.group("body"))
+    if not tools:
+        return {}
+    return {parent_phase.group(1): tools}
+
+
+def _tool_plan_names_from_yaml_text(yaml_text: str) -> list[str]:
+    """Extract tool names from a ``tool_plan:`` block in raw yaml text.
+
+    Avoids pulling in PyYAML — the structure is well-known (`tool_plan:` then
+    a flat list of ``- name: "..."`` mappings under it).
+    """
+    # Find the ``tool_plan:`` line and consume the indented block underneath.
+    lines = yaml_text.splitlines()
+    out: list[str] = []
+    in_block = False
+    block_indent: int | None = None
+    for raw in lines:
+        line = raw.rstrip()
+        stripped = line.lstrip()
+        if not in_block:
+            if stripped.startswith("tool_plan:"):
+                in_block = True
+                block_indent = len(line) - len(stripped)
+            continue
+        if not stripped:
+            continue
+        cur_indent = len(line) - len(stripped)
+        if cur_indent <= (block_indent or 0):
+            break
+        # Entries look like ``- chat_cypher_search: "..."`` or ``- name: chat_cypher_search``.
+        item_match = re.match(r"-\s*([A-Za-z_][A-Za-z0-9_]*)\s*:", stripped)
+        if item_match:
+            out.append(item_match.group(1))
+    return out
+
+
+def is_phase_server_routable(phase: PhaseInfo) -> bool:
+    """Return True if every tool in this phase's plan is a DeepVista server tool.
+
+    If the phase has no ``tool_plan`` at all, returns False — caller defaults
+    such phases to host execution (the safe choice: the host has more
+    capabilities, not fewer).
+    """
+    if not phase.tool_plan:
+        return False
+    return all(name in SERVER_ONLY_TOOLS for name in phase.tool_plan)

--- a/skills/deepvista/reference/skill.md
+++ b/skills/deepvista/reference/skill.md
@@ -35,14 +35,41 @@ note (podcast, interview, book chapter, research summary). Full guide:
 
 ### `run` — write
 
-> [!CAUTION] Starts a new Skill run and creates a chat session. Confirm first.
+> [!CAUTION] Acquires the parent Skill card's run lock and either prints a host run packet or starts a DeepVista chat session. Confirm first.
 
 ```bash
-deepvista skill run <skill_id> [--input "context text"]
+deepvista skill run <skill_id> [--mode host|deepvista|auto] [--input "context text"]
 ```
 
-Output is **NDJSON** — same format as [chat.md](chat.md). The very first event
-contains the `run_chat_id` you'll need for `status` and continuation.
+Three modes, picked with `--mode` (default `host`):
+
+- **`host`** *(default)* — the CLI does **not** call `/imagine`. It prints a JSON header (`type: "skill_run_packet"`, skill_id, active phase, per-phase routing, user_input) followed by the workflow's SKILL.md body and the host-mode runtime contract. The host agent (Claude Code / OpenClaw / Cursor) drives the run itself via the [`phase`](#phase--mutate-an-in-progress-run-write) and [`complete`](#complete--release-the-run-lock-write) shims below. Use this when the workflow needs tools the host has (Bash, Edit, MCPs, your repo state).
+- **`deepvista`** — legacy behaviour: POSTs to `/imagine` and streams NDJSON from the DeepVista server agent, which drives the workflow end-to-end. Use this for KB-internal workflows (research, synthesis, card updates) where the server's tools are sufficient.
+- **`auto`** — inspects each phase's `tool_plan` and routes per phase. Phases whose plan is entirely server-side tools (`chat_cypher_search`, `upsert_context_card`, …) get a `"deepvista"` route in the packet; the rest stay `"host"`. The host agent follows the table.
+
+### `phase` — mutate an in-progress run (write)
+
+Used by host agents driving the workflow themselves after `skill run --mode host`. Each command parses the skill card, mutates accordion + mermaid markers, and writes via `/update_context_card`.
+
+```bash
+deepvista skill phase open <skill_id> "Phase N: <title>"
+deepvista skill phase done <skill_id> "Phase N: <title>" [--artifact-card-id ID]... [--next-phase "Phase N+1: …"]
+deepvista skill phase pause <skill_id> --reason "<short sentence>"
+deepvista skill phase run-on-deepvista <skill_id> "Phase N: <title>" [--input "..."]
+```
+
+- `open` marks the accordion `open="true"` and the mermaid node `:::dvActive`.
+- `done` marks `checked="true"` / `:::dvDone` and optionally embeds artifact `<contextCardBlock>`s. Pass `--next-phase` to open the next phase in the same write.
+- `pause` does **not** change `status` (the run lock stays held). Exits non-zero; the user resumes by re-running `deepvista skill run --mode host`.
+- `run-on-deepvista` delegates a single phase to the DeepVista server agent. Used by `--mode auto` for server-routable phases.
+
+### `complete` — release the run lock (write)
+
+```bash
+deepvista skill complete <skill_id> --review "<3–6 retrospective bullets>"
+```
+
+Appends the `## Review` section, sets `status="completed"` (releases the lock so the skill can be run again), and emits `<json>{"done": true}</json>`.
 
 ### `status` — read-only
 
@@ -99,7 +126,12 @@ traceback) so agents don't blow up. 5-minute on-disk body cache by default.
 
 ```bash
 deepvista skill list
-deepvista skill run <skill_id> --input "Focus on Q4 objectives"
+deepvista skill run <skill_id> --input "Focus on Q4 objectives"           # host mode (default)
+deepvista skill run <skill_id> --mode deepvista                            # legacy server-agent run
+deepvista skill run <skill_id> --mode auto                                 # per-phase routing
+deepvista skill phase open <skill_id> "Phase 1: …"                         # host: open the first phase
+deepvista skill phase done <skill_id> "Phase 1: …" --artifact-card-id <id> # host: complete + attach artifact
+deepvista skill complete <skill_id> --review "shipped on Friday — clean run"
 deepvista skill status <run_chat_id>
 deepvista skill discover --category persona
 deepvista skill install persona-researcher


### PR DESCRIPTION
https://app.visla.us/clip/1504999285488444050

## Summary

When the user runs a workflow skill from a host agent (Claude Code / OpenClaw / Cursor), today `deepvista skill run` always POSTs to `/imagine` and the **DeepVista server agent** drives the whole workflow — even when the host agent has more capable tools for the actual work (Bash, Edit, MCPs, user's repo state, …). This PR introduces a host-mode execution path so the workflow runs in the original agent by default.

### New surface

- `deepvista skill run <id> --mode {host|deepvista|auto}` — default **`host`**. Emits a structured packet (header + workflow body + host-mode runtime contract) on stdout for the host agent to drive. `deepvista` preserves today's `/imagine` behaviour. `auto` inspects each phase's `tool_plan` and routes per phase.
- `deepvista skill phase open / done / pause / run-on-deepvista` — host-side phase mutators. Each parses the skill card, mutates accordion attrs + mermaid `:::dvX` markers via `/update_context_card`, and produces the same card state shape as a DeepVista server-agent run.
- `deepvista skill complete --review …` — appends `## Review`, sets `status="completed"` (releases the run lock).

Lock semantics: `skill run --mode host` acquires `status="in_progress"`. `phase open/done` don't touch status. `phase pause` keeps the lock held and exits non-zero. `skill complete` releases.

### Implementation

- `deepvista_cli/workflow_doc.py` — `WorkflowDocument` parser/mutator for accordion + mermaid invariants, `tool_plan` extraction (handles both new-spec frontmatter and legacy inline yaml), `is_phase_server_routable` for `--mode auto`.
- `deepvista_cli/resources/workflow_host_runtime.md` — host-mode runtime contract embedded as a package resource and emitted by `skill run --mode host`.
- `deepvista_cli/commands/skill.py` — new flags, subgroup, and the per-mode dispatch.

## Companion change

Paired with the deepvista-side companion that adds the same runtime contract as a chat-agent skill and routes `deepvista-skill` to it: **DeepVista-AI/deepvista#2031**. Both should land together.

## Linear

DV-694: https://linear.app/deepvista/issue/DV-694/make-some-query-execution-to-be-in-the-original-agent

## Test plan

- [x] `skill run --mode host --dry-run` emits a well-formed packet without hitting `/imagine`.
- [x] `skill run --mode auto --dry-run` on `workflow-daily-linkedin-post`: Phase 1 (`tool_plan: chat_cypher_search`) routed `"deepvista"`, Phases 2–4 routed `"host"`.
- [x] `skill run --mode deepvista --dry-run` is byte-identical to the legacy `skill run --dry-run`.
- [x] End-to-end against prod on a throwaway test card: `skill run --mode host` → `phase open` → `phase done --artifact-card-id … --next-phase …` → `phase pause` → `phase done` → `skill complete`. Verified accordion attrs, mermaid class markers, embedded `<contextCardBlock>`, and `status` transitions at every step. Test cards deleted.
- [ ] **Not yet tested live**: `phase run-on-deepvista` prompt-engineering correctness (does the server agent honor "stop after this phase"?). Ships in v1 on prompt-engineering trust; will validate post-merge and tighten prompt if needed.
- [x] `uv run ruff check --fix deepvista_cli/` clean. `uv run pyright deepvista_cli/workflow_doc.py deepvista_cli/commands/skill.py` clean.