### PR TITLE
feat(DV-817): format session card with accordion turns

### DIFF
--- a/deepvista_cli/commands/session.py
+++ b/deepvista_cli/commands/session.py
@@ -229,6 +229,14 @@ def session_tick(ctx: click.Context, session_id: str, transcript: str, dry_run: 
             "turn_count": turn_num,
             "version": turn_num,
         }
+        # DV-817: seed the frontmatter `summary` from the first user turn so
+        # the vistabase list row has something to show before finalize runs
+        # the LLM rollup. Only write when missing — later ticks must not
+        # overwrite a summary the summarize-session skill has already set.
+        if not str(fm.get("summary") or "").strip():
+            placeholder = sn.summary_from_user_text(turn.user_text)
+            if placeholder:
+                updates["summary"] = placeholder
         existing_tools = _parse_counter(fm.get("tools_used"))
         for name, count in turn.tool_counts.items():
             existing_tools[name] = existing_tools.get(name, 0) + count

--- a/deepvista_cli/commands/session.py
+++ b/deepvista_cli/commands/session.py
@@ -229,14 +229,6 @@ def session_tick(ctx: click.Context, session_id: str, transcript: str, dry_run: 
             "turn_count": turn_num,
             "version": turn_num,
         }
-        # DV-817: seed the frontmatter `summary` from the first user turn so
-        # the vistabase list row has something to show before finalize runs
-        # the LLM rollup. Only write when missing — later ticks must not
-        # overwrite a summary the summarize-session skill has already set.
-        if not str(fm.get("summary") or "").strip():
-            placeholder = sn.summary_from_user_text(turn.user_text)
-            if placeholder:
-                updates["summary"] = placeholder
         existing_tools = _parse_counter(fm.get("tools_used"))
         for name, count in turn.tool_counts.items():
             existing_tools[name] = existing_tools.get(name, 0) + count
@@ -246,6 +238,17 @@ def session_tick(ctx: click.Context, session_id: str, transcript: str, dry_run: 
         fm, _ = sn.parse_frontmatter(body)
 
     payload = {"card_id": card_id, "description": body, "reason": "session-tick"}
+
+    # DV-827: while the AI finalize title pipeline is still ramping up
+    # reliability, give the card a meaningful title for the first few ticks
+    # using the first user turn. We gate on the pre-tick turn count so that
+    # an opening tick which flushes many turns at once still writes the
+    # title once, but later ticks past the threshold leave it alone (so the
+    # AI title at finalize, or a user rename, sticks).
+    if last_idx < sn.TITLE_REWRITE_TICK_THRESHOLD and turns:
+        derived_title = sn.title_from_first_user_turn(turns[0].user_text)
+        if derived_title:
+            payload["title"] = derived_title
 
     if dry_run:
         format_output(

--- a/deepvista_cli/session_note.py
+++ b/deepvista_cli/session_note.py
@@ -42,11 +42,14 @@ DEFAULT_AGENT = "claude-code"
 FRONTMATTER_FENCE = "---"
 TURN_HEAD_CHAR_LIMIT = 80
 SUMMARY_CHAR_LIMIT = 400
-# The frontmatter `summary` field surfaces in the vistabase list-row preview
-# (DV-817). It's seeded from the first user turn during `session tick` and
-# replaced with an LLM rollup at finalize, so the placeholder text needs to
-# be short and single-line.
-FRONTMATTER_SUMMARY_CHAR_LIMIT = 140
+# Heuristic title length applied during the first 3 ticks (DV-827). Mirrors
+# TURN_HEAD_CHAR_LIMIT for consistency with the in-body turn-head line; the
+# `deepvista-summarize-session` skill aims for ≤ 60 chars Title Case at
+# finalize, so this acts as a slightly looser pre-AI placeholder.
+TITLE_CHAR_LIMIT = 80
+# How many of the first ticks rewrite the title from the first user turn.
+# Past this, the card's title is left alone until the AI finalize step.
+TITLE_REWRITE_TICK_THRESHOLD = 3
 BODY_SIZE_CAP_BYTES = 50_000
 
 
@@ -123,7 +126,6 @@ def serialize_frontmatter(fm: dict[str, Any], rest: str) -> str:
         "version",
         "transcript_path",
         "tools_used",
-        "summary",
         "status",
     ]
     lines = [FRONTMATTER_FENCE]
@@ -287,16 +289,15 @@ def _truncate(text: str, limit: int) -> str:
     return text[: limit - 1].rstrip() + "…"
 
 
-def summary_from_user_text(text: str) -> str:
-    """Build a single-line frontmatter `summary` from a user turn's text.
+def title_from_first_user_turn(text: str) -> str:
+    """Heuristic placeholder title derived from a session's first user turn.
 
-    Used at first tick as a placeholder until the `deepvista-summarize-session`
-    skill produces a real LLM-generated summary at finalize. Returns an empty
-    string when the input is blank — callers should skip writing the field in
-    that case rather than persisting an empty placeholder.
+    Applied at ticks 1–``TITLE_REWRITE_TICK_THRESHOLD`` to give the card a
+    meaningful name before the `deepvista-summarize-session` skill writes
+    an AI title at finalize. Empty input returns an empty string so callers
+    can skip the field.
     """
-    cleaned = _truncate(text, FRONTMATTER_SUMMARY_CHAR_LIMIT)
-    return cleaned
+    return _truncate(text, TITLE_CHAR_LIMIT)
 
 
 # ---------------------------------------------------------------------------

--- a/deepvista_cli/session_note.py
+++ b/deepvista_cli/session_note.py
@@ -40,8 +40,13 @@ AGENT_ID_TAG_PREFIX = "agent_id:"
 PROJECT_TAG_PREFIX = "project:"
 DEFAULT_AGENT = "claude-code"
 FRONTMATTER_FENCE = "---"
-TURN_HEADING_RE = re.compile(r"^### Turn (\d+) · ")
+TURN_HEAD_CHAR_LIMIT = 80
 SUMMARY_CHAR_LIMIT = 400
+# The frontmatter `summary` field surfaces in the vistabase list-row preview
+# (DV-817). It's seeded from the first user turn during `session tick` and
+# replaced with an LLM rollup at finalize, so the placeholder text needs to
+# be short and single-line.
+FRONTMATTER_SUMMARY_CHAR_LIMIT = 140
 BODY_SIZE_CAP_BYTES = 50_000
 
 
@@ -118,6 +123,7 @@ def serialize_frontmatter(fm: dict[str, Any], rest: str) -> str:
         "version",
         "transcript_path",
         "tools_used",
+        "summary",
         "status",
     ]
     lines = [FRONTMATTER_FENCE]
@@ -260,12 +266,17 @@ def summarize_turn(turn: Turn, index: int, now: datetime | None = None) -> str:
     )
     tools = ", ".join(f"{k}({v})" for k, v in tool_pairs) or "_(none)_"
     files = ", ".join(f"`{p}`" for p in turn.files_touched[:8]) or "_(none)_"
+    head_preview = _truncate(turn.user_text, TURN_HEAD_CHAR_LIMIT) or "(no user text)"
+    head = f"Turn {index} · {head_preview}"
     return (
-        f"### Turn {index} · {ts}\n"
+        "<accordion-plain>\n"
+        f"{head}\n\n"
         f"**User:** {user}\n\n"
         f"**Assistant:** {assistant}\n\n"
         f"**Tools:** {tools}\n\n"
-        f"**Files touched:** {files}\n"
+        f"**Files touched:** {files}\n\n"
+        f"_{ts}_\n"
+        "</accordion-plain>\n"
     )
 
 
@@ -274,6 +285,18 @@ def _truncate(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
     return text[: limit - 1].rstrip() + "…"
+
+
+def summary_from_user_text(text: str) -> str:
+    """Build a single-line frontmatter `summary` from a user turn's text.
+
+    Used at first tick as a placeholder until the `deepvista-summarize-session`
+    skill produces a real LLM-generated summary at finalize. Returns an empty
+    string when the input is blank — callers should skip writing the field in
+    that case rather than persisting an empty placeholder.
+    """
+    cleaned = _truncate(text, FRONTMATTER_SUMMARY_CHAR_LIMIT)
+    return cleaned
 
 
 # ---------------------------------------------------------------------------
@@ -315,7 +338,7 @@ def _cap_body_size(body: str) -> str:
     fm, rest = parse_frontmatter(body)
     head, _, tail = rest.partition("## Turns")
     tail = tail.split("\n", 1)[1] if "\n" in tail else ""
-    turn_blocks = re.split(r"(?=^### Turn \d+ · )", tail, flags=re.MULTILINE)
+    turn_blocks = re.split(r"(?=^<accordion-plain>)", tail, flags=re.MULTILINE)
     turn_blocks = [b for b in turn_blocks if b.strip()]
     kept: list[str] = []
     size = len(serialize_frontmatter(fm, head + "## Turns\n\n").encode("utf-8"))
@@ -418,6 +441,8 @@ def session_tags(session_id: str, agent: str, cwd: str, agent_id: str | None = N
     ]
 
 
-def default_title(session_id: str, cwd: str) -> str:
-    project = Path(cwd).name or "session"
-    return f"{project} · {session_id[:8]}"
+def default_title(session_id: str, cwd: str, now: datetime | None = None) -> str:
+    project = Path(cwd).name
+    started = (now or datetime.now(UTC)).strftime("%Y-%m-%d %H:%M")
+    prefix = f"{project} session" if project else "session"
+    return f"{prefix} · {started}"

--- a/tests/test_session_note_format.py
+++ b/tests/test_session_note_format.py
@@ -1,0 +1,142 @@
+"""Tests for DV-817: session card title + turn-block formatting.
+
+The session card is rendered in DeepVista's vistabase using the
+``<accordion-plain>`` shortcode for each round, and the title is shown as the
+list-row label. These tests pin the format so a regression in the CLI is
+caught before it ships a wall of unwrapped turns to users.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from datetime import UTC, datetime
+
+from deepvista_cli import session_note as sn
+from deepvista_cli.session_note import Turn
+
+
+def test_default_title_is_human_readable() -> None:
+    now = datetime(2026, 5, 25, 14, 32, tzinfo=UTC)
+    title = sn.default_title("abcdef0123456789", "/Users/rj/Project/deepvista", now=now)
+    assert title == "deepvista session · 2026-05-25 14:32"
+
+
+def test_default_title_falls_back_when_cwd_unnamed() -> None:
+    now = datetime(2026, 5, 25, 14, 32, tzinfo=UTC)
+    title = sn.default_title("abcdef0123456789", "/", now=now)
+    assert title.startswith("session · 2026-05-25 14:32")
+
+
+def test_summarize_turn_wraps_in_accordion_plain() -> None:
+    turn = Turn(
+        user_text="Help me improve the session card UI",
+        assistant_text="Sure, here is the plan",
+        tool_counts=Counter({"Read": 3, "Edit": 1}),
+        files_touched=["/foo/bar.py"],
+    )
+    now = datetime(2026, 5, 25, 14, 32, tzinfo=UTC)
+    block = sn.summarize_turn(turn, 1, now=now)
+
+    assert block.startswith("<accordion-plain>\n")
+    assert block.rstrip().endswith("</accordion-plain>")
+
+    # Head line: "Turn N · <preview from user text>"
+    head_line = block.split("\n", 2)[1]
+    assert head_line == "Turn 1 · Help me improve the session card UI"
+
+    # Body keeps the existing structured fields.
+    assert "**User:** Help me improve the session card UI" in block
+    assert "**Assistant:** Sure, here is the plan" in block
+    assert "**Tools:** Read(3), Edit(1)" in block
+    assert "**Files touched:** `/foo/bar.py`" in block
+    assert "_2026-05-25T14:32:00+00:00_" in block
+
+
+def test_summarize_turn_head_falls_back_when_user_text_empty() -> None:
+    turn = Turn(user_text="", assistant_text="Some output", tool_counts=Counter())
+    block = sn.summarize_turn(turn, 7)
+    head_line = block.split("\n", 2)[1]
+    assert head_line == "Turn 7 · (no user text)"
+
+
+def test_summarize_turn_head_truncates_long_user_text() -> None:
+    long_text = "x" * 200
+    turn = Turn(user_text=long_text, assistant_text="ok", tool_counts=Counter())
+    block = sn.summarize_turn(turn, 1)
+    head_line = block.split("\n", 2)[1]
+    # "Turn 1 · " plus the truncated text — capped well under 200 chars
+    assert head_line.startswith("Turn 1 · ")
+    head_payload = head_line[len("Turn 1 · ") :]
+    assert len(head_payload) <= sn.TURN_HEAD_CHAR_LIMIT
+    assert head_payload.endswith("…")
+
+
+def test_serialize_frontmatter_round_trips_summary() -> None:
+    fm = {"agent": "claude-code", "summary": "First question text", "status": "active"}
+    body = sn.serialize_frontmatter(fm, "## Turns\n\n")
+    fm_back, _ = sn.parse_frontmatter(body)
+    assert fm_back["summary"] == "First question text"
+    # `summary` appears before `status` in the canonical order.
+    assert body.index("summary:") < body.index("status:")
+
+
+def test_append_turn_prepends_accordion_blocks() -> None:
+    fm = sn.seed_frontmatter("sess-1", "/tmp/proj", "/tmp/t.jsonl")
+    body = sn.build_initial_body(fm)
+
+    t1 = Turn(user_text="First question", assistant_text="A1", tool_counts=Counter())
+    body = sn.append_turn(body, sn.summarize_turn(t1, 1), {"turn_count": 1, "version": 1})
+
+    t2 = Turn(user_text="Second question", assistant_text="A2", tool_counts=Counter())
+    body = sn.append_turn(body, sn.summarize_turn(t2, 2), {"turn_count": 2, "version": 2})
+
+    # Two accordion blocks, newest first.
+    assert body.count("<accordion-plain>") == 2
+    second_idx = body.index("Turn 2 · ")
+    first_idx = body.index("Turn 1 · ")
+    assert second_idx < first_idx
+
+
+def test_summary_from_user_text_truncates_to_frontmatter_limit() -> None:
+    short = sn.summary_from_user_text("Short prompt")
+    assert short == "Short prompt"
+
+    long_text = "x" * (sn.FRONTMATTER_SUMMARY_CHAR_LIMIT + 50)
+    truncated = sn.summary_from_user_text(long_text)
+    assert len(truncated) <= sn.FRONTMATTER_SUMMARY_CHAR_LIMIT
+    assert truncated.endswith("…")
+
+
+def test_summary_from_user_text_collapses_newlines() -> None:
+    summary = sn.summary_from_user_text("line one\nline two")
+    assert "\n" not in summary
+    assert summary == "line one line two"
+
+
+def test_summary_from_user_text_returns_empty_for_blank_input() -> None:
+    assert sn.summary_from_user_text("") == ""
+    assert sn.summary_from_user_text("   \n  ") == ""
+
+
+def test_cap_body_size_splits_on_accordion_boundary(monkeypatch) -> None:
+    monkeypatch.setattr(sn, "BODY_SIZE_CAP_BYTES", 3000)
+
+    fm = sn.seed_frontmatter("sess-1", "/tmp/proj", "/tmp/t.jsonl")
+    body = sn.build_initial_body(fm)
+    for i in range(1, 11):
+        turn = Turn(
+            user_text=f"Question {i} " + "x" * 200,
+            assistant_text=f"Answer {i} " + "y" * 200,
+            tool_counts=Counter(),
+        )
+        body = sn.append_turn(body, sn.summarize_turn(turn, i), {"turn_count": i, "version": i})
+
+    # Body stayed under the cap.
+    assert len(body.encode("utf-8")) <= 3000
+
+    # Newest turn (10) survives; oldest got trimmed.
+    accordions = re.findall(r"<accordion-plain>", body)
+    assert len(accordions) >= 1
+    assert "Turn 10 · " in body
+    assert "Turn 1 · " not in body

--- a/tests/test_session_note_format.py
+++ b/tests/test_session_note_format.py
@@ -72,13 +72,34 @@ def test_summarize_turn_head_truncates_long_user_text() -> None:
     assert head_payload.endswith("…")
 
 
-def test_serialize_frontmatter_round_trips_summary() -> None:
+def test_serialize_frontmatter_round_trips_unknown_keys() -> None:
+    # Legacy session notes on disk may carry a `summary:` field written by an
+    # older CLI. The parser must still round-trip it so existing cards keep
+    # rendering correctly even after the writer dropped the field.
     fm = {"agent": "claude-code", "summary": "First question text", "status": "active"}
     body = sn.serialize_frontmatter(fm, "## Turns\n\n")
     fm_back, _ = sn.parse_frontmatter(body)
     assert fm_back["summary"] == "First question text"
-    # `summary` appears before `status` in the canonical order.
-    assert body.index("summary:") < body.index("status:")
+
+
+def test_title_from_first_user_turn_truncates_to_title_limit() -> None:
+    assert sn.title_from_first_user_turn("Short prompt") == "Short prompt"
+
+    long_text = "x" * (sn.TITLE_CHAR_LIMIT + 50)
+    truncated = sn.title_from_first_user_turn(long_text)
+    assert len(truncated) <= sn.TITLE_CHAR_LIMIT
+    assert truncated.endswith("…")
+
+
+def test_title_from_first_user_turn_collapses_whitespace() -> None:
+    derived = sn.title_from_first_user_turn("line one\nline two")
+    assert "\n" not in derived
+    assert derived == "line one line two"
+
+
+def test_title_from_first_user_turn_returns_empty_for_blank_input() -> None:
+    assert sn.title_from_first_user_turn("") == ""
+    assert sn.title_from_first_user_turn("   \n  ") == ""
 
 
 def test_append_turn_prepends_accordion_blocks() -> None:
@@ -96,27 +117,6 @@ def test_append_turn_prepends_accordion_blocks() -> None:
     second_idx = body.index("Turn 2 · ")
     first_idx = body.index("Turn 1 · ")
     assert second_idx < first_idx
-
-
-def test_summary_from_user_text_truncates_to_frontmatter_limit() -> None:
-    short = sn.summary_from_user_text("Short prompt")
-    assert short == "Short prompt"
-
-    long_text = "x" * (sn.FRONTMATTER_SUMMARY_CHAR_LIMIT + 50)
-    truncated = sn.summary_from_user_text(long_text)
-    assert len(truncated) <= sn.FRONTMATTER_SUMMARY_CHAR_LIMIT
-    assert truncated.endswith("…")
-
-
-def test_summary_from_user_text_collapses_newlines() -> None:
-    summary = sn.summary_from_user_text("line one\nline two")
-    assert "\n" not in summary
-    assert summary == "line one line two"
-
-
-def test_summary_from_user_text_returns_empty_for_blank_input() -> None:
-    assert sn.summary_from_user_text("") == ""
-    assert sn.summary_from_user_text("   \n  ") == ""
 
 
 def test_cap_body_size_splits_on_accordion_boundary(monkeypatch) -> None:


### PR DESCRIPTION
Wrap each turn block in `<accordion-plain>` so the rendered session card collapses to one line per round in the DeepVista editor instead of a wall of plaintext. Replace the hex-id title with a readable `<project> session · YYYY-MM-DD HH:MM` placeholder; the `deepvista-summarize-session` skill rewrites it to a Title-Case headline at finalize.

Seed the frontmatter `summary` field from the first user turn on first tick so the vistabase list-row preview has something to show during in-flight sessions. Later ticks never overwrite it — the finalize-time LLM rollup is the source of truth once the session ends.