### PR TITLE
release: v0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ users what's new between the version they have installed and the latest release.
 
 ## Unreleased
 
+## v0.1.11
+
+### Added
+- **Host-mode workflow execution for `skill run`** (DV-694). New
+  `--mode {host,deepvista,auto}` flag, defaulting to `host`. Host mode prints
+  a structured run packet (header + workflow SKILL.md body + host-mode
+  runtime contract) on stdout so the host agent (Claude Code / OpenClaw /
+  Cursor) drives the workflow itself via the new `skill phase
+  {open,done,pause,run-on-deepvista}` shims and `skill complete`. Deepvista
+  mode preserves today's `/imagine` behaviour. Auto mode inspects each
+  phase's `tool_plan` and routes server-routable phases to `/imagine` while
+  keeping the rest host-local. Phase shims mutate the parent Skill card's
+  description directly via `/update_context_card`, so the server-side schema
+  is unchanged.
+- **`skills-refresh` lint check** (DV-724). New
+  `deepvista lint --check skills-refresh --time-range <duration>` mode that
+  folds recently-updated notes into the workflow skill library — updating
+  existing skills and creating new ones where warranted. Accepts
+  `<int><s|m|h|d|w>` durations (e.g. `30m`, `4h`, `1d`, `2w`) and emits a
+  deterministic ISO-8601 UTC cutoff to the agent. Excluded from `--check
+  all` (write-intensive) and gated behind the `--fix`-style confirmation
+  prompt unless `-y` is passed.
+
+### Fixed
+- **`vistabase` URL in skill docs uses path-based routing** (DV-703).
+  Switched the documented URL form to the path-based scheme to match the
+  rest of the CLI's URL output.
+
 ### Changed
 - **`skill create-from-note` drops the `persona` kind** (DV-750). The server-side
   persona maker (`deepvista-make-persona-skill`) was removed in #2022, so the
@@ -16,6 +44,17 @@ users what's new between the version they have installed and the latest release.
   the CLI is now always *"Create a workflow skill from this note."* and the
   chat agent routes it to `deepvista-skill-workflow`. The `skills-refresh` lint
   check (DV-724) drops its persona-candidate branch for the same reason.
+
+### Removed
+- `skills/deepvista/reference/persona-knowledge-worker.md` — the underlying
+  `deepvista-persona-knowledge-worker` skill was removed from the backend in
+  #2022 (DV-695), so the routing pointer in the consolidated `deepvista`
+  skill no longer leads anywhere useful. Daily-loop guidance is still
+  discoverable through the per-subcommand reference files.
+
+## v0.1.10
+
+### Changed
 - **`skill create-from-note` delegates prompt to the server** (DV-585). The
   ~150-line synthesis prompt previously embedded in
   `deepvista_cli/commands/skill.py` is gone; the CLI now emits only
@@ -26,13 +65,6 @@ users what's new between the version they have installed and the latest release.
   files, which are now the single source of truth for frontmatter rules,
   mermaid requirements, and `upsert_context_card` instructions. Same UX, no
   more drift between client and server prompts.
-
-### Removed
-- `skills/deepvista/reference/persona-knowledge-worker.md` — the underlying
-  `deepvista-persona-knowledge-worker` skill was removed from the backend in
-  #2022 (DV-695), so the routing pointer in the consolidated `deepvista`
-  skill no longer leads anywhere useful. Daily-loop guidance is still
-  discoverable through the per-subcommand reference files.
 
 ### Added
 - **Session-scoped conversation notes** (DV-449 M1/M2). One rolling DeepVista

--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepvista",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Remote-managed skill catalog from DeepVista. Auto-syncs thin stubs into the plugin's skills dir on SessionStart; full bodies are lazy-loaded at invocation time.",
   "author": {
     "name": "DeepVista AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.10"
+version = "0.1.11"
 description = "CLI for DeepVista — chat, notes, skills, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -164,11 +164,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.10"
+version = "0.1.11"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Bump version to v0.1.11.

## Highlights since v0.1.10

- **Host-mode workflow execution for `skill run`** (DV-694, #113). New `--mode {host,deepvista,auto}` flag (default `host`) so host agents drive workflow execution locally via `skill phase` shims and `skill complete`.
- **`skills-refresh` lint check** (DV-724, #115). New `deepvista lint --check skills-refresh --time-range <duration>` mode that folds recent notes into the workflow skill library.
- **Fix:** path-based `vistabase` URL in skill docs (DV-703, #114).
- **Chore:** drop `--kind persona` from `skill create-from-note` and prune persona-knowledge-worker docs to match server-side removal (DV-750, #116).

## Test plan

- [x] `pyproject.toml` bumped to 0.1.11
- [x] `uv.lock` regenerated
- [x] `plugins/claude-code/.claude-plugin/plugin.json` synced (auto-bumped by pre-commit hook)
- [x] CHANGELOG.md `v0.1.11` section added
- [ ] CI passes (ruff, pyright, tests, `gh skill publish --dry-run`)