### PR TITLE
fix: teach skill the correct upgrade command for agent flows

### DIFF
--- a/skills/deepvista/SKILL.md
+++ b/skills/deepvista/SKILL.md
@@ -70,7 +70,7 @@ The command is cached (~1 hour TTL) so repeated invocations are cheap.
 |---|---|---|
 | *(empty)* | 0 | Up to date, snoozed, disabled, or network unreachable — say nothing. |
 | `JUST_UPGRADED <old> <new>` | 0 | Briefly confirm: "deepvista-cli upgraded to `<new>`." |
-| `UPGRADE_AVAILABLE <old> <new>` | 1 | Tell the user and offer `deepvista upgrade` — it fetches the changelog between `<old>` and `<new>` and prompts before installing. Snooze with `deepvista upgrade snooze`; disable with `deepvista upgrade disable`. |
+| `UPGRADE_AVAILABLE <old> <new>` | 1 | Tell the user and ask if they want to upgrade. If they confirm, run `deepvista upgrade install --yes` (the `--yes` flag skips the in-process prompt; without it the command blocks waiting for terminal input). To defer: `deepvista upgrade snooze`. To opt out: `deepvista upgrade disable`. |
 
 If `deepvista` is not on `PATH`, skip silently — do not attempt to install it automatically.
 

--- a/skills/deepvista/reference/shared.md
+++ b/skills/deepvista/reference/shared.md
@@ -96,16 +96,29 @@ The CLI detects agent type from environment variables (`CLAUDECODE=1`, `OPENCODE
 | stdout | Meaning |
 |---|---|
 | *(empty)* | up to date / snoozed / disabled / offline |
-| `UPGRADE_AVAILABLE <old> <new>` | run `deepvista upgrade` to install |
+| `UPGRADE_AVAILABLE <old> <new>` | run `deepvista upgrade install --yes` to install |
 | `JUST_UPGRADED <old> <new>` | just finished updating |
 
 ```bash
-deepvista upgrade                # interactive install (shows changelog, prompts)
-deepvista upgrade snooze         # defer with backoff (1d → 2d → 7d)
-deepvista upgrade disable        # opt out permanently
-deepvista upgrade enable         # re-enable
-deepvista upgrade status         # show cached state
+deepvista upgrade                        # alias for `upgrade install` — interactive
+deepvista upgrade check                  # fast cached check (exit 1 if update available)
+deepvista upgrade check --no-cache       # bypass cache, re-check against PyPI
+deepvista upgrade check --quiet          # no stdout; communicate via exit code only
+deepvista upgrade install                # interactive: shows changelog, prompts y/n/snooze
+deepvista upgrade install --yes          # non-interactive: install immediately (use this in agent flows)
+deepvista upgrade install --skip-skills  # upgrade CLI only, leave skills alone
+deepvista upgrade install --dry-run      # preview what would be installed, no changes
+deepvista upgrade snooze                 # defer with escalating backoff (1d → 2d → 7d)
+deepvista upgrade snooze --days 3        # snooze for a specific number of days
+deepvista upgrade disable                # opt out permanently
+deepvista upgrade enable                 # re-enable after disable
+deepvista upgrade status                 # show current version, cached latest, snooze state
 ```
+
+> **Agent note:** `deepvista upgrade` and `deepvista upgrade install` are interactive — they
+> prompt "Install now? [y/n/snooze]". In agent flows, always use
+> `deepvista upgrade install --yes` after the user has confirmed in the conversation, so the
+> agent never blocks waiting for a terminal prompt.
 
 ## Output format
 


### PR DESCRIPTION
## Summary

- `SKILL.md`: fixes the `UPGRADE_AVAILABLE` handler to instruct agents to run `deepvista upgrade install --yes` instead of `deepvista upgrade` — the bare command is interactive and blocks on a `[y/n/snooze]` prompt the agent can never answer
- `reference/shared.md`: expands the upgrade section with the full `install` subcommand reference (all flags: `--yes`, `--skip-skills`, `--dry-run`), all `check` flags (`--quiet`, `--no-cache`), `snooze --days`, and an explicit agent note warning about the interactive prompt

## Test plan

- [ ] Reinstall the skill and trigger an upgrade check — agent should now offer `deepvista upgrade install --yes` rather than getting stuck
- [ ] Verify `deepvista upgrade install --dry-run` output matches the documented format
- [ ] Verify `deepvista upgrade snooze --days 3` works as documented

🤖 Generated with [Claude Code](https://claude.ai/claude-code)