### PR TITLE
release: v0.1.14

### DIFF
--- a/plugins/claude-code/.claude-plugin/plugin.json
+++ b/plugins/claude-code/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "deepvista",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Remote-managed skill catalog from DeepVista. Auto-syncs thin stubs into the plugin's skills dir on SessionStart; full bodies are lazy-loaded at invocation time.",
   "author": {
     "name": "DeepVista AI",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "deepvista-cli"
-version = "0.1.13"
+version = "0.1.14"
 description = "CLI for DeepVista — chat, notes, skills, and memory from your terminal."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ wheels = [
 
 [[package]]
 name = "deepvista-cli"
-version = "0.1.13"
+version = "0.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Bump version for release.

## Changes since v0.1.13

- #129 feat(skill): add phase reset command + workflow run_hint in skill get
- #130 feat(plugin): announce DeepVista skill URL on Skill invocation
- #133 feat: consolidate DV-791 + DV-796 (unified agent tag + install.sh cleanup)
- #135 fix(notes): reject +quick input that would force title truncation