### PR TITLE
feat(skill): add phase reset command + workflow run_hint in skill get

### DIFF
--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -100,6 +100,13 @@ def skill_get(ctx: click.Context, skill_id: str) -> None:
     Read-only — never modifies the Skill.
     """
     data = _client(ctx).post("/get_context_card", {"card_id": skill_id, "card_type": "skill"})
+    # Remind host agents that workflow skills must be executed via `skill run`,
+    # not by reading the body with `skill get` and driving phases manually.
+    attrs = data.get("attributes") or {}
+    if attrs.get("type") == "workflow":
+        data["run_hint"] = (
+            f"workflow skill — to execute with phase tracking run: deepvista skill run --mode host {skill_id}"
+        )
     format_output(
         data, ctx.obj.output_format, title=f"Skill: {skill_id}", entity_type="skill", base_url=ctx.obj.auth_url
     )
@@ -423,6 +430,41 @@ def skill_phase_done(
             "artifacts": list(artifact_card_ids),
             "title": card.get("title", ""),
         },
+        ctx.obj.output_format,
+        entity_type="skill",
+        base_url=ctx.obj.auth_url,
+    )
+
+
+@skill_phase_group.command("reset")
+@click.argument("skill_id")
+@click.argument("phase_label")
+@click.option("--dry-run", is_flag=True, default=False, help="Preview without writing.")
+@click.pass_context
+def skill_phase_reset(ctx: click.Context, skill_id: str, phase_label: str, dry_run: bool) -> None:
+    """Reset a phase back to pending (unchecked, closed, mermaid dvTodo).
+
+    Use this to re-run a phase that was already marked done or active.
+    The run lock (status=in_progress) is not affected.
+    """
+    card, doc = _load_skill_doc(ctx, skill_id)
+    try:
+        doc.reset_phase(phase_label)
+    except PhaseNotFoundError as exc:
+        output_error(3, "Phase not found", str(exc))
+
+    if dry_run:
+        format_output(
+            {"dry_run": True, "would": "reset phase to pending", "skill_id": skill_id, "phase": phase_label},
+            ctx.obj.output_format,
+            entity_type="skill",
+            base_url=ctx.obj.auth_url,
+        )
+        return
+
+    _persist_doc(ctx, skill_id, doc, reason="host-phase-reset")
+    format_output(
+        {"ok": True, "skill_id": skill_id, "reset_phase": phase_label, "title": card.get("title", "")},
         ctx.obj.output_format,
         entity_type="skill",
         base_url=ctx.obj.auth_url,

--- a/deepvista_cli/resources/workflow_host_runtime.md
+++ b/deepvista_cli/resources/workflow_host_runtime.md
@@ -147,6 +147,7 @@ be run again), and emits `<json>{"done": true}</json>`.
 | --- | --- |
 | Open a phase | `deepvista skill phase open <skill_id> "Phase N: …"` |
 | Mark a phase done | `deepvista skill phase done <skill_id> "Phase N: …" [--artifact-card-id ID]…` |
+| Reset phase to pending | `deepvista skill phase reset <skill_id> "Phase N: …"` |
 | Pause (lock held) | `deepvista skill phase pause <skill_id> --reason "…"` |
 | Resume from pause | re-run `deepvista skill run --mode host <skill_id>` |
 | One-phase fallback to DeepVista | `deepvista skill phase run-on-deepvista <skill_id> "Phase N: …"` |

--- a/deepvista_cli/workflow_doc.py
+++ b/deepvista_cli/workflow_doc.py
@@ -194,6 +194,14 @@ class WorkflowDocument:
         self._body = _strip_open_from_other_accordions(self._body, keep_label=None)
         self._body = _set_mermaid_class_for_label(self._body, label=label, new_klass="dvDone")
 
+    def reset_phase(self, label: str) -> None:
+        """Reset a phase to pending: accordion unchecked and closed, mermaid node ``dvTodo``."""
+        if not self._has_phase(label):
+            raise PhaseNotFoundError(label)
+        self._body = _mutate_accordions(self._body, target_label=label, target_attrs={"checked": "false"})
+        self._body = _strip_open_from_other_accordions(self._body, keep_label=None)
+        self._body = _set_mermaid_class_for_label(self._body, label=label, new_klass="dvTodo")
+
     def append_artifact_block(self, label: str, card_id: str, card_type: str, title: str, summary: str) -> None:
         """Embed a ``<contextCardBlock>`` inside the named accordion's body.
 

--- a/skills/deepvista/reference/skill.md
+++ b/skills/deepvista/reference/skill.md
@@ -16,6 +16,32 @@ Read-only: `list`, `get`, `status`, `discover`, `sync --dry-run`, `load`.
 
 Show the app URL after writes: `https://app.deepvista.ai/skills/<id>`
 
+## Executing a workflow skill — required sequence
+
+> [!IMPORTANT] To run a workflow skill you **must** call `deepvista skill run --mode host <skill_id>` first. Do NOT call `skill get` and drive the phases manually — that skips the run lock, phase tracking, and the host runtime contract entirely.
+
+`skill run --mode host` does three things `skill get` does not:
+1. Acquires the run lock (`status = "in_progress"`) on the skill card.
+2. Emits the host runtime contract that tells you to call the `skill phase` shims.
+3. Indicates the `active_phase` so resumed runs continue from the right place.
+
+**Required sequence for every workflow run:**
+
+```bash
+# 1. Initiate the run (acquires lock, emits run packet + host runtime contract)
+deepvista skill run --mode host <skill_id>
+
+# 2. For each phase — open → execute → done
+deepvista skill phase open <skill_id> "Phase N: <title>"
+# … execute the phase using your own tools …
+deepvista skill phase done <skill_id> "Phase N: <title>" [--next-phase "Phase N+1: <title>"]
+
+# 3. Finalize
+deepvista skill complete <skill_id> --review "<3–6 retrospective bullets>"
+```
+
+If you called `skill get` and are already mid-workflow without a lock, call `skill run --mode host` now — it is idempotent on an already-in-progress card and will re-emit the correct active phase.
+
 ## Non-obvious: `skill run` modes
 
 `skill run` has three modes (set with `--mode`, default `host`):
@@ -31,10 +57,11 @@ Show the app URL after writes: `https://app.deepvista.ai/skills/<id>`
 After `skill run --mode host`, drive the run with:
 
 ```bash
-deepvista skill phase open <skill_id> "Phase N: <title>"
-deepvista skill phase done <skill_id> "Phase N: <title>" [--artifact-card-id ID] [--next-phase "…"]
+deepvista skill phase open  <skill_id> "Phase N: <title>"
+deepvista skill phase done  <skill_id> "Phase N: <title>" [--artifact-card-id ID] [--next-phase "…"]
+deepvista skill phase reset <skill_id> "Phase N: <title>"   # revert a done/active phase to pending
 deepvista skill phase pause <skill_id> --reason "<sentence>"
-deepvista skill complete <skill_id> --review "<3–6 retrospective bullets>"
+deepvista skill complete    <skill_id> --review "<3–6 retrospective bullets>"
 ```
 
 `complete` appends `## Review`, releases the run lock, and emits `{"done": true}`.


### PR DESCRIPTION
## Summary

- Adds `deepvista skill phase reset <skill_id> "Phase N: …"` to revert a done/active phase back to pending (accordion unchecked+closed, mermaid node `dvTodo`). Supports `--dry-run`.
- Injects a `run_hint` field in `skill get` output for workflow-type skills to steer host agents toward `skill run --mode host` instead of driving phases manually from the card body.
- Adds `reset_phase()` method to `WorkflowDocument` in `workflow_doc.py`.
- Updates `workflow_host_runtime.md` and `skills/deepvista/reference/skill.md` with the new command and a required execution sequence callout.

## Test plan

- [ ] `deepvista skill phase reset <id> "Phase 1: …"` reverts a done phase to pending
- [ ] `--dry-run` flag prints preview without writing
- [ ] `deepvista skill get <workflow-skill-id>` response includes `run_hint` field
- [ ] `deepvista skill get <non-workflow-skill-id>` does not include `run_hint`
- [ ] `gh skill publish --dry-run` passes on `skills/deepvista/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)