### PR TITLE
feat(DV-796): drop auto-capture hook install, point to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,27 @@ That's it. Your knowledge base is now accessible from any terminal.
 
 **Install once, then talk to your agent.** The agent handles authentication and all commands on your behalf.
 
+### Claude Code (recommended)
+
+Install the DeepVista plugin from inside Claude Code:
+
+```
+/plugin marketplace add DeepVista-AI/deepvista-cli
+/plugin install deepvista@deepvista-ai
+```
+
+The plugin keeps your local skills directory in sync with the DeepVista
+catalog on every `SessionStart`. It calls the `deepvista` CLI under the hood,
+so make sure that's installed and logged in (`uv tool install deepvista-cli`
+then `deepvista auth login`).
+
+### For non-Claude-Code agents (Cursor, OpenCode, OpenClaw, …)
+
 ```bash
 curl -sSL https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/install.sh | bash
 ```
 
-The script auto-detects your package manager (`uv`, `pipx`, or `pip`) and copies the consolidated `deepvista` skill into your agent's skill directory (Claude Code, OpenCode, Cursor, OpenClaw). If you upgraded from an earlier release, it also sweeps out the 12 legacy `deepvista-*` skills so you don't end up with both.
+The script auto-detects your package manager (`uv`, `pipx`, or `pip`) and copies the consolidated `deepvista` skill into your agent's skill directory (Cursor, OpenCode, OpenClaw, and Claude Code as a fallback). If you upgraded from an earlier release, it also sweeps out the 12 legacy `deepvista-*` skills so you don't end up with both.
 
 Prefer GitHub's CLI? `gh skill install DeepVista-AI/deepvista-cli` works too (GitHub CLI ≥ 2.90, preview).
 
@@ -144,15 +160,13 @@ Your agent will open the browser login page, guide you through pasting the auth 
 
 ### Auto-Capture
 
-The install script enables auto-capture in every detected agent — **no manual setup required**.
+Auto-capture (silently saving notable facts, decisions, and insights to your
+DeepVista knowledge base as you work) ships with the Claude Code plugin —
+install it from inside Claude Code with `/plugin install deepvista@deepvista-ai`.
 
-| Agent | Config file |
-|-------|-------------|
-| Claude Code | `~/.claude/CLAUDE.md` |
-| Cursor | `~/.cursor/rules` |
-| OpenCode | `~/.opencode/AGENTS.md` |
-
-Your agent silently saves facts, decisions, insights, and action items to your DeepVista knowledge base as you work. The install is idempotent — re-running won't duplicate anything.
+For Cursor / OpenCode / OpenClaw, the `deepvista` skill's reference docs
+include the same capture prompts that you can paste into your agent's global
+instructions file.
 
 ### Skill Reference
 
@@ -349,10 +363,11 @@ pip install git+https://github.com/DeepVista-AI/deepvista-cli.git
 uv tool install git+https://github.com/DeepVista-AI/deepvista-cli.git
 ```
 
-### As a Claude Code plugin
+### As a Claude Code plugin (recommended for Claude Code users)
 
-The plugin is additive on top of the CLI — it wires the DeepVista skill catalog
-into Claude Code on every `SessionStart`. Install in this order:
+The plugin is the canonical way to use DeepVista from Claude Code. It wires the
+DeepVista skill catalog into Claude Code on every `SessionStart` and ships the
+auto-capture hook. Install in this order:
 
 ```bash
 # 1. Install the CLI (required — the plugin calls it)

--- a/install.sh
+++ b/install.sh
@@ -64,48 +64,7 @@ for dir in "${SKILL_DIRS[@]}"; do
   echo "    Skill installed to $dir/$SKILL"
 done
 
-# Auto-capture instruction block (written to each agent's global instructions file)
-read -r -d '' AUTOCAPTURE_BLOCK << 'EOF' || true
-
-<!-- deepvista-auto-capture -->
-## DeepVista Auto-Capture
-
-When the user shares any of the following during a conversation, automatically save it to DeepVista notes using `deepvista notes +quick "<text>"` without asking for confirmation:
-
-- Personal or professional facts (role, company, team, background)
-- Decisions made or conclusions reached
-- Key insights, learnings, or observations
-- Action items or commitments
-- Meeting or conversation highlights
-
-Use `deepvista notes +quick` for single-line facts. For longer structured notes, use `deepvista notes create --title "..." --content "..."`.
-
-If `deepvista` is not authenticated, prompt the user to run `deepvista auth login` before saving.
-<!-- /deepvista-auto-capture -->
-EOF
-
-install_autocapture() {
-  local config_file="$1"
-  mkdir -p "$(dirname "$config_file")"
-  # Idempotent: skip if already installed
-  if [ -f "$config_file" ] && grep -q "deepvista-auto-capture" "$config_file" 2>/dev/null; then
-    return
-  fi
-  printf '%s\n' "$AUTOCAPTURE_BLOCK" >> "$config_file"
-  echo "    Auto-capture enabled in $config_file"
-}
-
-echo "==> Enabling DeepVista auto-capture..."
-
-[ -d "$HOME/.claude" ]   && install_autocapture "$HOME/.claude/CLAUDE.md"
-[ -d "$HOME/.cursor" ]   && install_autocapture "$HOME/.cursor/rules"
-[ -d "$HOME/.opencode" ] && install_autocapture "$HOME/.opencode/AGENTS.md"
-
-# OpenClaw: install autocapture to workspace AGENTS.md
 OPENCLAW_WORKSPACE="$HOME/.openclaw/workspace"
-if [ -d "$OPENCLAW_WORKSPACE" ]; then
-  install_autocapture "$OPENCLAW_WORKSPACE/AGENTS.md"
-fi
 
 # Skill interpretation rules block (written to each agent's global instructions file)
 read -r -d '' SKILL_RULES_BLOCK << 'EOF' || true
@@ -168,74 +127,6 @@ echo "==> Injecting skill interpretation rules..."
 if [ -d "$OPENCLAW_WORKSPACE" ]; then
   install_skill_rules "$OPENCLAW_WORKSPACE/AGENTS.md"
 fi
-
-echo "==> Installing DeepVista auto-capture hook..."
-
-# Source of truth: the Claude Code plugin ships the canonical hook scripts.
-# install.sh copies them from the clone so plugin + install.sh never drift.
-HOOK_SRC="$TMP/repo/plugins/claude-code/hooks/deepvista-autocapture.sh"
-if [ ! -f "$HOOK_SRC" ]; then
-  echo "Error: expected $HOOK_SRC in the cloned repo" >&2
-  exit 1
-fi
-
-install_stop_hook() {
-  local settings_file="$1"
-  local hook_script="$2"
-  mkdir -p "$(dirname "$settings_file")"
-
-  # Create settings file if missing
-  if [ ! -f "$settings_file" ]; then
-    echo '{}' > "$settings_file"
-  fi
-
-  # Idempotent: skip if hook already registered
-  if grep -q "deepvista-autocapture" "$settings_file" 2>/dev/null; then
-    echo "    Stop hook already registered in $settings_file"
-    return
-  fi
-
-  # Merge hook into settings JSON using Python (always available for deepvista)
-  python3 - "$settings_file" "$hook_script" <<'PYEOF'
-import sys, json
-
-settings_path, hook_cmd = sys.argv[1], sys.argv[2]
-try:
-    with open(settings_path) as f:
-        cfg = json.load(f)
-except Exception:
-    cfg = {}
-
-hooks = cfg.setdefault("hooks", {})
-stop_list = hooks.setdefault("Stop", [])
-stop_list.append({
-    "matcher": "",
-    "hooks": [{"type": "command", "command": hook_cmd}]
-})
-
-with open(settings_path, "w") as f:
-    json.dump(cfg, f, indent=2)
-PYEOF
-
-  echo "    Stop hook registered in $settings_file"
-}
-
-copy_hook() {
-  local hooks_dir="$1"
-  local dest="$hooks_dir/deepvista-autocapture.sh"
-  mkdir -p "$hooks_dir"
-  cp "$HOOK_SRC" "$dest"
-  chmod +x "$dest"
-  echo "    Hook copied to $dest"
-}
-
-# The hook format is Claude-Code-specific (reads $transcript_path from the
-# Stop event payload). Other agents don't use it — they rely on the skill's
-# `deepvista notes +quick` instructions injected into their CLAUDE.md / rules.
-copy_hook "$HOME/.claude/hooks"
-install_stop_hook "$HOME/.claude/settings.json" "$HOME/.claude/hooks/deepvista-autocapture.sh"
-
-echo "    Auto-capture hook active — notable facts will be saved to DeepVista after each conversation turn"
 
 echo "==> Installing DeepVista skill-trigger hook..."
 
@@ -306,7 +197,18 @@ else
 fi
 
 echo ""
+echo "==> DeepVista Claude Code plugin"
+echo ""
+echo "    Inside Claude Code, run:"
+echo ""
+echo "      /plugin marketplace add DeepVista-AI/deepvista-cli"
+echo "      /plugin install deepvista@deepvista-ai"
+echo ""
+echo "    Using a different AI agent? Paste this prompt:"
+echo ""
+echo "      Help me install the deepvista plugin for Claude Code: https://github.com/DeepVista-AI/deepvista-cli#as-a-claude-code-plugin"
+echo ""
 echo "DeepVista is ready. Open your AI agent and say:"
 echo ""
-echo '  Help me get started with DeepVista.'
+echo "  Help me get started with DeepVista."
 echo ""

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -27,17 +27,21 @@ whatever stubs were synced previously in place.
 
 ## Install
 
-Local development:
-
-```
-/plugin install /path/to/deepvista-cli/plugins/claude-code
-```
-
-From the marketplace:
+This is the recommended way to use DeepVista from Claude Code. Run these two
+commands inside Claude Code:
 
 ```
 /plugin marketplace add DeepVista-AI/deepvista-cli
 /plugin install deepvista@deepvista-ai
+```
+
+If you're on a different agent (Cursor, OpenCode, OpenClaw, …), use the
+[install script](../../README.md#for-non-claude-code-agents-cursor-opencode-openclaw-) instead.
+
+For local plugin development:
+
+```
+/plugin install /path/to/deepvista-cli/plugins/claude-code
 ```
 
 ## Commands


### PR DESCRIPTION
## Summary
- Removes auto-capture hook install logic from `install.sh` (now provided by the DeepVista Claude Code plugin).
- Adds a clean "Install plugin" section pointing users at the canonical Claude Code plugin install commands.
- Updates READMEs to make the plugin the primary install path.

Closes DV-796 — https://linear.app/deepvista/issue/DV-796

## Test plan
- [x] `bash install.sh` runs to completion with no "Hook copied to" output.
- [x] New "DeepVista Claude Code plugin" section prints with both commands.
- [x] `deepvista --version` still works after install.