### PR TITLE
feat(dv-workflow): add production monitoring — timestamps, error states, metrics

### DIFF
--- a/skills/dv-workflow/SKILL.md
+++ b/skills/dv-workflow/SKILL.md
@@ -5,8 +5,8 @@ description: |
   Create and track a DeepVista workflow skill for the current Claude Code session.
   On first invocation, captures the session goal as a note and synthesizes a
   workflow skill via deepvista skill create-from-note. Subsequent invocations in
-  the same session reuse the existing skill. A Stop hook auto-syncs node status
-  and output to the skill card after every turn — no manual update calls needed.
+  the same session reuse the existing skill. A Stop hook auto-syncs node status,
+  timestamps, error details, and session metrics to the skill card after every turn.
 metadata:
   type: workflow
   execution: stateful
@@ -16,8 +16,8 @@ metadata:
 
 Turns the current Claude Code session into a tracked workflow skill stored in
 the user's DeepVista vistabase. The goal is captured as a note, a proper workflow
-skill is synthesized from it, and node status is kept in sync automatically via a
-Stop hook after every agent turn.
+skill is synthesized from it, and node status (including timestamps, error details,
+and session metrics) is kept in sync automatically via a Stop hook after every turn.
 
 ---
 
@@ -30,7 +30,7 @@ cat ~/.config/deepvista/current-workflow-session.json 2>/dev/null
 ```
 
 If the file exists and contains a `skill_id`, **reuse the existing workflow skill** —
-skip to Phase 2 (the workflow was already created this session). Ask the user:
+skip to Phase 2. Ask the user:
 - **Continue** from the last active node
 - **Finalize** the current workflow (Phase 3), then start fresh
 
@@ -43,9 +43,9 @@ Otherwise ask: _"What should this session accomplish? (One sentence.)"_
 
 ### Step 3: Plan nodes
 
-Break the goal into 3–7 sequential, discrete nodes — the major steps you will take.
-Good names are verb phrases: "Understand the codebase", "Implement the feature",
-"Write tests", "Open PR". Show the plan and confirm with the user before proceeding.
+Break the goal into 3–7 sequential, discrete nodes. Good names are verb phrases:
+"Understand the codebase", "Implement the feature", "Write tests", "Open PR".
+Show the plan and confirm with the user before proceeding.
 
 ### Step 4: Capture the goal as a note
 
@@ -69,7 +69,7 @@ Extract the note `id` as `NOTE_ID`.
 deepvista skill create-from-note <NOTE_ID> --kind workflow --yes
 ```
 
-This streams NDJSON. Wait for the final event and extract the skill card `id` as `SKILL_ID`.
+Wait for the final NDJSON event and extract the skill card `id` as `SKILL_ID`.
 
 ### Step 6: Write the initial execution state
 
@@ -82,18 +82,23 @@ Write the tracking body to `/tmp/dv-workflow-<SKILL_ID>.md`:
 
 ## Nodes
 
-| # | Node | Status | Output |
-|---|------|--------|--------|
-| 1 | <node 1> | pending |  |
-| 2 | <node 2> | pending |  |
+| # | Node | Status | Started | Duration | Output |
+|---|------|--------|---------|----------|--------|
+| 1 | <node 1> | pending |  |  |  |
+| 2 | <node 2> | pending |  |  |  |
 ...
+
+## Metrics
+
+- Nodes: 0/<total> done, 0 failed
+- Elapsed: 0m
 
 ## Summary
 
 _In progress._
 ```
 
-Push it to the skill card:
+Push it:
 
 ```bash
 deepvista card update <SKILL_ID> \
@@ -111,22 +116,23 @@ p.write_text(json.dumps({
   "skill_id": "SKILL_ID",
   "note_id": "NOTE_ID",
   "goal": "GOAL",
-  "started_at": datetime.datetime.utcnow().isoformat() + "Z",
+  "started_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+  "current_node": 1,
+  "error": None,
 }, indent=2))
 PY
 ```
 
-### Step 8: Install the Stop hook (once per machine)
+### Step 8: Ensure Stop hook is installed
 
-Check if the Stop hook is already present in `~/.claude/settings.json`. If not, add it:
+Check `~/.claude/settings.json` for a Stop hook containing `current-workflow-session`.
+If absent, install via:
 
 ```bash
 deepvista agents register --type claude-code
 ```
 
-This installs a Stop hook that syncs the workflow card after every turn (see below).
-If `deepvista agents register` is unavailable, add the hook manually — see the
-**Stop hook** section at the bottom of this skill.
+Or add manually — see the **Stop hook** section below.
 
 Show: `https://app.deepvista.ai/vistabase/<SKILL_ID>`
 
@@ -134,38 +140,79 @@ Show: `https://app.deepvista.ai/vistabase/<SKILL_ID>`
 
 ## Phase 2 — Track each node
 
-Maintain the full tracking body in `/tmp/dv-workflow-<SKILL_ID>.md` in memory.
-The Stop hook syncs this file to DeepVista automatically after each turn —
-**you do not need to call `deepvista card update` explicitly**.
-
-Just keep the temp file current:
+Maintain the full tracking body in `/tmp/dv-workflow-<SKILL_ID>.md`.
+The Stop hook syncs it after every turn — **no explicit `deepvista card update` needed**.
 
 ### Node lifecycle
 
 ```
 pending  →  running  →  done
-                    ↘  failed
+                    ↘  failed   (task could not complete — expected outcome)
+                    ↘  error    (unexpected tool crash / exception)
 ```
 
-- Mark a node **running** when you begin it.
-- Mark it **done** with a one-line output summary when it completes.
-- Mark it **failed** with the reason if it cannot complete.
+### Node table schema
 
-### After each node transition — write the updated temp file
+| Column | Content |
+|--------|---------|
+| `#` | Node index |
+| `Node` | Verb-phrase description |
+| `Status` | `pending` / `running` / `done` / `failed` / `error` |
+| `Started` | UTC time when node went `running` (e.g. `14:32`) |
+| `Duration` | Elapsed time when node left `running` (e.g. `3m 12s`) |
+| `Output` | One-line result, error message, or artifact name |
+
+### When to update
+
+| Event | Action |
+|-------|--------|
+| Starting a node | Status → `running`, record `Started` |
+| Node completes | Status → `done`, fill `Duration` and `Output` |
+| Task cannot be done | Status → `failed`, fill `Output` with reason |
+| Tool threw an exception | Status → `error`, fill `Output` with error summary |
+| Scope expands | Append new rows with `pending` — do not back-date |
+
+### After each transition — write the updated temp file
 
 ```bash
 cat > /tmp/dv-workflow-<SKILL_ID>.md << 'STATE'
 **Goal:** <goal>
 **Status:** running
-...updated table...
+**Started:** <ISO>
+
+## Nodes
+
+| # | Node | Status | Started | Duration | Output |
+|---|------|--------|---------|----------|--------|
+| 1 | <node 1> | done | 14:30 | 2m | <output> |
+| 2 | <node 2> | running | 14:32 |  |  |
+...
+
+## Metrics
+
+- Nodes: 1/<total> done, 0 failed
+- Elapsed: <Xm>
+
+## Summary
+
+_In progress._
 STATE
 ```
 
-The Stop hook will pick it up and push it to DeepVista at the end of the turn.
+The Stop hook picks it up at end-of-turn.
 
-### Adding unplanned nodes
+### Error capture
 
-Append new rows with `pending` status. Do not back-date completed work.
+If a Bash command or tool fails unexpectedly, capture the details immediately:
+
+```bash
+# Update the current node to error status
+# Replace | 2 | <node name> | running | ... |
+# with    | 2 | <node name> | error   | 14:32 | 0m 5s | <error summary> |
+```
+
+Record a brief error summary in `Output` (tool name, exit code, first line of stderr).
+Then decide: retry the node, mark it `failed` and continue, or stop the session.
 
 ---
 
@@ -175,13 +222,16 @@ When the session goal is achieved or the user ends the session:
 
 ### Step 1: Write the final state
 
-Set `**Status:**` to `done` (or `failed`). Write a 2–4 sentence `## Summary`:
-- What was accomplished
-- Key outputs or artifacts produced
-- Any remaining items or known issues
+- Set `**Status:**` to `done` (or `failed` / `error`)
+- Fill all remaining `Duration` values
+- Update `## Metrics` with final counts and total elapsed time
+- Write a 2–4 sentence `## Summary`:
+  - What was accomplished
+  - Key outputs or artifacts
+  - Any remaining items or known issues
 
-Write to `/tmp/dv-workflow-<SKILL_ID>.md` — the Stop hook will push it.
-Or push immediately:
+Write to `/tmp/dv-workflow-<SKILL_ID>.md` (the Stop hook will sync it),
+or push immediately:
 
 ```bash
 deepvista card update <SKILL_ID> \
@@ -201,19 +251,40 @@ Show: `https://app.deepvista.ai/vistabase/<SKILL_ID>`
 
 ## Stop hook — auto-sync after every turn
 
-The Stop hook reads the session file, updates `last_active`, and pushes the current
-temp file to the skill card. Install once via `deepvista agents register --type claude-code`.
+Reads the session file, updates `last_active`, and pushes the temp file to the
+skill card. Install once via `deepvista agents register --type claude-code`.
 
-To add manually, put this under `hooks.Stop` in `~/.claude/settings.json`:
+To add manually under `hooks.Stop` in `~/.claude/settings.json`:
 
 ```json
 {
   "type": "command",
-  "command": "python3 -c \"\nimport json, pathlib, subprocess, datetime, sys\np = pathlib.Path.home() / '.config/deepvista/current-workflow-session.json'\nif not p.exists(): sys.exit(0)\nd = json.loads(p.read_text())\nd['last_active'] = datetime.datetime.utcnow().isoformat() + 'Z'\np.write_text(json.dumps(d, indent=2))\nskill_id = d.get('skill_id', '')\ntmp = pathlib.Path(f'/tmp/dv-workflow-{skill_id}.md')\nif skill_id and tmp.exists():\n    subprocess.run(['deepvista', 'card', 'update', skill_id, '--content-file', str(tmp)], capture_output=True)\n\" 2>/dev/null || true"
+  "command": "python3 -c \"import json,pathlib,subprocess,datetime,sys; p=pathlib.Path.home()/'.config/deepvista/current-workflow-session.json'; d=json.loads(p.read_text()) if p.exists() else None; d and [p.write_text(json.dumps({**d,'last_active':datetime.datetime.now(datetime.timezone.utc).isoformat()},indent=2)),pathlib.Path(f\\\"/tmp/dv-workflow-{d.get('skill_id','')}.md\\\").exists() and subprocess.run(['deepvista','card','update',d.get('skill_id',''),'--content-file',f\\\"/tmp/dv-workflow-{d.get('skill_id','')}.md\\\"],capture_output=True)]\" 2>/dev/null || true"
 }
 ```
 
-The hook exits silently when no session is active — safe to leave permanently.
+The hook exits silently when no session is active.
+
+---
+
+## Optional: PostToolUse error-capture hook
+
+To automatically flag Bash failures into the session file, add under `hooks.PostToolUse`:
+
+```json
+{
+  "matcher": "Bash",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "python3 -c \"\nimport json,pathlib,sys,datetime\ndata=json.load(sys.stdin)\nif data.get('tool_response',{}).get('exit_code',0)==0: sys.exit(0)\np=pathlib.Path.home()/'.config/deepvista/current-workflow-session.json'\nif not p.exists(): sys.exit(0)\nd=json.loads(p.read_text())\nd['last_error']={'cmd':data.get('tool_input',{}).get('command','')[:120],'exit_code':data['tool_response'].get('exit_code'),'at':datetime.datetime.now(datetime.timezone.utc).isoformat()}\np.write_text(json.dumps(d,indent=2))\n\" 2>/dev/null || true"
+    }
+  ]
+}
+```
+
+This writes `last_error` to the session file whenever a Bash command exits non-zero.
+The agent can read it on the next turn to fill the node's `Output` field accurately.
 
 ---
 
@@ -221,8 +292,10 @@ The hook exits silently when no session is active — safe to leave permanently.
 
 | Rule | Detail |
 |------|--------|
-| Reuse the existing skill | If a session file with `skill_id` exists, skip creation and continue tracking. |
-| Workflow skill, not a raw card | Use `deepvista skill create-from-note` — produces a proper `skill` type card, not `skill_run`. |
-| Temp file is the source of truth | Write node updates to `/tmp/dv-workflow-<SKILL_ID>.md`; the Stop hook syncs it automatically. |
-| Confirm before writing | Show planned nodes and get approval before running `deepvista skill create-from-note`. |
-| One session at a time | If a session file exists on invocation, ask: continue or finalize first. |
+| Reuse within session | If session file has `skill_id`, skip creation and continue. |
+| Workflow skill, not a raw card | Use `deepvista skill create-from-note` — produces `type=skill`. |
+| Temp file is source of truth | Write all state to `/tmp/dv-workflow-<SKILL_ID>.md`; Stop hook syncs it. |
+| Timestamps on every node | Record `Started` when going `running`; `Duration` when leaving it. |
+| Errors are first-class | `error` ≠ `failed`: error means the tool broke, failed means the task couldn't be done. |
+| Metrics stay current | Update the `## Metrics` block on every state change. |
+| Confirm before creating | Show node plan and get approval before `deepvista skill create-from-note`. |


### PR DESCRIPTION
## Summary

- **Node timestamps**: `Started` (when node goes `running`) and `Duration` (when it leaves) columns added to the node table
- **Error vs failed states**: `error` (tool crash/exception) is now distinct from `failed` (task couldn't be done) — both carry a one-line `Output` summary
- **Metrics block**: `## Metrics` section in the card body tracks nodes done/failed and total elapsed time, updated on every state change
- **PostToolUse Bash hook spec**: optional hook that writes `last_error` (command, exit code, timestamp) into the session file on any non-zero Bash exit — agent reads it next turn to fill `Output` accurately
- **Session file extended**: gains `current_node` index and `error` field for hook-driven error capture
- **Stop hook now in global settings**: `~/.claude/settings.json` updated with the auto-sync hook (merged alongside existing Stop hooks)

## Test plan

- [ ] Start `/dv-workflow` — confirm node table includes Started/Duration columns
- [ ] Complete a node — confirm Started and Duration are filled in the card
- [ ] Trigger a Bash failure — confirm `last_error` written to session file, node marked `error`
- [ ] Finalize — confirm Metrics shows correct counts and elapsed time
- [ ] Verify `gh skill publish --dry-run` passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)