### PR TITLE
refactor(skills): slim reference files — remove --help rewrites

### DIFF
--- a/skills/deepvista/SKILL.md
+++ b/skills/deepvista/SKILL.md
@@ -121,6 +121,8 @@ If the source material isn't yet a DeepVista note, capture it first
    to read from stdin) so the exact bytes are stored.
 4. **Read-only commands are safe.** `list`, `get`, `+search`, `+grep`, `+similar`,
    `show`, `discover`, `export`, `status` — run without confirmation.
+5. **Check `--help` for exact flags.** When you need exact flag syntax or available options,
+   run `deepvista <subcommand> --help` rather than guessing from memory.
 
 ## See also
 

--- a/skills/deepvista/reference/chat.md
+++ b/skills/deepvista/reference/chat.md
@@ -1,76 +1,44 @@
 # Chat — send messages to the DeepVista AI agent
 
-The agent can search the user's knowledge base, create cards, run web searches, and
-call tools. All output on write streams as NDJSON.
+The agent can search the knowledge base, create cards, run web searches, and call
+tools. Run `deepvista chat --help` or `deepvista chat <cmd> --help` for full flag
+reference.
 
 ## Commands
 
-### `sessions` — read-only
+`sessions` · `get` · `delete` · `+send`
 
-```bash
-deepvista chat sessions [--limit N] [--offset N] [--search "query"]
-```
+## Agent conventions
 
-List chat sessions. `--search` matches on the session summary.
+> [!CAUTION] `+send` may cause the agent to create cards and write to vistabase.
+> Confirm first. `delete` is destructive — confirm first.
 
-### `get` — read-only
+Read-only: `sessions`, `get`.
 
-```bash
-deepvista chat get <chat_id>
-```
+## NDJSON event format (non-obvious)
 
-Returns session metadata (`id`, `summary`, `created_at`, `status`). Full message
-history is not included by this endpoint — use the app UI or `+send --chat-id` to
-continue the conversation.
-
-### `delete` — destructive
-
-> [!CAUTION] Destructive. Confirm first.
-
-```bash
-deepvista chat delete <chat_id>
-```
-
-### `+send` — write
-
-> [!CAUTION] Sends a message. The agent may create cards, call tools, and write to
-> vistabase. Confirm first.
-
-```bash
-deepvista chat +send "your message" [--chat-id ID] [--new]
-```
-
-| Flag | Required | Default | Purpose |
-|---|---|---|---|
-| `<message>` | yes | — | Text to send |
-| `--chat-id ID` | no | — | Continue an existing session |
-| `--new` | no | `false` | Force a new session (ignore any cached `--chat-id`) |
-
-## NDJSON event format
-
-`+send` streams events as the agent responds. One JSON object per line.
+`+send` streams one JSON object per line. Key fields to parse:
 
 ```json
-{"type": "chat_session", "id": "abc123", ...}
-{"type": "page", "page": {"user_instruction": "...", ...}}
+{"type": "chat_session", "id": "abc123"}
+```
+First event — save `id` to continue the conversation later.
+
+```json
 {"type": "page_delta", "parts": [
-  {"type": "tool_result", "output": "partial response text...", "done": false}
-], "page_index": 0}
+  {"type": "tool_result", "output": "full text so far", "done": false}
+]}
+```
+`output` is the **full accumulated text**, not an incremental delta. Diff against the
+previous `output` to print only new content, or just overwrite.
+
+```json
 {"type": "page_delta", "parts": [
-  {"type": "tool_result", "output": "full response text", "done": true,
+  {"type": "tool_result", "output": "final text", "done": true,
    "options": ["follow-up 1", "follow-up 2"]}
 ]}
 ```
-
-Key fields:
-
-- `type: "chat_session"` — first event; save `id` for continuation.
-- `type: "page_delta"` → `parts[].type: "tool_result"` — the agent's text.
-  `output` is the **full accumulated text so far**, not an incremental delta.
-- `parts[].done: true` — final chunk. `options` may contain suggested follow-ups.
-
-Agents parsing the stream should diff against the previous `output` to print only the
-new portion, or just overwrite on each event.
+`done: true` = final chunk. `options` may contain suggested follow-ups.
 
 ## Examples
 
@@ -81,11 +49,7 @@ deepvista chat +send "What are my open tasks?" --new
 # Continue
 deepvista chat +send "Tell me more about the first one" --chat-id abc123
 
-# Ask the agent to create a note
-deepvista chat +send "Create a note summarizing our ML strategy discussion"
-
-# List / search
-deepvista chat sessions --limit 5
+# Search sessions
 deepvista chat sessions --search "roadmap"
 ```
 

--- a/skills/deepvista/reference/lint.md
+++ b/skills/deepvista/reference/lint.md
@@ -1,107 +1,54 @@
 # Lint — LLM health checks over the vistabase
 
-`deepvista lint` asks the DeepVista agent to audit the knowledge base for
-quality issues: duplicates, contradictions, stale claims, orphan cards,
-missing cross-references, and data gaps. Inspired by
-[karpathy's LLM health-check idea](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
+`deepvista lint` asks the DeepVista agent to audit the knowledge base for quality
+issues. Run `deepvista lint --help` for full flag reference.
 
-The agent uses `find_similar_cards`, `chat_cypher_search`, and `exa_search`
-to investigate, then streams a numbered findings list back as NDJSON
-(same format as `chat +send`).
+## Agent conventions
 
-## Command
+> [!CAUTION] Calls the DeepVista agent. With `--fix`, the agent may merge, update, or
+> delete cards. Confirm with the user before executing. Scheduled `--fix` runs must
+> pass `--yes` to accept non-interactively.
 
-### `lint` — write (agent invocation)
+Read-only: `deepvista lint --dry-run` (prints the prompt without calling the agent).
 
-> [!CAUTION] Calls the DeepVista agent. With `--fix`, the agent may merge,
-> update, or delete cards. Confirm with the user before executing.
+## Check kinds
+
+| `--check` | What it looks for |
+|---|---|
+| `duplicates` | Near-duplicate cards (semantic). |
+| `contradictions` | Cards whose claims conflict. |
+| `stale` | Content likely out of date. |
+| `orphans` | Cards with no inbound refs or relationships. |
+| `missing-refs` | Concepts mentioned but lacking their own card. |
+| `gaps` | Under-described entities that could be enriched. |
+| `all` | All of the above (default). |
+
+## Scheduling
+
+Lint is most useful run periodically so the vistabase stays clean as it grows.
 
 ```bash
-deepvista lint [--check KIND]... [--fix] [--chat-id ID] [--dry-run]
+# Claude Code — self-pacing background loop
+/loop deepvista lint --check duplicates
+
+# Persistent schedule (survives session end)
+/schedule "every 4 hours" deepvista lint --check duplicates
+/schedule "weekly" deepvista lint --fix --yes
+
+# cron (any agent)
+0 */4 * * *  deepvista lint --check duplicates >> ~/.config/deepvista/logs/lint.log 2>&1
 ```
-
-| Flag | Default | Purpose |
-|---|---|---|
-| `--check KIND` | `all` | Scope: `duplicates`, `contradictions`, `stale`, `orphans`, `missing-refs`, `gaps`, `all`. Repeatable. |
-| `--fix` | off | Let the agent apply fixes (merge duplicates, update stale cards, link orphans). Default is report-only. |
-| `--chat-id ID` | — | Continue an existing lint session. |
-| `--dry-run` | — | Print the prompt that would be sent to the agent without calling it. |
-
-## Checks
-
-| Check | What it looks for |
-|---|---|
-| `duplicates` | Near-duplicate cards (semantic). Canonical vs. loser. |
-| `contradictions` | Cards whose claims conflict — newer source supersedes older. |
-| `stale` | Content likely out of date relative to newer cards or general knowledge. |
-| `orphans` | Cards with no inbound refs or graph relationships. |
-| `missing-refs` | Concepts mentioned but lacking their own card. |
-| `gaps` | Under-described entities that could be filled with a web search. |
 
 ## Examples
 
 ```bash
-# Full health check, report only
-deepvista lint
-
-# Just duplicates
+deepvista lint                                              # full check, report only
 deepvista lint --check duplicates
-
-# Duplicates + contradictions, let the agent fix
 deepvista lint --check duplicates --check contradictions --fix
-
-# Preview the prompt
 deepvista lint --dry-run
 ```
 
-## Scheduling (periodic linting)
-
-The whole point of lint is to run it periodically so the vistabase stays
-clean as it grows. Two good cadences:
-
-- **Every 4 hours:** catch freshly-added cards before they drift.
-- **Weekly:** full `--fix` pass.
-
-### Claude Code — background /loop
-
-```bash
-# In a Claude Code session, kick off a self-pacing loop.
-# /loop without an explicit interval runs indefinitely — stop it with /stop.
-/loop deepvista lint --check duplicates
-```
-
-Or schedule it persistently with the `schedule` skill (survives session end):
-
-```bash
-/schedule "every 4 hours" deepvista lint --check duplicates
-/schedule "weekly" deepvista lint --fix --yes
-```
-
-`--fix` normally prompts for confirmation; scheduled runs must pass `--yes`
-to accept the write blast radius non-interactively.
-
-### Cursor Agent — cron
-
-Cursor doesn't ship a native scheduler. Use system cron. Log into the
-existing CLI config directory so logs live next to credentials and respect
-`DEEPVISTA_CONFIG_DIR`:
-
-```cron
-# One-time setup: mkdir -p ~/.config/deepvista/logs
-#
-# Every 4 hours: lint + re-index notes.
-0 */4 * * *  deepvista lint --check duplicates >> ~/.config/deepvista/logs/lint.log 2>&1
-15 */4 * * * deepvista notes index --limit 50  >> ~/.config/deepvista/logs/index.log 2>&1
-```
-
-### Any agent — `at` / launchd / systemd
-
-`deepvista lint` is stdout-friendly (NDJSON), so pipe it into whatever job
-runner you already have.
-
 ## See also
 
-- [notes.md](notes.md) — `deepvista notes index` triggers entity extraction
-  on individual notes; often paired with `lint --check missing-refs`.
-- [chat.md](chat.md) — `lint` is a curated variant of `chat +send`; the
-  NDJSON event format is identical.
+- [notes.md](notes.md) — `deepvista notes index` for entity extraction on individual notes
+- [chat.md](chat.md) — lint uses the same NDJSON event format as `chat +send`

--- a/skills/deepvista/reference/notes.md
+++ b/skills/deepvista/reference/notes.md
@@ -1,241 +1,75 @@
 # Notes — quick capture and CRUD
 
-Notes are shorthand for knowledge cards with `type=note`. Everything here is
-equivalent to the matching `deepvista card --type note ...` call.
-
-Global flags and authentication: see [shared.md](shared.md).
+Notes are shorthand for `card --type note`. Run `deepvista notes --help` or
+`deepvista notes <cmd> --help` for full flag reference.
 
 ## Commands
 
-### `list` — read-only
+`list` · `get` · `create` · `update` · `delete` · `index` · `+quick`
+`session-init` · `session-tick` · `session-finalize` · `history` · `diff` · `restore`
 
+## Agent conventions
+
+> [!CAUTION] `create`, `update`, `delete`, `index`, `restore`, `session-*` are writes.
+> Confirm with the user first (except `+quick` in auto-capture mode — see [openclaw.md](openclaw.md)).
+
+- **Always use `--content-file <absolute-path>`** for anything more than ~200 chars or
+  containing newlines. Never paste large content inline. Pass `-` to read from stdin.
+- Show the app URL after any write: `https://app.deepvista.ai/notes/<id>`
+- Use `--dry-run` to preview without writing.
+
+## Non-obvious commands
+
+**`+quick`** — single-line fast capture. First ~50 chars become the title:
 ```bash
-deepvista notes list [--limit N] [--page N]
+deepvista notes +quick "Alice confirmed the API deadline is April 15"
 ```
 
-Returns titles, ids, and update timestamps. Default page size is 20.
+**`index`** — queues entity extraction + embedding refresh on unprocessed notes.
+Run after bulk imports or after a long offline period. Pair with
+`deepvista lint --check missing-refs`.
 
-### `get` — read-only
+**`session-init` / `session-tick` / `session-finalize`** — rolling session note hooks
+used by the DeepVista Claude Code plugin. `session-init` is idempotent (safe in
+`SessionStart`); `session-tick` appends turn summaries; `session-finalize` marks
+`status: complete` and queues enrichment.
 
-```bash
-deepvista notes get <note_id>
-```
+**`history` / `diff` / `restore`** — version history. `restore` captures the current
+state as a new version first, so it's reversible.
 
-Returns the full note including the markdown body. Use this before editing.
-
-### `create` — write
-
-> [!CAUTION] Creates a note. Confirm with the user first.
-
-```bash
-deepvista notes create --title "Title" [--content "..."] [--content-file PATH] [--tags '["t1","t2"]']
-```
-
-| Flag | When |
-|---|---|
-| `--title` | required |
-| `--content` | short inline content only — ≤200 chars, no newlines |
-| `--content-file PATH` | **preferred** for anything bigger. Use an absolute path. `--content-file -` reads from stdin. |
-| `--tags` | JSON array of strings |
-| `--dry-run` | preview without writing |
-
-**Always use `--content-file` for large content, files, or URLs.** Never paraphrase —
-the file contents are stored verbatim.
-
-### `update` — write
-
-> [!CAUTION] Modifies an existing note. Confirm first.
-
-```bash
-deepvista notes update <note_id> [--title "..."] [--content "..."] [--content-file PATH] [--tags '["t1"]']
-```
-
-Same content rules as `create`. Only provided fields are changed.
-
-### `delete` — destructive
-
-> [!CAUTION] Destructive. Confirm first.
-
-```bash
-deepvista notes delete <note_id>
-```
-
-### `index` — write
-
-> [!CAUTION] Queues the DeepVista agent to run entity extraction + graph
-> linking + embedding refresh on unprocessed notes. Confirm first.
-
-```bash
-deepvista notes index [--limit N] [--note-id ID]... [--all] [--dry-run]
-```
-
-| Flag | When |
-|---|---|
-| `--limit N` | Max notes to process (default 50, max 500, newest first) |
-| `--note-id ID` | Target specific note(s). Repeatable. Implies re-enrichment — the unenriched filter is dropped for explicit IDs, and `--all` is redundant. |
-| `--all` | Re-enrich every note up to `--limit`, not just those with a null embedding. Ignored when `--note-id` is set. |
-| `--dry-run` | Preview the request without calling the backend |
-
-Posts to the server-side `/index_notes` route, which enqueues one chat task
-per card using the same pipeline `create_context_card` uses. Use after
-bulk-importing notes, after a long offline period, or when entities appear
-missing from the graph. Pair with `deepvista lint --check missing-refs` to
-find concepts that still need their own card.
-
-### `session-init` — write
-
-> [!CAUTION] Creates a rolling note on first call per `session-id`. Meant
-> for agent SessionStart hooks; confirm before running by hand.
-
-```bash
-deepvista notes session-init \
-  --session-id <id> \
-  --transcript <path> \
-  --cwd <dir> \
-  [--agent claude-code] [--agent-version X.Y.Z] [--dry-run]
-```
-
-Idempotent. Looks up an existing session note by `cc-session:<id>` tag; if
-none, creates one with seeded frontmatter (agent, project_dir, git branch/commit,
-started_at, status=active). Caches the resolved `note_id` at
-`$XDG_STATE_HOME/deepvista/sessions/<session-id>.json` so every subsequent
-`session-tick` is a single HTTP call.
-
-### `session-tick` — write
-
-> [!CAUTION] Appends a new turn block and bumps the note's version.
-
-```bash
-deepvista notes session-tick \
-  --session-id <id> \
-  --transcript <path> \
-  [--dry-run]
-```
-
-Parses the transcript JSONL, extracts turns newer than `last_turn_index`
-from the cache, renders a heuristic summary per turn (first ~400 chars of
-user/assistant + tool counts + files touched), prepends it inside
-`## Turns`, and updates `turn_count` / `version` / `updated_at` in the
-frontmatter. Body capped at ~50 KB — oldest turns are dropped first.
-
-### `session-finalize` — write
-
-> [!CAUTION] Flips status to `complete` and queues enrichment.
-
-```bash
-deepvista notes session-finalize \
-  --session-id <id> \
-  [--transcript <path>] \
-  [--no-enrich] [--dry-run]
-```
-
-Marks the frontmatter `status: complete` and calls `/index_notes` on the
-session note. Pass `--transcript` to flush any remaining turns first.
-
-### `history` — read-only
-
-```bash
-deepvista notes history <note_id> [--limit N]
-```
-
-List prior versions of a note (newest first). Returns `version`, `reason`,
-`changed_by`, `created_at`. Backed by `/get_context_card_history`.
-
-### `diff` — read-only
-
-```bash
-deepvista notes diff <note_id> <from_version> <to_version>
-```
-
-Unified diff between two versions of a note. In `--format table` mode the
-diff is printed directly; in `--format json` it is returned under `.diff`.
-
-### `restore` — write (reversible)
-
-> [!CAUTION] Rolls the note back. Current state is captured as a new
-> version first so restore itself is reversible.
-
-```bash
-deepvista notes restore <note_id> <version> [--yes] [--dry-run]
-```
-
-Backed by `/restore_context_card_version`. The server's UPDATE trigger
-captures the pre-restore state, so you can always `restore` again to the
-prior `version`.
-
-### Hook installation (Claude Code)
-
-Install the DeepVista Claude Code plugin — it registers all three hooks
-(`SessionStart`, `Stop`, `SessionEnd`) automatically:
+### Hook installation (Claude Code plugin)
 
 ```
 /plugin marketplace add DeepVista-AI/deepvista-cli
 /plugin install deepvista@deepvista-ai
 ```
 
-The plugin ships the canonical scripts at
-`${CLAUDE_PLUGIN_ROOT}/hooks/deepvista-session-{start,turn,end}.sh`.
-
-Manual install (non-plugin users): copy the scripts from
-`plugins/claude-code/hooks/` in the repo into `~/.claude/hooks/` and
-reference them in `~/.claude/settings.json`:
-
-```json
-{
-  "hooks": {
-    "SessionStart": [
-      { "hooks": [{ "type": "command", "command": "$HOME/.claude/hooks/deepvista-session-start.sh" }] }
-    ],
-    "Stop": [
-      { "hooks": [{ "type": "command", "command": "$HOME/.claude/hooks/deepvista-session-turn.sh" }] }
-    ],
-    "SessionEnd": [
-      { "hooks": [{ "type": "command", "command": "$HOME/.claude/hooks/deepvista-session-end.sh" }] }
-    ]
-  }
-}
-```
-
-Every script is non-blocking (`&` background) so Claude Code latency is
-unaffected. Scripts silently no-op if `deepvista` is not on `PATH` or
-auth is missing.
-
-### `+quick` — write
-
-> [!CAUTION] Writes a new note. Confirm first (or skip confirmation if the agent is
-> running as an auto-capture hook — see [openclaw.md](openclaw.md)).
-
-```bash
-deepvista notes +quick "your text here"
-```
-
-Single-line quick capture. First ~50 characters of the text become the title; the full
-text is saved as the body.
+Manual install: copy `plugins/claude-code/hooks/` into `~/.claude/hooks/` and wire
+`SessionStart`, `Stop`, and `SessionEnd` in `~/.claude/settings.json`.
 
 ## Examples
 
 ```bash
-# List recent
-deepvista notes list --limit 5
-
-# Structured note
-deepvista notes create \
-  --title "Standup 2026-04-20" \
-  --content-file /tmp/standup-notes.md \
-  --tags '["standup","team"]'
-
 # Quick capture
-deepvista notes +quick "Alice mentioned the API migration deadline is April 15"
+deepvista notes +quick "Decided to drop legacy auth middleware — compliance req"
 
-# Read-then-edit
-deepvista notes get note_abc123
-deepvista notes update note_abc123 --title "Standup — April 20"
+# Structured note from file
+deepvista notes create --title "Standup 2026-04-20" \
+  --content-file /tmp/standup.md --tags '["standup"]'
+
+# Read then edit
+deepvista notes get <note_id>
+deepvista notes update <note_id> --title "Standup — April 20"
 
 # From stdin
-curl -s https://example.com/page.md | \
+curl -sL https://example.com/page.md | \
   deepvista notes create --title "Reference page" --content-file -
+
+# Index after bulk import
+deepvista notes index --limit 100
 ```
 
-## After a write
+## See also
 
-Show the user the app URL: `https://app.deepvista.ai/notes/<id>`.
+- [vistabase-card.md](vistabase-card.md) — underlying `card --type note` commands
+- [openclaw.md](openclaw.md) — auto-capture without confirmation

--- a/skills/deepvista/reference/shared.md
+++ b/skills/deepvista/reference/shared.md
@@ -1,16 +1,7 @@
 # Shared — auth, profiles, global flags, exit codes
 
 Foundational reference for every `deepvista` subcommand. Read this first.
-
-## Install
-
-```bash
-uv tool install 'deepvista-cli[ui]'   # preferred
-pip install 'deepvista-cli[ui]'       # alternative
-```
-
-The `[ui]` extra adds the optional terminal UI (`deepvista ui`). Omit to keep the
-CLI-only install small.
+Run `deepvista --help` or `deepvista <subcommand> --help` for full flag reference.
 
 ## Authentication
 
@@ -22,26 +13,19 @@ deepvista auth logout                 # clear credentials
 ```
 
 Credentials live in `~/.config/deepvista/credentials.json` (mode `0600`).
-Re-run `auth login` after `logout` to get a new token.
 
-## Global flags (must come BEFORE the resource name)
+## Global flags — must come BEFORE the resource name
 
 ```
 deepvista [GLOBAL FLAGS] <resource> <command> [options]
 ```
 
-| Flag | Default | Purpose |
-|---|---|---|
-| `--profile NAME` | `default` | Switch between profiles (e.g. `staging`, `prod`) |
-| `--format json\|table` | `json` | `json` is agent-friendly; `table` is human-readable |
-| `--verbose` | off | Print request/response details |
-| `--dry-run` | off | Preview without writing (supported on every stateful command) |
-| `--api-url URL` | — | Override the API base URL |
-| `--version` | — | Print CLI version and exit |
-| `--help` | — | Context-sensitive help |
-
 **Wrong:** `deepvista card list --profile staging`
 **Right:** `deepvista --profile staging card list`
+
+Key global flags: `--profile NAME`, `--format json|table`, `--verbose`, `--dry-run`, `--api-url URL`.
+
+`--dry-run` is supported on every stateful command — use it to preview before writing.
 
 ## Profiles
 
@@ -49,49 +33,28 @@ deepvista [GLOBAL FLAGS] <resource> <command> [options]
 deepvista config list                 # list configured profiles
 ```
 
-Each profile has its own credentials, so you can hold separate tokens for `default`,
-`staging`, `prod`, etc. Profile state lives in `~/.config/deepvista/`.
-
-## Resources and support commands
-
-| Resource | What it manages |
-|---|---|
-| `card` | Knowledge base entries of every type (note, person, topic, file, …) |
-| `notes` | Convenience wrapper over `card --type note` |
-| `skill` | Structured workflows (formerly "recipes") |
-| `vistabase` (alias: `memory`) | Implicit memory auto-accumulated from chat |
-| `chat` | AI agent sessions |
-| `auth`, `config`, `upgrade`, `agents`, `ui` | CLI plumbing |
+Each profile holds separate credentials. Profile state lives in `~/.config/deepvista/`.
 
 ## Agent registration & heartbeat
 
-DeepVista tracks which AI agent is running the CLI so the dashboard can show each
-agent's state and config. On first skill load, register once:
+Register once per machine so the DeepVista dashboard shows this agent's state:
 
 ```bash
 deepvista agents register --type claude-code --name "My Claude"
 ```
 
-This records the agent and installs a `Stop` hook in `~/.claude/settings.json` that
-calls `deepvista agents sync --type claude-code --status online` after each turn. The
-hook produces a heartbeat every conversation turn — an agent idle for 10+ minutes
-shows as offline in the dashboard. Other supported types: `opencode`, `cursor`,
-`windsurf`, `cline`, `aider`, `openclaw`, `deepvista-cli`, `github-copilot`.
+This installs a `Stop` hook in `~/.claude/settings.json` that sends a heartbeat after each turn.
 
 ```bash
-deepvista agents get --type claude-code      # check this machine's registration
+deepvista agents get --type claude-code      # check registration
 deepvista agents list                         # all registered agents
-deepvista agents +status                      # quick status check
 deepvista agents sync --type claude-code --status online   # manual heartbeat
 deepvista agents delete --type claude-code    # unregister + remove hook
 ```
 
-The CLI detects agent type from environment variables (`CLAUDECODE=1`, `OPENCODE`,
-`CURSOR`, `WINDSURF`, `CLINE`) when not passed explicitly.
-
 ## Updates
 
-`deepvista upgrade check` is fast, cached (~1h TTL), and non-blocking. Outputs:
+`deepvista upgrade check` is fast, cached (~1h TTL), non-blocking.
 
 | stdout | Meaning |
 |---|---|
@@ -100,36 +63,26 @@ The CLI detects agent type from environment variables (`CLAUDECODE=1`, `OPENCODE
 | `JUST_UPGRADED <old> <new>` | just finished updating |
 
 ```bash
-deepvista upgrade                        # alias for `upgrade install` — interactive
 deepvista upgrade check                  # fast cached check (exit 1 if update available)
-deepvista upgrade check --no-cache       # bypass cache, re-check against PyPI
-deepvista upgrade check --quiet          # no stdout; communicate via exit code only
-deepvista upgrade install                # interactive: shows changelog, prompts y/n/snooze
-deepvista upgrade install --yes          # non-interactive: install immediately (use this in agent flows)
-deepvista upgrade install --skip-skills  # upgrade CLI only, leave skills alone
-deepvista upgrade install --dry-run      # preview what would be installed, no changes
-deepvista upgrade snooze                 # defer with escalating backoff (1d → 2d → 7d)
-deepvista upgrade snooze --days 3        # snooze for a specific number of days
+deepvista upgrade install --yes          # non-interactive install (use in agent flows)
+deepvista upgrade snooze                 # defer upgrade
 deepvista upgrade disable                # opt out permanently
-deepvista upgrade enable                 # re-enable after disable
-deepvista upgrade status                 # show current version, cached latest, snooze state
+deepvista upgrade status                 # show version + snooze state
 ```
 
 > **Agent note:** `deepvista upgrade` and `deepvista upgrade install` are interactive — they
-> prompt "Install now? [y/n/snooze]". In agent flows, always use
-> `deepvista upgrade install --yes` after the user has confirmed in the conversation, so the
-> agent never blocks waiting for a terminal prompt.
+> prompt "Install now? [y/n/snooze]". In agent flows always use
+> `deepvista upgrade install --yes` after user confirmation so the agent never blocks.
 
 ## Output format
 
-**JSON (default)** — one object, agent-friendly. Errors follow:
+**JSON (default)** — agent-friendly. Errors:
 
 ```json
 {"error": {"code": 2, "message": "Not authenticated", "detail": "Run `deepvista auth login`"}}
 ```
 
-**NDJSON** — for streaming commands (`chat +send`, `skill run`). One JSON object per
-line as events arrive.
+**NDJSON** — streaming commands (`chat +send`, `skill run`): one JSON object per line.
 
 **Table** — pass `--format table` for human-readable output.
 
@@ -144,14 +97,4 @@ line as events arrive.
 | 4 | network error |
 | 5 | internal error |
 
-Agents should branch on exit codes before parsing stdout — exit 0 guarantees valid
-JSON on stdout, non-zero exit guarantees a structured error on stdout.
-
-## Terminal UI (optional)
-
-```bash
-deepvista ui
-```
-
-Launches a Textual-based UI for browsing cards, notes, and chats. Requires the `[ui]`
-extra at install time.
+Branch on exit codes before parsing stdout — exit 0 guarantees valid JSON; non-zero guarantees a structured error object.

--- a/skills/deepvista/reference/skill-create-from-note.md
+++ b/skills/deepvista/reference/skill-create-from-note.md
@@ -2,132 +2,74 @@
 
 `deepvista skill create-from-note` asks the DeepVista agent to read one or more
 source notes (podcast episodes, interview transcripts, book chapters, research
-summaries) and synthesize a **workflow** skill grounded in their content — the
-frameworks or steps the source describes, turned into an executable workflow
-(inputs → phases → output template).
+summaries) and synthesize a **workflow** skill grounded in their content.
+Run `deepvista skill create-from-note --help` for full flag reference.
 
-Streams NDJSON identical to `chat +send` and `skill run`. The generated
-skill is stored as a context card of `type=skill`, linked back to every
-source note via `related_context_card_ids`.
+The generated skill is stored as a context card of `type=skill`, linked back to
+every source note via `related_context_card_ids`. Streams NDJSON identical to
+`chat +send`.
 
-## Command
+## Agent conventions
 
 > [!CAUTION] Write — the agent creates skill cards in the user's project.
 > Confirm before executing, or pass `--yes` for scripted/batch use.
 
-```bash
-deepvista skill create-from-note [NOTE_ID]...
-  [--note-id UUID]...
-  [--from-file PATH | -]
-  [--from-search QUERY]
-  [--from-similar SEED_NOTE_ID]
-  [--from-tag TAG]
-  [--from-grep REGEX]
-  [--limit N]
-  [--kind workflow]...
-  [--chat-id ID] [--yes] [--dry-run]
-```
+## Non-obvious: source selectors
 
-| Flag | Default | Purpose |
-| --- | --- | --- |
-| `NOTE_ID...` | — | Zero or more positional source-note UUIDs. Back-compat: a single positional keeps the exact legacy prompt. |
-| `--note-id UUID` | — | Repeatable alternative to positional IDs (friendlier in scripts). |
-| `--from-file PATH` | — | Read one ID per line from a file. `#` lines and blank lines are ignored. Pass `-` for stdin. |
-| `--from-search QUERY` | — | Hybrid vector + keyword search over notes (same backend as `card +search`). |
-| `--from-similar SEED` | — | Graph-style neighbours: notes similar to a seed note by title + snippet. |
-| `--from-tag TAG` | — | All notes whose `tags` list contains TAG (client-side filter over the latest 200 notes). |
-| `--from-grep REGEX` | — | Notes whose content matches a regex (via `/grep_context_cards`). |
-| `--limit N` | `5` (max 25) | Cap on resolved source notes so the synthesis prompt stays within the agent's usable context. |
-| `--kind KIND` | `workflow` | Repeatable. Currently only `workflow` is supported — the persona maker was removed server-side (DV-750). |
-| `--chat-id ID` | — | Continue an existing synthesis session (iterate on the skills). |
-| `--yes` / `-y` | off | Skip the confirmation prompt. Required for scripts and cron. |
-| `--dry-run` | — | Resolve the source notes and print the prompt without calling the agent. |
+Beyond passing note IDs directly, `create-from-note` supports several selectors that
+let you describe *which* notes to synthesize without knowing their IDs upfront:
 
-All selectors compose. Positional + `--note-id` + every `--from-*` flag are
-union-merged and de-duplicated, capped by `--limit`.
+| Selector | What it resolves |
+|---|---|
+| `--from-search QUERY` | Hybrid vector + keyword search over notes |
+| `--from-similar SEED_NOTE_ID` | Notes similar to a seed note (graph neighbours) |
+| `--from-tag TAG` | All notes whose `tags` list contains TAG |
+| `--from-grep REGEX` | Notes whose content matches a regex |
+| `--from-file PATH` | Read one ID per line from a file; pass `-` for stdin |
 
-## When to use
+All selectors compose — union-merged, de-duplicated, capped by `--limit N` (default 5, max 25).
 
-- You've captured one or more podcast episodes / interviews / book chapters
-  as notes and want a reusable workflow skill extracted.
-- You want to synthesize across notes — e.g. three Lenny episodes on
-  positioning → a single positioning workflow — not one skill per episode.
-- You want to batch-convert a corpus (e.g. every note tagged `lenny`) into
-  installable skills.
+Use `--dry-run` to preview resolved notes + the synthesis prompt before spending tokens.
 
-## Usage patterns
-
-### 1. Single note — unchanged
+## Examples
 
 ```bash
+# Single note
 deepvista skill create-from-note 0d5d1fb2-7414-4593-abc4-fb74984f4b2f
-```
 
-### 2. Multiple notes pinned by hand
+# Multiple notes
+deepvista skill create-from-note 0d5d1fb2-... 8a1f2c40-... --kind workflow --yes
 
-```bash
+# Semantic selector — no prior IDs needed
 deepvista skill create-from-note \
-  0d5d1fb2-... 8a1f2c40-... 4f9e6b17-... \
-  --kind workflow --yes
-```
+  --from-search "product-market fit signals" --limit 5 --kind workflow --yes
 
-### 3. Pipe from a prior search
+# Tag corpus rollup
+deepvista skill create-from-note --from-tag lenny --limit 10 --yes
 
-```bash
-# Every note matching "positioning" → one synthesized workflow skill
+# Graph expansion from a seed
+deepvista skill create-from-note --from-similar 0d5d1fb2-... --limit 4 --yes
+
+# Regex selector
+deepvista skill create-from-note --from-grep "DRI|operating rhythm" --yes
+
+# Pipe from a prior search
 deepvista notes list --limit 100 \
   | jq -r '.notes[] | select(.title | test("positioning"; "i")) | .id' \
   | deepvista skill create-from-note --from-file - --kind workflow --yes
-```
 
-### 4. Semantic selector — no prior IDs needed
-
-```bash
-deepvista skill create-from-note \
-  --from-search "product-market fit signals" \
-  --limit 5 --kind workflow --yes
-```
-
-### 5. Graph expansion from a seed
-
-```bash
-# Start from one great Lenny episode → synthesize across its neighbours.
-deepvista skill create-from-note \
-  --from-similar 0d5d1fb2-... --limit 4 --yes
-```
-
-### 6. Tag corpus rollup
-
-```bash
-# One skill that distills everything you've captured from Lenny's Podcast.
-deepvista skill create-from-note --from-tag lenny --limit 10 --yes
-```
-
-### 7. Regex selector for ad-hoc corpora
-
-```bash
-deepvista skill create-from-note --from-grep "DRI|operating rhythm" --yes
-```
-
-### 8. Preview first
-
-```bash
+# Preview first
 deepvista skill create-from-note --from-tag lenny --limit 5 --dry-run
 ```
 
-The dry-run output includes `resolved_notes` (every ID + title the agent
-will see) and the full `user_instruction` — inspect before spending tokens.
-
 ## After creation
 
-Generated skills land with `status=unconfirmed`. Inspect each with
+Generated skills land with `status=unconfirmed`. Inspect with
 [`deepvista card get <card_id>`](vistabase-card.md) and verify the SKILL.md
 body before running.
 
 ## See also
 
-- [notes.md](notes.md) — capturing the source notes (`deepvista notes create`
-  with `--content-file`) and re-indexing.
-- [skill.md](skill.md) — listing and running the generated skills.
-- [skill-research-to-skill.md](skill-research-to-skill.md) — broader pattern
-  (search → synthesize → run) when the source material spans multiple cards.
+- [notes.md](notes.md) — capturing source notes and re-indexing
+- [skill.md](skill.md) — listing and running the generated skills
+- [skill-research-to-skill.md](skill-research-to-skill.md) — broader search → synthesize → run pattern

--- a/skills/deepvista/reference/skill.md
+++ b/skills/deepvista/reference/skill.md
@@ -1,171 +1,78 @@
 # Skill — structured workflows
 
-A Skill is a multi-step checklist the agent works
-through phase by phase. `deepvista skill run` creates a chat session linked to the
-Skill run so you can continue it like a regular conversation.
+A Skill is a multi-step workflow the agent works through phase by phase.
+Run `deepvista skill --help` or `deepvista skill <cmd> --help` for full flag reference.
 
 ## Commands
 
-### `list` — read-only
+`list` · `get` · `run` · `phase` · `complete` · `status`
+`create-from-note` · `discover` · `install` · `sync` · `load`
 
-```bash
-deepvista skill list [--limit N] [--page N]
-```
+## Agent conventions
 
-### `get` — read-only
+> [!CAUTION] `run`, `phase`, `complete`, `install` are writes. Confirm first.
 
-```bash
-deepvista skill get <skill_id>
-```
+Read-only: `list`, `get`, `status`, `discover`, `sync --dry-run`, `load`.
 
-Returns the full Skill definition including every phase and step.
+Show the app URL after writes: `https://app.deepvista.ai/skills/<id>`
 
-### `create-from-note` — write
+## Non-obvious: `skill run` modes
 
-> [!CAUTION] The agent creates skill cards grounded in a source note.
-> Confirm first (or pass `--yes` in batch scripts).
+`skill run` has three modes (set with `--mode`, default `host`):
 
-```bash
-deepvista skill create-from-note <note_id> [--kind workflow]... [--yes] [--dry-run]
-```
+| Mode | Behaviour |
+|---|---|
+| `host` | CLI prints a JSON run packet + SKILL.md body. The **host agent** (Claude Code, Cursor, etc.) drives the run using `skill phase` / `skill complete` shims. Use when the workflow needs host tools (Bash, Edit, MCPs, repo state). |
+| `deepvista` | Posts to `/imagine`, streams NDJSON from the DeepVista server agent end-to-end. Use for KB-internal workflows where server tools are sufficient. |
+| `auto` | Routes per-phase: server-side tool phases go to DeepVista, the rest stay host. |
 
-Synthesizes a `workflow` skill from a source note (podcast, interview,
-book chapter, research summary). Full guide:
-[skill-create-from-note.md](skill-create-from-note.md).
+## Non-obvious: host-mode shims
 
-### `run` — write
-
-> [!CAUTION] Acquires the parent Skill card's run lock and either prints a host run packet or starts a DeepVista chat session. Confirm first.
-
-```bash
-deepvista skill run <skill_id> [--mode host|deepvista|auto] [--input "context text"]
-```
-
-Three modes, picked with `--mode` (default `host`):
-
-- **`host`** *(default)* — the CLI does **not** call `/imagine`. It prints a JSON header (`type: "skill_run_packet"`, skill_id, active phase, per-phase routing, user_input) followed by the workflow's SKILL.md body and the host-mode runtime contract. The host agent (Claude Code / OpenClaw / Cursor) drives the run itself via the [`phase`](#phase--mutate-an-in-progress-run-write) and [`complete`](#complete--release-the-run-lock-write) shims below. Use this when the workflow needs tools the host has (Bash, Edit, MCPs, your repo state).
-- **`deepvista`** — legacy behaviour: POSTs to `/imagine` and streams NDJSON from the DeepVista server agent, which drives the workflow end-to-end. Use this for KB-internal workflows (research, synthesis, card updates) where the server's tools are sufficient.
-- **`auto`** — inspects each phase's `tool_plan` and routes per phase. Phases whose plan is entirely server-side tools (`chat_cypher_search`, `upsert_context_card`, …) get a `"deepvista"` route in the packet; the rest stay `"host"`. The host agent follows the table.
-
-### `phase` — mutate an in-progress run (write)
-
-Used by host agents driving the workflow themselves after `skill run --mode host`. Each command parses the skill card, mutates accordion + mermaid markers, and writes via `/update_context_card`.
+After `skill run --mode host`, drive the run with:
 
 ```bash
 deepvista skill phase open <skill_id> "Phase N: <title>"
-deepvista skill phase done <skill_id> "Phase N: <title>" [--artifact-card-id ID]... [--next-phase "Phase N+1: …"]
-deepvista skill phase pause <skill_id> --reason "<short sentence>"
-deepvista skill phase run-on-deepvista <skill_id> "Phase N: <title>" [--input "..."]
-```
-
-- `open` marks the accordion `open="true"` and the mermaid node `:::dvActive`.
-- `done` marks `checked="true"` / `:::dvDone` and optionally embeds artifact `<contextCardBlock>`s. Pass `--next-phase` to open the next phase in the same write.
-- `pause` does **not** change `status` (the run lock stays held). Exits non-zero; the user resumes by re-running `deepvista skill run --mode host`.
-- `run-on-deepvista` delegates a single phase to the DeepVista server agent. Used by `--mode auto` for server-routable phases.
-
-### `complete` — release the run lock (write)
-
-```bash
+deepvista skill phase done <skill_id> "Phase N: <title>" [--artifact-card-id ID] [--next-phase "…"]
+deepvista skill phase pause <skill_id> --reason "<sentence>"
 deepvista skill complete <skill_id> --review "<3–6 retrospective bullets>"
 ```
 
-Appends the `## Review` section, sets `status="completed"` (releases the lock so the skill can be run again), and emits `<json>{"done": true}</json>`.
+`complete` appends `## Review`, releases the run lock, and emits `{"done": true}`.
 
-### `status` — read-only
+## Non-obvious: `sync` and `load`
 
-```bash
-deepvista skill status <run_chat_id>
-```
+`sync` writes thin `SKILL.md` stubs (frontmatter + lazy-fetch shell) into the agent
+skills directory. Safe in a `SessionStart` hook — always exits 0. Idempotent; only
+touches dirs with the `x-deepvista-catalog` marker; never overwrites user-authored
+skills.
 
-Returns run state: `running`, `awaiting_input`, `completed`, `failed`, `paused`.
-
-### `discover` — read-only
-
-```bash
-deepvista skill discover [--search "query"] [--category persona|productivity|workflow] [--limit N]
-```
-
-Browse the marketplace of public skills.
-
-### `install` — write
-
-> [!CAUTION] Copies a marketplace skill into the user's library. Confirm first.
-
-```bash
-deepvista skill install <skill_id>
-```
-
-### `sync` — catalog sync (safe, throttled)
-
-```bash
-deepvista skill sync [--target DIR] [--prefix dv-] [--limit N]
-                     [--throttle-min N] [--force] [--dry-run] [--quiet]
-```
-
-Writes thin `SKILL.md` stubs into an agent skills directory (default
-`~/.claude/skills/`, which opencode / Cursor / Codex also read). Each stub
-is frontmatter plus `` !`deepvista skill load <id>` `` — the real body is
-fetched at skill-invocation time, not at sync time.
-
-Idempotent. Adds / updates / removes stubs to match the server catalog.
-Only touches dirs carrying the `x-deepvista-catalog` marker — user-authored
-skills are never overwritten. Safe inside a SessionStart hook: always exits
-0 even on auth or network errors.
-
-### `load` — print full SKILL.md body (lazy fetch)
-
-```bash
-deepvista skill load <skill_id> [--no-cache] [--ttl N]
-```
-
-Prints the full SKILL.md body for one catalog skill to stdout. Called by
-stubs at invocation time. On error, prints a readable error body (not a
-traceback) so agents don't blow up. 5-minute on-disk body cache by default.
+`load` fetches the full SKILL.md body for a catalog skill at invocation time (5-min
+cache). Called by stubs — rarely needed directly.
 
 ## Examples
 
 ```bash
 deepvista skill list
-deepvista skill run <skill_id> --input "Focus on Q4 objectives"           # host mode (default)
-deepvista skill run <skill_id> --mode deepvista                            # legacy server-agent run
-deepvista skill run <skill_id> --mode auto                                 # per-phase routing
-deepvista skill phase open <skill_id> "Phase 1: …"                         # host: open the first phase
-deepvista skill phase done <skill_id> "Phase 1: …" --artifact-card-id <id> # host: complete + attach artifact
-deepvista skill complete <skill_id> --review "shipped on Friday — clean run"
-deepvista skill status <run_chat_id>
-deepvista skill discover --category persona
-deepvista skill install deepvista-persona-founder-coach
-deepvista skill sync --dry-run --throttle-min 0
-deepvista skill load 11111111-1111-1111-1111-111111111111
+deepvista skill run <skill_id> --input "Focus on Q4"          # host mode
+deepvista skill run <skill_id> --mode deepvista                # server agent
+deepvista skill run <skill_id> --mode auto                     # per-phase routing
+deepvista skill phase open <skill_id> "Phase 1: …"
+deepvista skill phase done <skill_id> "Phase 1: …" --artifact-card-id <id>
+deepvista skill complete <skill_id> --review "clean run, shipped Friday"
+deepvista skill discover --category workflow
+deepvista skill sync --dry-run
 ```
-
-## Plugin install
-
-For auto-sync on every session:
-
-- **Claude Code**: `/plugin install /path/to/deepvista-cli/plugins/claude-code`
-- **opencode**: drop `plugins/opencode/` into `~/.config/opencode/plugins/deepvista/`
-- **Cursor / Codex / other**: add `deepvista skill sync --quiet` to a cron or shell init
-
-See [plugins/README.md](../../plugins/README.md) for full install recipes.
 
 ## Continuing a run
 
-`skill run` returns a `run_chat_id`. To keep the conversation going:
+`skill run` returns a `run_chat_id`. Continue with:
 
 ```bash
-deepvista chat +send "Add one more step to phase 2" --chat-id <run_chat_id>
+deepvista chat +send "Add one more step" --chat-id <run_chat_id>
 ```
-
-## After a write
-
-Show the app URL: `https://app.deepvista.ai/skills/<id>`.
 
 ## See also
 
-- [skill-analyze-notes.md](skill-analyze-notes.md) — common Skill that searches +
-  synthesizes notes
-- [skill-research-to-skill.md](skill-research-to-skill.md) — pattern for running a
-  Skill with curated knowledge-base context as `--input`
-- [skill-import-files.md](skill-import-files.md) — bulk-import files as cards so a
-  Skill can search them
+- [skill-create-from-note.md](skill-create-from-note.md) — synthesize a skill from notes
+- [skill-research-to-skill.md](skill-research-to-skill.md) — research then run pattern
+- [skill-analyze-notes.md](skill-analyze-notes.md) — notes synthesis pattern

--- a/skills/deepvista/reference/vistabase-card.md
+++ b/skills/deepvista/reference/vistabase-card.md
@@ -1,142 +1,60 @@
 # Cards — the knowledge base
 
-`deepvista card` is the full-featured interface to your knowledge base. Every entry
-is a card; types include `person`, `organization`, `message`, `todo`, `topic`,
-`keypoint`, `file`, `note`, `skill`, `skill_run`.
+`deepvista card` manages every knowledge base entry. Types: `person`, `organization`,
+`message`, `todo`, `topic`, `keypoint`, `file`, `note`, `skill`, `skill_run`.
 
-`deepvista notes` is a thin convenience wrapper over `card --type note`. Use
-[notes.md](notes.md) for note-only ergonomics; use this for everything else.
+Run `deepvista card --help` or `deepvista card <cmd> --help` for full flag reference.
+
+`deepvista notes` is a thin convenience wrapper over `card --type note`.
+Use [notes.md](notes.md) for note-only ergonomics.
 
 ## Commands
 
-### `list` — read-only
+`list` · `get` · `create` · `update` · `edit` · `delete`
+`+search` · `+similar` · `+grep` · `+pin` · `+archive`
 
-```bash
-deepvista card list [--type TYPE] [--status STATUS] [--limit N] [--page N] \
-                    [--order-by FIELD] [--order asc|desc]
-```
+## Agent conventions
 
-Filter by `--type` (e.g. `person`, `topic`, `file`) and `--status`
-(`pinned`, `archived`, `normal`).
+> [!CAUTION] `create`, `update`, `edit`, `delete`, `+pin`, `+archive` are writes.
+> Confirm first. Use `--dry-run` to preview.
 
-### `get` — read-only
+- **Always use `--content-file <absolute-path>`** for large content — never inline.
+- Show the app URL after any write: `https://app.deepvista.ai/vistabase/<id>`
+- Read-only commands (`list`, `get`, `+search`, `+similar`, `+grep`) are safe to run
+  without confirmation.
 
-```bash
-deepvista card get <card_id>
-```
+## Non-obvious gotchas
 
-Returns the full card including body, metadata, and tags.
+**`edit` requires an exact string match.** `--old-string` must appear exactly once in
+the current body — it is replaced with `--new-string`. Fails if not found. Use
+`card get` to read the current body before calling `edit`. Prefer `update
+--content-file` when replacing large sections.
 
-### `create` — write
-
-> [!CAUTION] Confirm before running.
-
-```bash
-deepvista card create --type TYPE --title "Title" \
-  [--content "..." | --content-file PATH] [--tags '["t1","t2"]'] [--no-enrich]
-```
-
-`--no-enrich` disables the automatic metadata enrichment (e.g. linking known people
-and organizations). Use `--content-file` for large content — same rule as notes.
-
-### `update` — write
-
-> [!CAUTION] Confirm before running.
-
-```bash
-deepvista card update <card_id> [--title "..."] [--content "..." | --content-file PATH] \
-  [--type TYPE] [--tags '["t1"]'] [--status pinned|archived]
-```
-
-Use `--status pinned` / `--status archived` to change visibility. Only provided fields
-are modified.
-
-### `edit` — write (targeted string replace)
-
-> [!CAUTION] Confirm before running.
-
-```bash
-deepvista card edit <card_id> --old-string "..." --new-string "..." [--replace-all]
-```
-
-Works like Claude Code's Edit tool: `--old-string` must appear exactly once in the
-current body, and it is replaced with `--new-string`. Pass `--replace-all` to replace
-every occurrence. Fails if `--old-string` is not found.
-
-### `delete` — destructive
-
-> [!CAUTION] Destructive. Confirm before running.
-
-```bash
-deepvista card delete <card_id> [--type TYPE]
-```
-
-### `+search` — read-only
-
-```bash
-deepvista card +search "query text" [--type TYPE] [--limit N]
-```
-
-Hybrid vector + keyword search. Combines semantic matching with precise keyword
-recall. Prefer this over `+grep` when the user's phrasing is fuzzy.
-
-### `+similar` — read-only
-
-```bash
-deepvista card +similar <card_id> [--limit N]
-```
-
-Pure semantic-neighbor lookup anchored on an existing card.
-
-### `+grep` — read-only
-
-```bash
-deepvista card +grep "pattern" [--type TYPE] [-i] [--limit N] [-C N]
-```
-
-Literal / regex content matching. `-i` for case-insensitive, `-C N` for N lines of
-context. Prefer this when the user wants exact text matches (`TODO`, `FIXME`, URLs).
-
-### `+pin` / `+archive` — write
-
-> [!CAUTION] Confirm before running.
-
-```bash
-deepvista card +pin <card_id>
-deepvista card +archive <card_id>
-```
-
-Shorthand for `update --status pinned` / `update --status archived`.
+**`+search` vs `+grep`:** `+search` is hybrid vector+keyword (fuzzy, semantic).
+`+grep` is literal/regex. Use `+search` for concepts, `+grep` for exact strings like
+`TODO`, URLs, or identifiers.
 
 ## Examples
 
 ```bash
-# Hybrid search
+# Search
 deepvista card +search "quarterly metrics"
-deepvista card +search "machine learning team" --type person
-
-# Grep with context
+deepvista card +search "ML team" --type person
 deepvista card +grep "TODO|FIXME" --type note -i
-deepvista card +grep "API endpoint" -C 2
 
-# Create a topic card
+# Create
 deepvista card create --type topic \
-  --title "Machine Learning Strategy" \
-  --content-file /tmp/ml-strategy.md
+  --title "ML Strategy" --content-file /tmp/ml-strategy.md
 
-# Targeted fix
-deepvista card edit abc123 --old-string "old API URL" --new-string "new API URL"
+# Targeted patch
+deepvista card edit <id> --old-string "old API URL" --new-string "new API URL"
 
-# Pin something
-deepvista card +pin abc123
+# Pin
+deepvista card +pin <id>
 ```
-
-## After a write
-
-Show the app URL: `https://app.deepvista.ai/vistabase/<id>`.
 
 ## See also
 
-- [notes.md](notes.md) — convenience wrapper for `--type note`
-- [vistabase.md](vistabase.md) — read-only view of implicit memory
-- [skill-import-files.md](skill-import-files.md) — bulk-import files as cards
+- [notes.md](notes.md) — `--type note` convenience wrapper
+- [vistabase.md](vistabase.md) — implicit memory (read-only)
+- [skill-import-files.md](skill-import-files.md) — bulk-import files as `type=file` cards


### PR DESCRIPTION
## Summary

- Reference files under `skills/deepvista/reference/` were duplicating `--help` output verbatim, adding ~770 lines of flag tables that agents can get directly from the CLI
- Each file now points agents to `--help` and retains only: agent conventions (caution markers, URL patterns, `--content-file` rule), non-obvious gotchas, routing guidance, and representative examples
- Net: **-543 lines** (~70% reduction across 7 reference files)
- Added convention #5 to `SKILL.md`: check `--help` for exact flags rather than guessing from memory

## Files changed

| File | Change |
|---|---|
| `reference/shared.md` | Removed global flags table; kept auth, critical ordering gotcha, agent reg, upgrade agent note, exit codes |
| `reference/notes.md` | Removed CRUD flag tables; kept session hooks, `+quick`, `--content-file` rule |
| `reference/vistabase-card.md` | Removed flag tables; kept exact-string-match gotcha, `+search` vs `+grep` guidance |
| `reference/chat.md` | Removed `+send` flags; kept NDJSON event format (non-obvious, critical for agents) |
| `reference/lint.md` | Removed flag table; kept checks table and scheduling patterns |
| `reference/skill.md` | Removed simple flag tables; kept run modes (host/deepvista/auto) and phase shims |
| `reference/skill-create-from-note.md` | Removed full flag table; kept selector reference and all usage pattern examples |
| `SKILL.md` | Added convention #5: check `--help` for exact flags |

## Test plan

- [x] `gh skill publish --dry-run` passes (warnings only, no errors)
- [ ] Reinstall locally and verify agent can execute common workflows with `--help` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)