### PR TITLE
fix(dv-workflow): create workflow skill via create-from-note + auto-sync Stop hook

### DIFF
--- a/skills/dv-workflow/SKILL.md
+++ b/skills/dv-workflow/SKILL.md
@@ -2,10 +2,11 @@
 license: Apache-2.0
 name: dv-workflow
 description: |
-  Create and track a DeepVista workflow execution card for the current Claude Code session.
-  When invoked, plans the session as named nodes, creates a skill_run card in the user's
-  vistabase, updates each node's status and output as work progresses, and writes a final
-  summary when the session ends.
+  Create and track a DeepVista workflow skill for the current Claude Code session.
+  On first invocation, captures the session goal as a note and synthesizes a
+  workflow skill via deepvista skill create-from-note. Subsequent invocations in
+  the same session reuse the existing skill. A Stop hook auto-syncs node status
+  and output to the skill card after every turn — no manual update calls needed.
 metadata:
   type: workflow
   execution: stateful
@@ -13,42 +14,68 @@ metadata:
 
 # /dv-workflow — Session Workflow Tracker
 
-Turns the current Claude Code session into a tracked workflow. Captures the goal,
-breaks it into nodes, records each node's status and output as you work, and writes
-a final summary — all stored as a `skill_run` card in the user's DeepVista vistabase.
+Turns the current Claude Code session into a tracked workflow skill stored in
+the user's DeepVista vistabase. The goal is captured as a note, a proper workflow
+skill is synthesized from it, and node status is kept in sync automatically via a
+Stop hook after every agent turn.
 
 ---
 
 ## Phase 1 — Initialize
 
-### Step 1: Capture the goal
-
-If the user typed `/dv-workflow <goal>`, use that text as the goal.
-Otherwise ask: _"What should this session accomplish? (One sentence.)"_
-
-### Step 2: Check for an existing session
+### Step 1: Check for an existing session
 
 ```bash
 cat ~/.config/deepvista/current-workflow-session.json 2>/dev/null
 ```
 
-If the file exists, ask the user:
-- **Continue** the existing workflow (skip to Phase 2, resume from the last node)
-- **Finalize** the old one first (run Phase 3 for it, then start fresh)
-- **Discard** and start fresh (delete the session file)
+If the file exists and contains a `skill_id`, **reuse the existing workflow skill** —
+skip to Phase 2 (the workflow was already created this session). Ask the user:
+- **Continue** from the last active node
+- **Finalize** the current workflow (Phase 3), then start fresh
+
+If no session file exists, continue to Step 2.
+
+### Step 2: Capture the goal
+
+If the user typed `/dv-workflow <goal>`, use that text.
+Otherwise ask: _"What should this session accomplish? (One sentence.)"_
 
 ### Step 3: Plan nodes
 
 Break the goal into 3–7 sequential, discrete nodes — the major steps you will take.
-Good node names are verb phrases: "Understand the codebase", "Implement the feature",
-"Write tests", "Open PR". Confirm the plan with the user before proceeding.
+Good names are verb phrases: "Understand the codebase", "Implement the feature",
+"Write tests", "Open PR". Show the plan and confirm with the user before proceeding.
 
-### Step 4: Create the workflow card
-
-Write the initial card body to a temp file:
+### Step 4: Capture the goal as a note
 
 ```bash
-cat > /tmp/dv-workflow-init.md << 'CARD'
+deepvista notes create \
+  --title "<goal>" \
+  --content "Session goal: <goal>
+
+## Planned nodes
+1. <node 1>
+2. <node 2>
+...
+"
+```
+
+Extract the note `id` as `NOTE_ID`.
+
+### Step 5: Synthesize the workflow skill
+
+```bash
+deepvista skill create-from-note <NOTE_ID> --kind workflow --yes
+```
+
+This streams NDJSON. Wait for the final event and extract the skill card `id` as `SKILL_ID`.
+
+### Step 6: Write the initial execution state
+
+Write the tracking body to `/tmp/dv-workflow-<SKILL_ID>.md`:
+
+```
 **Goal:** <goal>
 **Status:** running
 **Started:** <UTC ISO timestamp>
@@ -64,20 +91,16 @@ cat > /tmp/dv-workflow-init.md << 'CARD'
 ## Summary
 
 _In progress._
-CARD
 ```
 
-Create the card (confirm before running — write operation):
+Push it to the skill card:
 
 ```bash
-deepvista card create --type skill_run \
-  --title "<goal>" \
-  --content-file /tmp/dv-workflow-init.md
+deepvista card update <SKILL_ID> \
+  --content-file /tmp/dv-workflow-<SKILL_ID>.md
 ```
 
-Extract the `id` field from the JSON response. Call it `CARD_ID`.
-
-### Step 5: Write the session state file
+### Step 7: Write the session state file
 
 ```bash
 python3 - << 'PY'
@@ -85,21 +108,37 @@ import json, pathlib, datetime
 p = pathlib.Path.home() / ".config/deepvista/current-workflow-session.json"
 p.parent.mkdir(parents=True, exist_ok=True)
 p.write_text(json.dumps({
-  "card_id": "CARD_ID",
+  "skill_id": "SKILL_ID",
+  "note_id": "NOTE_ID",
   "goal": "GOAL",
   "started_at": datetime.datetime.utcnow().isoformat() + "Z",
 }, indent=2))
 PY
 ```
 
-Show the card URL: `https://app.deepvista.ai/vistabase/<CARD_ID>`
+### Step 8: Install the Stop hook (once per machine)
+
+Check if the Stop hook is already present in `~/.claude/settings.json`. If not, add it:
+
+```bash
+deepvista agents register --type claude-code
+```
+
+This installs a Stop hook that syncs the workflow card after every turn (see below).
+If `deepvista agents register` is unavailable, add the hook manually — see the
+**Stop hook** section at the bottom of this skill.
+
+Show: `https://app.deepvista.ai/vistabase/<SKILL_ID>`
 
 ---
 
 ## Phase 2 — Track each node
 
-Keep the full card body in memory throughout the session. After each meaningful
-step, update it and push the change.
+Maintain the full tracking body in `/tmp/dv-workflow-<SKILL_ID>.md` in memory.
+The Stop hook syncs this file to DeepVista automatically after each turn —
+**you do not need to call `deepvista card update` explicitly**.
+
+Just keep the temp file current:
 
 ### Node lifecycle
 
@@ -108,79 +147,73 @@ pending  →  running  →  done
                     ↘  failed
 ```
 
-- Mark a node **running** when you start working on it.
+- Mark a node **running** when you begin it.
 - Mark it **done** with a one-line output summary when it completes.
-- Mark it **failed** with the reason if it cannot be completed.
+- Mark it **failed** with the reason if it cannot complete.
 
-### Pushing an update
-
-After any status change, write the current card body to a temp file and call:
+### After each node transition — write the updated temp file
 
 ```bash
-deepvista card update <CARD_ID> \
-  --content-file /tmp/dv-workflow-<CARD_ID>.md
+cat > /tmp/dv-workflow-<SKILL_ID>.md << 'STATE'
+**Goal:** <goal>
+**Status:** running
+...updated table...
+STATE
 ```
 
-> **Update cadence:** after each node transitions state, not after every individual
-> tool call. A node that takes ten tool calls gets one update when it finishes.
+The Stop hook will pick it up and push it to DeepVista at the end of the turn.
 
 ### Adding unplanned nodes
 
-If the scope expands, append new rows with `pending` status in the next card update.
-Do not back-date completed work as a new node.
+Append new rows with `pending` status. Do not back-date completed work.
 
 ---
 
 ## Phase 3 — Finalize
 
-When the session goal is achieved, or the user explicitly ends the session:
+When the session goal is achieved or the user ends the session:
 
-### Step 1: Write the final card body
+### Step 1: Write the final state
 
-Set the top-level `**Status:**` to `done` (or `failed`).
-Write a 2–4 sentence `## Summary` covering:
+Set `**Status:**` to `done` (or `failed`). Write a 2–4 sentence `## Summary`:
 - What was accomplished
 - Key outputs or artifacts produced
 - Any remaining items or known issues
 
-### Step 2: Push the final update
+Write to `/tmp/dv-workflow-<SKILL_ID>.md` — the Stop hook will push it.
+Or push immediately:
 
 ```bash
-deepvista card update <CARD_ID> \
-  --content-file /tmp/dv-workflow-<CARD_ID>.md
+deepvista card update <SKILL_ID> \
+  --content-file /tmp/dv-workflow-<SKILL_ID>.md
 ```
 
-### Step 3: Clean up
+### Step 2: Clean up
 
 ```bash
 rm -f ~/.config/deepvista/current-workflow-session.json
 rm -f /tmp/dv-workflow-*.md
 ```
 
-Show the final card: `https://app.deepvista.ai/vistabase/<CARD_ID>`
+Show: `https://app.deepvista.ai/vistabase/<SKILL_ID>`
 
 ---
 
-## Stop hook — live heartbeat after each turn (optional)
+## Stop hook — auto-sync after every turn
 
-Add this entry under `hooks.Stop` in `~/.claude/settings.json` so the session
-file stays fresh even between explicit node updates:
+The Stop hook reads the session file, updates `last_active`, and pushes the current
+temp file to the skill card. Install once via `deepvista agents register --type claude-code`.
+
+To add manually, put this under `hooks.Stop` in `~/.claude/settings.json`:
 
 ```json
 {
   "type": "command",
-  "command": "python3 -c \"import json,pathlib,datetime; p=pathlib.Path.home()/'.config/deepvista/current-workflow-session.json'; d=json.loads(p.read_text()) if p.exists() else None; d and p.write_text(json.dumps({**d,'last_active':datetime.datetime.utcnow().isoformat()+'Z'},indent=2))\" 2>/dev/null || true"
+  "command": "python3 -c \"\nimport json, pathlib, subprocess, datetime, sys\np = pathlib.Path.home() / '.config/deepvista/current-workflow-session.json'\nif not p.exists(): sys.exit(0)\nd = json.loads(p.read_text())\nd['last_active'] = datetime.datetime.utcnow().isoformat() + 'Z'\np.write_text(json.dumps(d, indent=2))\nskill_id = d.get('skill_id', '')\ntmp = pathlib.Path(f'/tmp/dv-workflow-{skill_id}.md')\nif skill_id and tmp.exists():\n    subprocess.run(['deepvista', 'card', 'update', skill_id, '--content-file', str(tmp)], capture_output=True)\n\" 2>/dev/null || true"
 }
 ```
 
-The hook updates `last_active` in the session file after every turn. It exits
-silently when no session is active — safe to leave permanently.
-
-To install via DeepVista's hook manager instead:
-
-```bash
-deepvista agents register --type claude-code
-```
+The hook exits silently when no session is active — safe to leave permanently.
 
 ---
 
@@ -188,8 +221,8 @@ deepvista agents register --type claude-code
 
 | Rule | Detail |
 |------|--------|
-| One active workflow per session | If a session file already exists on `/dv-workflow`, ask the user what to do (continue / finalize / discard). |
-| Confirm before card create | Show the node plan and get approval before calling `deepvista card create`. |
-| Full-body updates only | Use `deepvista card update --content-file` (not `card edit`) to push state — avoids exact-string fragility. |
-| Temp file naming | Use `/tmp/dv-workflow-<CARD_ID>.md` so multiple sessions on the same machine don't collide. |
-| Don't update every tool call | Update after node transitions only — avoids API noise. |
+| Reuse the existing skill | If a session file with `skill_id` exists, skip creation and continue tracking. |
+| Workflow skill, not a raw card | Use `deepvista skill create-from-note` — produces a proper `skill` type card, not `skill_run`. |
+| Temp file is the source of truth | Write node updates to `/tmp/dv-workflow-<SKILL_ID>.md`; the Stop hook syncs it automatically. |
+| Confirm before writing | Show planned nodes and get approval before running `deepvista skill create-from-note`. |
+| One session at a time | If a session file exists on invocation, ask: continue or finalize first. |


### PR DESCRIPTION
## Summary

- **Workflow skill, not a raw card**: Phase 1 now runs `deepvista skill create-from-note <note_id> --kind workflow --yes` to produce a proper `skill`-type card instead of a `skill_run` tracking card
- **Session reuse**: on re-invocation, checks `~/.config/deepvista/current-workflow-session.json` for an existing `skill_id` and resumes tracking rather than creating a new skill
- **Auto-sync Stop hook**: the agent only needs to keep `/tmp/dv-workflow-<SKILL_ID>.md` current; the Stop hook (installed via `deepvista agents register --type claude-code`) pushes it to DeepVista after every turn automatically — no explicit `deepvista card update` calls needed from the agent during Phase 2

## Test plan

- [ ] `/dv-workflow` on a fresh session — confirm note created, skill synthesized via `create-from-note`, session file written with `skill_id`
- [ ] `/dv-workflow` again mid-session — confirm it detects existing `skill_id` and asks continue/finalize
- [ ] Complete a node — confirm temp file updated and Stop hook syncs it to the skill card
- [ ] Finalize — confirm summary written and session file cleaned up

🤖 Generated with [Claude Code](https://claude.ai/claude-code)