### PR TITLE
fix(install): run deepvista upgrade when already installed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,17 +12,22 @@ if ! command -v uv >/dev/null 2>&1; then
   export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 fi
 
-if command -v uv >/dev/null 2>&1; then
-  uv tool install --force "deepvista-cli[ui]"
-elif command -v pipx >/dev/null 2>&1; then
-  pipx install "deepvista-cli[ui]"
-elif command -v pip3 >/dev/null 2>&1; then
-  pip3 install --user "deepvista-cli[ui]"
-elif command -v pip >/dev/null 2>&1; then
-  pip install --user "deepvista-cli[ui]"
+if command -v deepvista >/dev/null 2>&1; then
+  echo "    deepvista already installed — running upgrade..."
+  deepvista upgrade
 else
-  echo "Error: no Python package manager found (pip, pipx, or uv required)" >&2
-  exit 1
+  if command -v uv >/dev/null 2>&1; then
+    uv tool install "deepvista-cli[ui]"
+  elif command -v pipx >/dev/null 2>&1; then
+    pipx install "deepvista-cli[ui]"
+  elif command -v pip3 >/dev/null 2>&1; then
+    pip3 install --user "deepvista-cli[ui]"
+  elif command -v pip >/dev/null 2>&1; then
+    pip install --user "deepvista-cli[ui]"
+  else
+    echo "Error: no Python package manager found (pip, pipx, or uv required)" >&2
+    exit 1
+  fi
 fi
 
 echo "==> Installing DeepVista skills..."


### PR DESCRIPTION
## Summary
- `install.sh` now checks if `deepvista` is already on `PATH` and calls `deepvista upgrade` instead of forcing a full reinstall
- Fresh installs still go through the `uv`/`pipx`/`pip` path (without `--force`)

## Test plan
- [ ] Run `curl -sSL https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/install.sh | bash` on a machine with deepvista already installed — should print "running upgrade..." and call `deepvista upgrade`
- [ ] Run on a clean machine without deepvista — should install via `uv tool install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)