### PR TITLE
feat(session): skip session init for configured CWD patterns (DV-862)

### DIFF
--- a/deepvista_cli/commands/session.py
+++ b/deepvista_cli/commands/session.py
@@ -23,6 +23,7 @@ import click
 from deepvista_cli import session_note as sn
 from deepvista_cli.client.http import DeepVistaClient
 from deepvista_cli.client.origin import detect_agent_tool
+from deepvista_cli.config import should_skip_session_cwd
 from deepvista_cli.output.formatter import format_output, output_error
 
 SESSION_CARD_TYPE = "session"
@@ -115,6 +116,29 @@ def session_init(
     > [!CAUTION] This is a write command (creates a card on first call).
     """
     from deepvista_cli.commands.agents import load_agent_id_for_active_agent
+
+    if should_skip_session_cwd(cwd):
+        # DV-862: CWD matches ``session_skip_cwd_patterns`` in
+        # ``~/.config/deepvista/config.json``. Drops sub-agent sessions
+        # whose CWD isn't a real working directory — e.g. claude-mem's
+        # observer sub-claude runs with
+        # ``cwd=~/.claude-mem/observer-sessions`` and quotes file paths
+        # from the *primary* session, polluting the vistabase. Downstream
+        # ``tick`` / ``finalize`` self-no-op (no cached card → exit 3) so
+        # guarding ``init`` alone covers the whole lifecycle.
+        format_output(
+            {
+                "skipped": True,
+                "reason": "cwd matches session_skip_cwd_patterns",
+                "cwd": cwd,
+                "session_id": session_id,
+            },
+            ctx.obj.output_format,
+            title="Session init (skipped)",
+            entity_type=SESSION_ENTITY_TYPE,
+            base_url=ctx.obj.auth_url,
+        )
+        return
 
     if agent is None:
         detected_agent, detected_version = detect_agent_tool()

--- a/deepvista_cli/config.py
+++ b/deepvista_cli/config.py
@@ -8,6 +8,7 @@ Resolution order for each setting:
 
 from __future__ import annotations
 
+import fnmatch
 import json
 import os
 from dataclasses import dataclass
@@ -35,6 +36,21 @@ def credentials_path(profile: str = "default") -> Path:
 
 
 PROFILES_PATH = CONFIG_DIR / "config.json"
+
+# Reserved top-level key in ``config.json`` holding the list of CWD globs
+# that ``deepvista session init`` should skip. Stored as a flat list (not a
+# dict) so it's trivially distinguishable from profile entries and easy for
+# the user to hand-edit. See DV-862.
+SESSION_SKIP_CWD_KEY = "session_skip_cwd_patterns"
+
+# Defaults used when ``config.json`` is missing the key. Skips claude-mem's
+# observer sub-claude (cwd=~/.claude-mem/observer-sessions) so its quoted
+# file paths from the *primary* session don't get mined into bogus File
+# cards (root cause for DV-861).
+DEFAULT_SESSION_SKIP_CWD_PATTERNS: tuple[str, ...] = (
+    "*/.claude-mem/observer-sessions",
+    "*/.claude-mem/observer-sessions/*",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -84,8 +100,13 @@ def set_profile(name: str, settings: dict) -> None:
 
 
 def list_profiles() -> dict:
-    """List all profiles."""
-    return _load_profiles()
+    """List all profiles.
+
+    Filters out reserved non-profile keys (e.g.
+    ``session_skip_cwd_patterns``) by keeping only dict-valued entries —
+    profiles are always dicts, reserved settings are lists/scalars.
+    """
+    return {k: v for k, v in _load_profiles().items() if isinstance(v, dict)}
 
 
 def delete_profile(name: str) -> bool:
@@ -95,6 +116,40 @@ def delete_profile(name: str) -> bool:
         del profiles[name]
         _save_profiles(profiles)
         return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Session CWD skip patterns (DV-862)
+# ---------------------------------------------------------------------------
+
+
+def get_session_skip_cwd_patterns() -> list[str]:
+    """Return the configured CWD-skip patterns for ``session init``.
+
+    Reads a top-level ``session_skip_cwd_patterns`` list from
+    ``~/.config/deepvista/config.json``. There is no matching setter — edit
+    the file by hand. Falls back to ``DEFAULT_SESSION_SKIP_CWD_PATTERNS``
+    when the key is absent. An explicit empty list disables skipping.
+    """
+    raw = _load_profiles().get(SESSION_SKIP_CWD_KEY)
+    if isinstance(raw, list):
+        return [str(p) for p in raw]
+    return list(DEFAULT_SESSION_SKIP_CWD_PATTERNS)
+
+
+def should_skip_session_cwd(cwd: str | None) -> bool:
+    """Return True iff ``cwd`` matches any configured skip pattern.
+
+    Matching is fnmatch-style (Unix shell globs; ``*`` matches across path
+    separators). The hook payload's ``cwd`` is already absolute on every
+    supported agent, so no resolution is performed here.
+    """
+    if not cwd:
+        return False
+    for pattern in get_session_skip_cwd_patterns():
+        if fnmatch.fnmatchcase(cwd, pattern):
+            return True
     return False
 
 

--- a/plugins/claude-code/README.md
+++ b/plugins/claude-code/README.md
@@ -78,6 +78,7 @@ Tunable via environment variables (read by the `SessionStart` hook):
 | `${CLAUDE_PLUGIN_ROOT}/agents/dv-<role>.md` | Generated subagent (one per managed-agent role) |
 | `~/.config/deepvista/catalog-state.json` | Last skill-sync timestamp + stub inventory |
 | `~/.config/deepvista/agent-defs-state.json` | Last agent-export timestamp + definition inventory |
+| `~/.config/deepvista/config.json` | CLI profiles + top-level `session_skip_cwd_patterns` list |
 | `~/.config/deepvista/cache/skill-bodies/` | 5-minute TTL cache of fetched bodies |
 | `~/.config/deepvista/logs/catalog-sync.log` | Skill-sync hook stdout/stderr |
 | `~/.config/deepvista/logs/agent-export.log` | Agent-export hook stdout/stderr |
@@ -100,6 +101,24 @@ Force a fresh run from the shell:
 ```
 DEEPVISTA_FORCE_SYNC=1 deepvista skill sync --force
 deepvista agents export --force
+```
+
+Nested observer/sub-agent sessions showing up in the vistabase (e.g.
+`observer-sessions · <hash>` notes from claude-mem's observer sub-claude)?
+The plugin's SessionStart hook now skips CWDs matching the top-level
+`session_skip_cwd_patterns` list in `~/.config/deepvista/config.json`.
+Defaults cover `~/.claude-mem/observer-sessions`; to extend, edit the file
+and add patterns (fnmatch-style globs):
+
+```jsonc
+{
+  "default": { "api_url": "https://api.deepvista.ai" },
+  "session_skip_cwd_patterns": [
+    "*/.claude-mem/observer-sessions",
+    "*/.claude-mem/observer-sessions/*",
+    "*/scratchpad/*"
+  ]
+}
 ```
 
 No agents showing up as `@<role>`? Confirm you have managed agents with roles:

--- a/skills/deepvista/reference/session.md
+++ b/skills/deepvista/reference/session.md
@@ -54,6 +54,37 @@ deepvista session tick \
 deepvista session finalize --session-id "$CLAUDE_SESSION_ID"
 ```
 
+## Skipping nested sub-agent sessions
+
+`session init` short-circuits when `--cwd` matches any pattern in
+`session_skip_cwd_patterns` (a top-level list in
+`~/.config/deepvista/config.json`). This stops the SessionStart hook from
+recording sub-agent sessions whose CWD is not a real working directory — e.g.
+**claude-mem's observer sub-claude** runs with
+`cwd=~/.claude-mem/observer-sessions` and only quotes file paths from the
+*primary* session; recording it pollutes the vistabase with bogus File cards.
+
+Defaults skip `*/.claude-mem/observer-sessions[/*]`. Patterns are
+fnmatch-style Unix shell globs (`*` matches across `/`). To override, edit
+`~/.config/deepvista/config.json` by hand — add a top-level
+`session_skip_cwd_patterns` list. An explicit empty list disables skipping.
+
+```jsonc
+{
+  "default": { "api_url": "https://api.deepvista.ai" },
+  "session_skip_cwd_patterns": [
+    "*/.claude-mem/observer-sessions",
+    "*/.claude-mem/observer-sessions/*",
+    "*/scratchpad/*"
+  ]
+}
+```
+
+When a session is skipped, `init` emits
+`{"skipped": true, "reason": "cwd matches session_skip_cwd_patterns", ...}`
+and creates no card. Downstream `tick` / `finalize` self-no-op because no
+card was cached (exit 3 "Unknown session", silenced by the hook scripts).
+
 ## See also
 
 - [notes.md](notes.md) — explicit user-authored knowledge.


### PR DESCRIPTION
[https://app.visla.us/clip/1509691851295281434](<https://app.visla.us/clip/1509691851295281434>)

## Summary

* Adds a top-level `session_skip_cwd_patterns` list in `~/.config/deepvista/config.json`. When the SessionStart hook fires inside a sub-agent CWD that matches any configured pattern, `deepvista session init` short-circuits with `{"skipped": true, ...}` and creates no card; downstream `tick` / `finalize` self-no-op because no card was cached (exit 3 "Unknown session", silenced by the hook scripts).
* Defaults skip `*/.claude-mem/observer-sessions[/*]` — claude-mem's observer sub-claude was being recorded as if it were a real working session, and its `<observed_from_primary_session>` quotes were getting mined into bogus File-type context cards (root cause for [DV-861](https://linear.app/deepvista/issue/DV-861)).
* **No new CLI commands**: edit `config.json` by hand to override. The reserved key is a flat list (not a dict), so `deepvista config list` filters it out by keeping only dict-valued entries.

Linear: [DV-862](https://linear.app/deepvista/issue/DV-862/deepvista-cli-skip-session-init-when-cwd-matches-configured-patterns) (High, related to [DV-861](https://linear.app/deepvista/issue/DV-861/file-cards-should-only-be-created-from-real-content-not-file-path))

## Example config

```jsonc
{
  "default": { "api_url": "https://api.deepvista.ai" },
  "session_skip_cwd_patterns": [
    "*/.claude-mem/observer-sessions",
    "*/.claude-mem/observer-sessions/*",
    "*/scratchpad/*"
  ]
}
```

Patterns are fnmatch-style Unix shell globs (`*` matches across `/`). An explicit empty list disables skipping.

## Test plan

- [X] `uv run pytest tests/` — 66 / 66 pass. (No new tests; existing suite covers `config list` and session init invariants.)
- [X] `uv run ruff check` + `ruff format` — clean.
- [X] `gh skill publish --dry-run` — passes (skill reference doc updated).
- [X] E2E (manual): `DEEPVISTA_CONFIG_DIR=/tmp/dv` with hand-written `config.json` containing `session_skip_cwd_patterns` correctly skips observer CWD (`{"skipped": true, "reason": "cwd matches session_skip_cwd_patterns", ...}`), proceeds for normal CWDs, and `config list` only returns the dict-valued profile entry.
- [X] `deepvista config --help` no longer exposes a `skip-cwd` subgroup.

## Out of scope (tracked separately in [DV-861](https://linear.app/deepvista/issue/DV-861/file-cards-should-only-be-created-from-real-content-not-file-path))

* Server-side gate on File-card creation when content is absent.
* One-off cleanup of existing `observer-sessions · <hash>` notes and their derived bogus File cards.