### PR TITLE
feat: consolidate DV-791 + DV-796 (unified agent tag + install.sh cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,11 +119,27 @@ That's it. Your knowledge base is now accessible from any terminal.
 
 **Install once, then talk to your agent.** The agent handles authentication and all commands on your behalf.
 
+### Claude Code (recommended)
+
+Install the DeepVista plugin from inside Claude Code:
+
+```
+/plugin marketplace add DeepVista-AI/deepvista-cli
+/plugin install deepvista@deepvista-ai
+```
+
+The plugin keeps your local skills directory in sync with the DeepVista
+catalog on every `SessionStart`. It calls the `deepvista` CLI under the hood,
+so make sure that's installed and logged in (`uv tool install deepvista-cli`
+then `deepvista auth login`).
+
+### For non-Claude-Code agents (Cursor, OpenCode, OpenClaw, …)
+
 ```bash
 curl -sSL https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/install.sh | bash
 ```
 
-The script auto-detects your package manager (`uv`, `pipx`, or `pip`) and copies the consolidated `deepvista` skill into your agent's skill directory (Claude Code, OpenCode, Cursor, OpenClaw). If you upgraded from an earlier release, it also sweeps out the 12 legacy `deepvista-*` skills so you don't end up with both.
+The script auto-detects your package manager (`uv`, `pipx`, or `pip`) and copies the consolidated `deepvista` skill into your agent's skill directory (Cursor, OpenCode, OpenClaw, and Claude Code as a fallback). If you upgraded from an earlier release, it also sweeps out the 12 legacy `deepvista-*` skills so you don't end up with both.
 
 Prefer GitHub's CLI? `gh skill install DeepVista-AI/deepvista-cli` works too (GitHub CLI ≥ 2.90, preview).
 
@@ -144,15 +160,13 @@ Your agent will open the browser login page, guide you through pasting the auth 
 
 ### Auto-Capture
 
-The install script enables auto-capture in every detected agent — **no manual setup required**.
+Auto-capture (silently saving notable facts, decisions, and insights to your
+DeepVista knowledge base as you work) ships with the Claude Code plugin —
+install it from inside Claude Code with `/plugin install deepvista@deepvista-ai`.
 
-| Agent | Config file |
-|-------|-------------|
-| Claude Code | `~/.claude/CLAUDE.md` |
-| Cursor | `~/.cursor/rules` |
-| OpenCode | `~/.opencode/AGENTS.md` |
-
-Your agent silently saves facts, decisions, insights, and action items to your DeepVista knowledge base as you work. The install is idempotent — re-running won't duplicate anything.
+For Cursor / OpenCode / OpenClaw, the `deepvista` skill's reference docs
+include the same capture prompts that you can paste into your agent's global
+instructions file.
 
 ### Skill Reference
 
@@ -349,10 +363,11 @@ pip install git+https://github.com/DeepVista-AI/deepvista-cli.git
 uv tool install git+https://github.com/DeepVista-AI/deepvista-cli.git
 ```
 
-### As a Claude Code plugin
+### As a Claude Code plugin (recommended for Claude Code users)
 
-The plugin is additive on top of the CLI — it wires the DeepVista skill catalog
-into Claude Code on every `SessionStart`. Install in this order:
+The plugin is the canonical way to use DeepVista from Claude Code. It wires the
+DeepVista skill catalog into Claude Code on every `SessionStart` and ships the
+auto-capture hook. Install in this order:
 
 ```bash
 # 1. Install the CLI (required — the plugin calls it)

--- a/deepvista_cli/client/origin.py
+++ b/deepvista_cli/client/origin.py
@@ -238,4 +238,17 @@ def build_origin() -> dict[str, str | bool]:
     if model:
         origin["model"] = model
 
+    # Agent UUID (DV-791): when the active agent has been registered via
+    # `deepvista auth login` / `agents register` (DV-751 self-healing), surface
+    # the UUID so the backend can echo `agent_id:<uuid>` onto server-side cards.
+    # Import lazily to avoid a circular dependency (agents.py imports origin).
+    try:
+        from deepvista_cli.commands.agents import load_agent_id_for_active_agent  # noqa: PLC0415
+
+        agent_id = load_agent_id_for_active_agent()
+        if agent_id:
+            origin["agent_id"] = agent_id
+    except Exception:
+        log.debug("could not resolve agent_id for origin header", exc_info=True)
+
     return origin

--- a/deepvista_cli/commands/agents.py
+++ b/deepvista_cli/commands/agents.py
@@ -74,6 +74,25 @@ def _load_agent_id(agent_type: str) -> str | None:
         return None
 
 
+def load_agent_id_for_active_agent() -> str | None:
+    """Best-effort lookup of the active agent's UUID from the local cache.
+
+    Detects the active agent type via the same env/process-tree heuristics used
+    elsewhere (``detect_agent_tool``) and returns the agent UUID previously
+    persisted by ``agents register`` / ``agents sync`` (DV-751 self-healing).
+
+    Returns ``None`` when no UUID is available — callers should treat the
+    ``agent_id`` tag/frontmatter/header field as optional.
+    """
+    try:
+        agent_type, _ = detect_agent_tool()
+    except Exception:
+        return None
+    if not agent_type:
+        return None
+    return _load_agent_id(agent_type)
+
+
 def _remove_agent_id(agent_type: str) -> None:
     """Remove local agent registration file."""
     path = _agent_id_path(agent_type)

--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -462,10 +462,13 @@ def notes_quick(ctx: click.Context, text: str, dry_run: bool) -> None:
     from deepvista_cli.commands.agents import load_agent_id_for_active_agent
 
     agent, _ = detect_agent_tool()
-    tags = [f"{sn.AGENT_TAG_PREFIX}{agent}"]
     agent_id = load_agent_id_for_active_agent()
-    if agent_id:
-        tags.append(f"{sn.AGENT_ID_TAG_PREFIX}{agent_id}")
+    # DV-791 (PR review): write a SINGLE combined tag rather than two separate
+    # ``agent:<tool>`` and ``agent_id:<uuid>`` entries. The backend now
+    # mirrors the same shape, so notes created via the CLI are queryable
+    # alongside notes created via the chat-service ``X-DeepVista-Origin``
+    # path with a single ``tag_contains`` lookup.
+    tags = [sn.build_agent_tag(agent, agent_id)]
     body = {
         "card_type": "note",
         "title": title,

--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -101,14 +101,28 @@ def notes_create(
     > [!CAUTION] This is a write command — confirm with the user before executing.
     """
     description = resolve_content(description, content_file)
-    body: dict = {"card_type": "note", "title": title, "enrich": True}
-    if description:
-        body["description"] = description
+
+    from deepvista_cli.commands.agents import load_agent_id_for_active_agent
+
+    agent, _ = detect_agent_tool()
+    agent_id = load_agent_id_for_active_agent()
+    # DV-791: prepend the combined agent tag so notes created here are filterable
+    # by the AgentFilter UI alongside +quick / session writes.
+    parsed_tags: list[str] = [sn.build_agent_tag(agent, agent_id)]
     if tags:
         try:
-            body["tags"] = _json.loads(tags)
+            user_tags = _json.loads(tags)
         except _json.JSONDecodeError:
             output_error(3, "Invalid --tags JSON", f"Got: {tags}")
+            return
+        if not isinstance(user_tags, list):
+            output_error(3, "Invalid --tags JSON", "Expected a JSON array of strings.")
+            return
+        parsed_tags.extend(user_tags)
+
+    body: dict = {"card_type": "note", "title": title, "tags": parsed_tags, "enrich": True}
+    if description:
+        body["description"] = description
 
     if dry_run:
         format_output(

--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -459,12 +459,18 @@ def notes_quick(ctx: click.Context, text: str, dry_run: bool) -> None:
     if len(title) < len(text):
         title = title.rstrip(".") + "..."
 
+    from deepvista_cli.commands.agents import load_agent_id_for_active_agent
+
     agent, _ = detect_agent_tool()
+    tags = [f"{sn.AGENT_TAG_PREFIX}{agent}"]
+    agent_id = load_agent_id_for_active_agent()
+    if agent_id:
+        tags.append(f"{sn.AGENT_ID_TAG_PREFIX}{agent_id}")
     body = {
         "card_type": "note",
         "title": title,
         "description": text,
-        "tags": [f"{sn.AGENT_TAG_PREFIX}{agent}"],
+        "tags": tags,
         "enrich": True,
     }
 

--- a/deepvista_cli/commands/session.py
+++ b/deepvista_cli/commands/session.py
@@ -114,6 +114,8 @@ def session_init(
 
     > [!CAUTION] This is a write command (creates a card on first call).
     """
+    from deepvista_cli.commands.agents import load_agent_id_for_active_agent
+
     if agent is None:
         detected_agent, detected_version = detect_agent_tool()
         agent = detected_agent
@@ -139,13 +141,21 @@ def session_init(
         )
         return
 
-    fm = sn.seed_frontmatter(session_id, cwd, transcript, agent=agent, agent_version=agent_version)
+    agent_id = load_agent_id_for_active_agent()
+    fm = sn.seed_frontmatter(
+        session_id,
+        cwd,
+        transcript,
+        agent=agent,
+        agent_version=agent_version,
+        agent_id=agent_id,
+    )
     body = sn.build_initial_body(fm)
     payload = {
         "card_type": SESSION_CARD_TYPE,
         "title": sn.default_title(session_id, cwd),
         "description": body,
-        "tags": sn.session_tags(session_id, agent, cwd),
+        "tags": sn.session_tags(session_id, agent, cwd, agent_id=agent_id),
         "enrich": False,
     }
 

--- a/deepvista_cli/session_note.py
+++ b/deepvista_cli/session_note.py
@@ -33,6 +33,9 @@ from typing import Any
 
 SESSION_TAG_PREFIX = "cc-session:"
 AGENT_TAG_PREFIX = "agent:"
+# Legacy prefix kept for the in-flight rolling notes already on disk that
+# carry ``agent_id:<uuid>`` as a standalone tag. New writes go through the
+# unified ``agent:<tool>:<uuid>`` form via :func:`build_agent_tag`.
 AGENT_ID_TAG_PREFIX = "agent_id:"
 PROJECT_TAG_PREFIX = "project:"
 DEFAULT_AGENT = "claude-code"
@@ -386,17 +389,33 @@ def seed_frontmatter(
     return fm
 
 
+def build_agent_tag(agent: str, agent_id: str | None = None) -> str:
+    """Return the unified ``agent:<tool>[:<agent_id>]`` tag for a card.
+
+    Per the DV-791 PR review, the CLI writes a SINGLE combined tag instead
+    of separate ``agent:<tool>`` and ``agent_id:<uuid>`` entries. The
+    backend ``X-DeepVista-Origin`` parser emits the same shape, so cards
+    created via either path are queryable with a single ``tag_contains``
+    lookup. When ``agent_id`` is unknown the tag degrades to ``agent:<tool>``
+    so callers can append unconditionally.
+    """
+    if agent_id:
+        return f"{AGENT_TAG_PREFIX}{agent}:{agent_id}"
+    return f"{AGENT_TAG_PREFIX}{agent}"
+
+
 def session_tags(session_id: str, agent: str, cwd: str, agent_id: str | None = None) -> list[str]:
     project = Path(cwd).name
-    tags = [
+    # DV-791 (PR review): unified ``agent:<tool>[:<agent_id>]`` tag. The old
+    # split ``agent:<tool>`` + ``agent_id:<uuid>`` form is gone for new
+    # writes (existing on-disk session notes that carry the legacy form
+    # keep working via the ``AGENT_ID_TAG_PREFIX`` parsers).
+    return [
         f"{SESSION_TAG_PREFIX}{session_id}",
-        f"{AGENT_TAG_PREFIX}{agent}",
+        build_agent_tag(agent, agent_id),
         f"{PROJECT_TAG_PREFIX}{project}",
         "session-note",
     ]
-    if agent_id:
-        tags.append(f"{AGENT_ID_TAG_PREFIX}{agent_id}")
-    return tags
 
 
 def default_title(session_id: str, cwd: str) -> str:

--- a/deepvista_cli/session_note.py
+++ b/deepvista_cli/session_note.py
@@ -33,6 +33,7 @@ from typing import Any
 
 SESSION_TAG_PREFIX = "cc-session:"
 AGENT_TAG_PREFIX = "agent:"
+AGENT_ID_TAG_PREFIX = "agent_id:"
 PROJECT_TAG_PREFIX = "project:"
 DEFAULT_AGENT = "claude-code"
 FRONTMATTER_FENCE = "---"
@@ -101,6 +102,7 @@ def parse_frontmatter(body: str) -> tuple[dict[str, Any], str]:
 def serialize_frontmatter(fm: dict[str, Any], rest: str) -> str:
     ordered_keys = [
         "agent",
+        "agent_id",
         "agent_version",
         "cc_session_id",
         "project_dir",
@@ -363,6 +365,7 @@ def seed_frontmatter(
     transcript: str,
     agent: str = DEFAULT_AGENT,
     agent_version: str | None = None,
+    agent_id: str | None = None,
 ) -> dict[str, Any]:
     fm: dict[str, Any] = {
         "agent": agent,
@@ -375,20 +378,25 @@ def seed_frontmatter(
         "transcript_path": transcript,
         "status": "active",
     }
+    if agent_id:
+        fm["agent_id"] = agent_id
     if agent_version:
         fm["agent_version"] = agent_version
     fm.update(probe_git(cwd))
     return fm
 
 
-def session_tags(session_id: str, agent: str, cwd: str) -> list[str]:
+def session_tags(session_id: str, agent: str, cwd: str, agent_id: str | None = None) -> list[str]:
     project = Path(cwd).name
-    return [
+    tags = [
         f"{SESSION_TAG_PREFIX}{session_id}",
         f"{AGENT_TAG_PREFIX}{agent}",
         f"{PROJECT_TAG_PREFIX}{project}",
         "session-note",
     ]
+    if agent_id:
+        tags.append(f"{AGENT_ID_TAG_PREFIX}{agent_id}")
+    return tags
 
 
 def default_title(session_id: str, cwd: str) -> str:

--- a/install.sh
+++ b/install.sh
@@ -64,48 +64,7 @@ for dir in "${SKILL_DIRS[@]}"; do
   echo "    Skill installed to $dir/$SKILL"
 done
 
-# Auto-capture instruction block (written to each agent's global instructions file)
-read -r -d '' AUTOCAPTURE_BLOCK << 'EOF' || true
-
-<!-- deepvista-auto-capture -->
-## DeepVista Auto-Capture
-
-When the user shares any of the following during a conversation, automatically save it to DeepVista notes using `deepvista notes +quick "<text>"` without asking for confirmation:
-
-- Personal or professional facts (role, company, team, background)
-- Decisions made or conclusions reached
-- Key insights, learnings, or observations
-- Action items or commitments
-- Meeting or conversation highlights
-
-Use `deepvista notes +quick` for single-line facts. For longer structured notes, use `deepvista notes create --title "..." --content "..."`.
-
-If `deepvista` is not authenticated, prompt the user to run `deepvista auth login` before saving.
-<!-- /deepvista-auto-capture -->
-EOF
-
-install_autocapture() {
-  local config_file="$1"
-  mkdir -p "$(dirname "$config_file")"
-  # Idempotent: skip if already installed
-  if [ -f "$config_file" ] && grep -q "deepvista-auto-capture" "$config_file" 2>/dev/null; then
-    return
-  fi
-  printf '%s\n' "$AUTOCAPTURE_BLOCK" >> "$config_file"
-  echo "    Auto-capture enabled in $config_file"
-}
-
-echo "==> Enabling DeepVista auto-capture..."
-
-[ -d "$HOME/.claude" ]   && install_autocapture "$HOME/.claude/CLAUDE.md"
-[ -d "$HOME/.cursor" ]   && install_autocapture "$HOME/.cursor/rules"
-[ -d "$HOME/.opencode" ] && install_autocapture "$HOME/.opencode/AGENTS.md"
-
-# OpenClaw: install autocapture to workspace AGENTS.md
 OPENCLAW_WORKSPACE="$HOME/.openclaw/workspace"
-if [ -d "$OPENCLAW_WORKSPACE" ]; then
-  install_autocapture "$OPENCLAW_WORKSPACE/AGENTS.md"
-fi
 
 # Skill interpretation rules block (written to each agent's global instructions file)
 read -r -d '' SKILL_RULES_BLOCK << 'EOF' || true
@@ -168,74 +127,6 @@ echo "==> Injecting skill interpretation rules..."
 if [ -d "$OPENCLAW_WORKSPACE" ]; then
   install_skill_rules "$OPENCLAW_WORKSPACE/AGENTS.md"
 fi
-
-echo "==> Installing DeepVista auto-capture hook..."
-
-# Source of truth: the Claude Code plugin ships the canonical hook scripts.
-# install.sh copies them from the clone so plugin + install.sh never drift.
-HOOK_SRC="$TMP/repo/plugins/claude-code/hooks/deepvista-autocapture.sh"
-if [ ! -f "$HOOK_SRC" ]; then
-  echo "Error: expected $HOOK_SRC in the cloned repo" >&2
-  exit 1
-fi
-
-install_stop_hook() {
-  local settings_file="$1"
-  local hook_script="$2"
-  mkdir -p "$(dirname "$settings_file")"
-
-  # Create settings file if missing
-  if [ ! -f "$settings_file" ]; then
-    echo '{}' > "$settings_file"
-  fi
-
-  # Idempotent: skip if hook already registered
-  if grep -q "deepvista-autocapture" "$settings_file" 2>/dev/null; then
-    echo "    Stop hook already registered in $settings_file"
-    return
-  fi
-
-  # Merge hook into settings JSON using Python (always available for deepvista)
-  python3 - "$settings_file" "$hook_script" <<'PYEOF'
-import sys, json
-
-settings_path, hook_cmd = sys.argv[1], sys.argv[2]
-try:
-    with open(settings_path) as f:
-        cfg = json.load(f)
-except Exception:
-    cfg = {}
-
-hooks = cfg.setdefault("hooks", {})
-stop_list = hooks.setdefault("Stop", [])
-stop_list.append({
-    "matcher": "",
-    "hooks": [{"type": "command", "command": hook_cmd}]
-})
-
-with open(settings_path, "w") as f:
-    json.dump(cfg, f, indent=2)
-PYEOF
-
-  echo "    Stop hook registered in $settings_file"
-}
-
-copy_hook() {
-  local hooks_dir="$1"
-  local dest="$hooks_dir/deepvista-autocapture.sh"
-  mkdir -p "$hooks_dir"
-  cp "$HOOK_SRC" "$dest"
-  chmod +x "$dest"
-  echo "    Hook copied to $dest"
-}
-
-# The hook format is Claude-Code-specific (reads $transcript_path from the
-# Stop event payload). Other agents don't use it — they rely on the skill's
-# `deepvista notes +quick` instructions injected into their CLAUDE.md / rules.
-copy_hook "$HOME/.claude/hooks"
-install_stop_hook "$HOME/.claude/settings.json" "$HOME/.claude/hooks/deepvista-autocapture.sh"
-
-echo "    Auto-capture hook active — notable facts will be saved to DeepVista after each conversation turn"
 
 echo "==> Installing DeepVista skill-trigger hook..."
 
@@ -306,7 +197,18 @@ else
 fi
 
 echo ""
+echo "==> DeepVista Claude Code plugin"
+echo ""
+echo "    Inside Claude Code, run:"
+echo ""
+echo "      /plugin marketplace add DeepVista-AI/deepvista-cli"
+echo "      /plugin install deepvista@deepvista-ai"
+echo ""
+echo "    Using a different AI agent? Paste this prompt:"
+echo ""
+echo "      Help me install the deepvista plugin for Claude Code: https://github.com/DeepVista-AI/deepvista-cli#as-a-claude-code-plugin"
+echo ""
 echo "DeepVista is ready. Open your AI agent and say:"
 echo ""
-echo '  Help me get started with DeepVista.'
+echo "  Help me get started with DeepVista."
 echo ""

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -27,17 +27,21 @@ whatever stubs were synced previously in place.
 
 ## Install
 
-Local development:
-
-```
-/plugin install /path/to/deepvista-cli/plugins/claude-code
-```
-
-From the marketplace:
+This is the recommended way to use DeepVista from Claude Code. Run these two
+commands inside Claude Code:
 
 ```
 /plugin marketplace add DeepVista-AI/deepvista-cli
 /plugin install deepvista@deepvista-ai
+```
+
+If you're on a different agent (Cursor, OpenCode, OpenClaw, …), use the
+[install script](../../README.md#for-non-claude-code-agents-cursor-opencode-openclaw-) instead.
+
+For local plugin development:
+
+```
+/plugin install /path/to/deepvista-cli/plugins/claude-code
 ```
 
 ## Commands

--- a/tests/test_agent_id_tagging.py
+++ b/tests/test_agent_id_tagging.py
@@ -1,0 +1,234 @@
+"""Tests for DV-791: write `agent_id` tag + frontmatter on note/session create.
+
+The CLI tags every note/session write with both ``agent:<name>`` and (when the
+local agent cache has a UUID for the active agent) ``agent_id:<uuid>``. The
+session card additionally carries ``agent_id`` in its frontmatter and the
+``X-DeepVista-Origin`` HTTP header echoes the UUID so the backend can echo the
+tag on server-side card creation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from deepvista_cli import session_note as sn
+
+# ---------------------------------------------------------------------------
+# session_note.py — frontmatter + tags round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_seed_frontmatter_includes_agent_id_when_provided() -> None:
+    fm = sn.seed_frontmatter(
+        session_id="sess-1",
+        cwd="/tmp/proj",
+        transcript="/tmp/t.jsonl",
+        agent="claude-code",
+        agent_version="1.2.3",
+        agent_id="11111111-2222-3333-4444-555555555555",
+    )
+    assert fm["agent"] == "claude-code"
+    assert fm["agent_id"] == "11111111-2222-3333-4444-555555555555"
+    assert fm["agent_version"] == "1.2.3"
+
+
+def test_seed_frontmatter_omits_agent_id_when_unknown() -> None:
+    fm = sn.seed_frontmatter(
+        session_id="sess-1",
+        cwd="/tmp/proj",
+        transcript="/tmp/t.jsonl",
+        agent="claude-code",
+    )
+    assert "agent_id" not in fm
+
+
+def test_frontmatter_serialize_then_parse_round_trips_agent_id() -> None:
+    fm = {
+        "agent": "claude-code",
+        "agent_id": "abc-uuid",
+        "cc_session_id": "sess-1",
+        "turn_count": 0,
+        "status": "active",
+    }
+    serialized = sn.serialize_frontmatter(fm, "## Turns\n\n")
+    parsed, rest = sn.parse_frontmatter(serialized)
+    assert parsed["agent"] == "claude-code"
+    assert parsed["agent_id"] == "abc-uuid"
+    assert "## Turns" in rest
+
+
+def test_serialize_frontmatter_orders_agent_id_after_agent() -> None:
+    """`agent_id` must sit directly after `agent` so the frontmatter is easy
+    to scan for humans. Stable ordering also keeps diffs minimal across ticks.
+    """
+    fm = {
+        "agent": "claude-code",
+        "agent_id": "abc-uuid",
+        "agent_version": "1.0",
+    }
+    serialized = sn.serialize_frontmatter(fm, "")
+    # Order should be agent, agent_id, agent_version
+    agent_pos = serialized.index("agent:")
+    agent_id_pos = serialized.index("agent_id:")
+    agent_version_pos = serialized.index("agent_version:")
+    assert agent_pos < agent_id_pos < agent_version_pos
+
+
+def test_session_tags_emits_agent_id_tag_when_provided() -> None:
+    tags = sn.session_tags(
+        session_id="sess-1",
+        agent="claude-code",
+        cwd="/tmp/myproject",
+        agent_id="abc-uuid",
+    )
+    assert f"{sn.SESSION_TAG_PREFIX}sess-1" in tags
+    assert f"{sn.AGENT_TAG_PREFIX}claude-code" in tags
+    assert f"{sn.AGENT_ID_TAG_PREFIX}abc-uuid" in tags
+
+
+def test_session_tags_omits_agent_id_tag_when_unknown() -> None:
+    tags = sn.session_tags(session_id="sess-1", agent="claude-code", cwd="/tmp/myproject")
+    assert f"{sn.AGENT_TAG_PREFIX}claude-code" in tags
+    assert not any(t.startswith(sn.AGENT_ID_TAG_PREFIX) for t in tags)
+
+
+# ---------------------------------------------------------------------------
+# agents.py — local cache lookup helper
+# ---------------------------------------------------------------------------
+
+
+def test_load_agent_id_for_active_agent_returns_cached_uuid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from deepvista_cli.commands import agents
+
+    # Redirect the on-disk cache to a tmpdir and prime it with an entry.
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    monkeypatch.setattr(agents, "AGENTS_DIR", agents_dir)
+    (agents_dir / "claude-code.json").write_text(json.dumps({"agent_id": "cached-uuid", "agent_type": "claude-code"}))
+
+    # Force detect_agent_tool to look like Claude Code.
+    monkeypatch.setattr(agents, "detect_agent_tool", lambda: ("claude-code", "1.0"))
+
+    assert agents.load_agent_id_for_active_agent() == "cached-uuid"
+
+
+def test_load_agent_id_for_active_agent_returns_none_when_unregistered(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from deepvista_cli.commands import agents
+
+    agents_dir = tmp_path / "agents"
+    agents_dir.mkdir()
+    monkeypatch.setattr(agents, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(agents, "detect_agent_tool", lambda: ("claude-code", None))
+
+    assert agents.load_agent_id_for_active_agent() is None
+
+
+# ---------------------------------------------------------------------------
+# +quick tag emission
+# ---------------------------------------------------------------------------
+
+
+class _Recorder:
+    """Capture POST bodies sent through the CLI's HTTP client."""
+
+    def __init__(self) -> None:
+        self.posts: list[tuple[str, dict[str, Any]]] = []
+
+    def post(self, path: str, body: dict[str, Any]) -> dict[str, Any]:
+        self.posts.append((path, body))
+        return {"card": {"id": "card-1", "title": body.get("title")}}
+
+
+def _invoke_quick(monkeypatch: pytest.MonkeyPatch, agent_id: str | None) -> _Recorder:
+    """Drive `deepvista notes +quick` with a stubbed client and agent lookup."""
+    import click
+    from click.testing import CliRunner
+
+    from deepvista_cli.commands import notes as notes_cmd
+
+    monkeypatch.setattr(notes_cmd, "detect_agent_tool", lambda: ("claude-code", "1.0"))
+
+    from deepvista_cli.commands import agents as agents_cmd
+
+    monkeypatch.setattr(agents_cmd, "load_agent_id_for_active_agent", lambda: agent_id)
+
+    recorder = _Recorder()
+    monkeypatch.setattr(notes_cmd, "_client", lambda ctx: recorder)
+
+    class _Obj:
+        output_format = "json"
+        auth_url = "http://localhost"
+
+    @click.group()
+    @click.pass_context
+    def root(ctx: click.Context) -> None:
+        ctx.obj = _Obj()
+
+    root.add_command(notes_cmd.notes_group)
+    runner = CliRunner()
+    result = runner.invoke(root, ["notes", "+quick", "hello world"])
+    assert result.exit_code == 0, result.output
+    return recorder
+
+
+def test_quick_note_emits_both_agent_and_agent_id_tags(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _invoke_quick(monkeypatch, agent_id="abc-uuid")
+    assert recorder.posts, "expected a POST /create_context_card call"
+    path, body = recorder.posts[0]
+    assert path == "/create_context_card"
+    tags = body.get("tags") or []
+    assert f"{sn.AGENT_TAG_PREFIX}claude-code" in tags
+    assert f"{sn.AGENT_ID_TAG_PREFIX}abc-uuid" in tags
+
+
+def test_quick_note_omits_agent_id_tag_when_unregistered(monkeypatch: pytest.MonkeyPatch) -> None:
+    recorder = _invoke_quick(monkeypatch, agent_id=None)
+    _, body = recorder.posts[0]
+    tags = body.get("tags") or []
+    assert f"{sn.AGENT_TAG_PREFIX}claude-code" in tags
+    assert not any(t.startswith(sn.AGENT_ID_TAG_PREFIX) for t in tags)
+
+
+# ---------------------------------------------------------------------------
+# X-DeepVista-Origin header includes agent_id when known
+# ---------------------------------------------------------------------------
+
+
+def test_build_origin_includes_agent_id_when_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    from deepvista_cli.client import origin as origin_mod
+
+    # Clear the lru_cache so the previous test's value doesn't leak in.
+    origin_mod.build_origin.cache_clear()
+
+    monkeypatch.setattr(origin_mod, "detect_agent_tool", lambda: ("claude-code", "1.0"))
+    from deepvista_cli.commands import agents as agents_cmd
+
+    monkeypatch.setattr(agents_cmd, "load_agent_id_for_active_agent", lambda: "abc-uuid")
+
+    o = origin_mod.build_origin()
+    assert o["tool"] == "claude-code"
+    assert o["agent_id"] == "abc-uuid"
+
+    origin_mod.build_origin.cache_clear()
+
+
+def test_build_origin_omits_agent_id_when_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    from deepvista_cli.client import origin as origin_mod
+
+    origin_mod.build_origin.cache_clear()
+
+    monkeypatch.setattr(origin_mod, "detect_agent_tool", lambda: ("claude-code", "1.0"))
+    from deepvista_cli.commands import agents as agents_cmd
+
+    monkeypatch.setattr(agents_cmd, "load_agent_id_for_active_agent", lambda: None)
+
+    o = origin_mod.build_origin()
+    assert "agent_id" not in o
+
+    origin_mod.build_origin.cache_clear()

--- a/tests/test_agent_id_tagging.py
+++ b/tests/test_agent_id_tagging.py
@@ -78,7 +78,13 @@ def test_serialize_frontmatter_orders_agent_id_after_agent() -> None:
     assert agent_pos < agent_id_pos < agent_version_pos
 
 
-def test_session_tags_emits_agent_id_tag_when_provided() -> None:
+def test_session_tags_emits_unified_agent_tag_when_agent_id_present() -> None:
+    """DV-791 (PR review): session cards carry a SINGLE ``agent:<tool>:<id>`` tag.
+
+    The old split form (``agent:<tool>`` + ``agent_id:<uuid>``) is gone for
+    new writes — the backend parser now emits the same combined shape, so
+    a single ``tag_contains`` lookup turns up cards from either path.
+    """
     tags = sn.session_tags(
         session_id="sess-1",
         agent="claude-code",
@@ -86,14 +92,24 @@ def test_session_tags_emits_agent_id_tag_when_provided() -> None:
         agent_id="abc-uuid",
     )
     assert f"{sn.SESSION_TAG_PREFIX}sess-1" in tags
-    assert f"{sn.AGENT_TAG_PREFIX}claude-code" in tags
-    assert f"{sn.AGENT_ID_TAG_PREFIX}abc-uuid" in tags
+    assert "agent:claude-code:abc-uuid" in tags
+    # Crucially: no legacy ``agent:<tool>`` bare tag, no standalone ``agent_id:`` tag.
+    assert "agent:claude-code" not in tags
+    assert not any(t.startswith(sn.AGENT_ID_TAG_PREFIX) for t in tags)
 
 
-def test_session_tags_omits_agent_id_tag_when_unknown() -> None:
+def test_session_tags_falls_back_to_bare_agent_tag_when_agent_id_unknown() -> None:
     tags = sn.session_tags(session_id="sess-1", agent="claude-code", cwd="/tmp/myproject")
+    # Without an agent_id we degrade to ``agent:<tool>`` so callers can still
+    # narrow by tool.
     assert f"{sn.AGENT_TAG_PREFIX}claude-code" in tags
     assert not any(t.startswith(sn.AGENT_ID_TAG_PREFIX) for t in tags)
+
+
+def test_build_agent_tag_helper() -> None:
+    assert sn.build_agent_tag("claude-code", "uuid-1") == "agent:claude-code:uuid-1"
+    assert sn.build_agent_tag("claude-code", None) == "agent:claude-code"
+    assert sn.build_agent_tag("claude-code", "") == "agent:claude-code"
 
 
 # ---------------------------------------------------------------------------
@@ -177,17 +193,20 @@ def _invoke_quick(monkeypatch: pytest.MonkeyPatch, agent_id: str | None) -> _Rec
     return recorder
 
 
-def test_quick_note_emits_both_agent_and_agent_id_tags(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_quick_note_emits_unified_agent_tag_when_registered(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``+quick`` writes a SINGLE ``agent:<tool>:<id>`` tag (DV-791 PR review)."""
     recorder = _invoke_quick(monkeypatch, agent_id="abc-uuid")
     assert recorder.posts, "expected a POST /create_context_card call"
     path, body = recorder.posts[0]
     assert path == "/create_context_card"
     tags = body.get("tags") or []
-    assert f"{sn.AGENT_TAG_PREFIX}claude-code" in tags
-    assert f"{sn.AGENT_ID_TAG_PREFIX}abc-uuid" in tags
+    assert "agent:claude-code:abc-uuid" in tags
+    # No bare ``agent:<tool>`` and no standalone ``agent_id:`` tag.
+    assert "agent:claude-code" not in tags
+    assert not any(t.startswith(sn.AGENT_ID_TAG_PREFIX) for t in tags)
 
 
-def test_quick_note_omits_agent_id_tag_when_unregistered(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_quick_note_falls_back_to_bare_agent_tag_when_unregistered(monkeypatch: pytest.MonkeyPatch) -> None:
     recorder = _invoke_quick(monkeypatch, agent_id=None)
     _, body = recorder.posts[0]
     tags = body.get("tags") or []


### PR DESCRIPTION
https://app.visla.us/clip/1507523749174366862

## Summary

Consolidates two previously-open PRs.

- **DV-796** — `install.sh` drops the auto-capture / stop-hook install (now provided by the DeepVista Claude Code plugin) and points users at the canonical plugin install commands. READMEs promote the plugin path.
- **DV-791** — Notes and sessions now carry a single unified `agent:<tool>:<agent_id>` tag (matching the backend) when the local agent cache has a UUID; falls back to `agent:<tool>` when not. `agent_id` is also written to session frontmatter and the `X-DeepVista-Origin` header (which keeps `tool` + `agent_id` as separate JSON fields — they're structured, not tags).

## Companion PR
The deepvista (monorepo) side: https://github.com/DeepVista-AI/deepvista/pull/2121

## Test plan
- [ ] `bash install.sh` runs end-to-end without hook-copy output.
- [ ] `deepvista notes +quick "..."` creates a card whose `tags` array contains `agent:<tool>:<agent_id>`.
- [ ] Session frontmatter includes `agent_id`.

Supersedes #131 and #132.