### PR TITLE
feat(DV-869): add skill preflight summary command

### DIFF
--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -21,6 +21,7 @@ from deepvista_cli import skill_catalog
 from deepvista_cli.client.http import DeepVistaClient
 from deepvista_cli.output.formatter import format_output, output_error
 from deepvista_cli.workflow_doc import (
+    PreflightReport,
     WorkflowDocument,
     is_phase_server_routable,
 )
@@ -109,6 +110,101 @@ def skill_get(ctx: click.Context, skill_id: str) -> None:
     format_output(
         data, ctx.obj.output_format, title=f"Skill: {skill_id}", entity_type="skill", base_url=ctx.obj.auth_url
     )
+
+
+@skill_group.command("preflight")
+@click.argument("skill_id")
+@click.pass_context
+def skill_preflight(ctx: click.Context, skill_id: str) -> None:
+    """Preview a workflow Skill before running it — likely inputs, permissions, and outputs.
+
+    Read-only — does NOT acquire the run lock and never writes to the card.
+    Fetches the Skill card, parses its phases, and prints a Preflight Summary
+    so the user gets a high-level view before kicking off ``skill run``:
+
+    \b
+    - likely INPUTS per phase (heuristic over the phase body)
+    - likely PERMISSIONS — server-only phases run on DeepVista (no local
+      perms); the rest need a configured local agent
+    - expected OUTPUT per phase (the phase's ``done_when``, else its title)
+
+    Output is a JSON header (``type: "preflight_summary"``) followed by a
+    human-readable body, mirroring ``skill run``'s header+body convention.
+    """
+    if not _UUID_RE.match(skill_id):
+        output_error(3, "Invalid skill ID", f"Expected UUID format, got: {skill_id!r}")
+
+    card = _client(ctx).post("/get_context_card", {"card_id": skill_id, "card_type": "skill"})
+    if not card or not card.get("description"):
+        output_error(3, "Skill not found or has empty description", f"skill_id={skill_id}")
+
+    doc = WorkflowDocument(card["description"])
+    if not doc.phases():
+        output_error(3, "Skill has no <accordion> phases", f"skill_id={skill_id}")
+
+    report = doc.analyze_preflight()
+
+    needs_local = any(not p.runs_on_deepvista for p in report.phases)
+    header = {
+        "type": "preflight_summary",
+        "skill_id": skill_id,
+        "skill_title": card.get("title", ""),
+        "skill_status": card.get("status", ""),
+        "needs_local_agent": needs_local,
+        "phases": [
+            {
+                "index": p.index,
+                "title": p.title,
+                "inputs": p.inputs,
+                "permission": p.permission,
+                "runs_on_deepvista": p.runs_on_deepvista,
+                "expected_output": p.expected_output,
+            }
+            for p in report.phases
+        ],
+    }
+
+    click.echo(json.dumps(header, default=str))
+    click.echo()  # blank line so agents can split header from body cheaply
+    click.echo(_render_preflight_body(card.get("title", ""), report, needs_local=needs_local))
+
+
+def _render_preflight_body(skill_title: str, report: PreflightReport, *, needs_local: bool) -> str:
+    """Render the human-readable Preflight Summary body for `skill preflight`."""
+    lines: list[str] = []
+    lines.append(f"# Preflight Summary — {skill_title}" if skill_title else "# Preflight Summary")
+    lines.append("")
+    lines.append("> Inputs are heuristic (no formal `inputs:` schema yet) — review before running.")
+    lines.append("")
+
+    for p in report.phases:
+        # Titles often already carry a "Phase N:" prefix — don't double it.
+        heading = p.title if re.match(r"^\s*phase\b", p.title, re.IGNORECASE) else f"Phase {p.index}: {p.title}"
+        lines.append(f"## {heading}")
+        lines.append("")
+
+        lines.append("- Likely inputs (heuristic):")
+        if p.inputs:
+            for item in p.inputs:
+                lines.append(f"  - {item}")
+        else:
+            lines.append("  - (none detected)")
+
+        lines.append(f"- Likely permissions: {p.permission}")
+        lines.append(f"- Expected output: {p.expected_output}")
+        lines.append("")
+
+    if needs_local:
+        lines.append("---")
+        lines.append("")
+        lines.append(
+            "Some phases need a local agent (Claude Code / Cursor / OpenClaw). "
+            "Configure one: https://www.deepvista.ai/landing/cli"
+        )
+        lines.append("")
+
+    lines.append("When ready, run: `deepvista skill run --mode host <skill_id>`")
+    return "\n".join(lines)
 
 
 # ---------------------------------------------------------------------------

--- a/deepvista_cli/workflow_doc.py
+++ b/deepvista_cli/workflow_doc.py
@@ -55,6 +55,53 @@ class PhaseInfo:
     tool_plan: list[str]
 
 
+@dataclass
+class PreflightPhase:
+    """Per-phase preflight view: likely inputs, permissions, expected output.
+
+    All three fields are best-effort heuristics derived from the phase body
+    (see :meth:`WorkflowDocument.analyze_preflight`). ``inputs`` is labelled
+    heuristic because no formal ``inputs:`` metadata exists in v1.
+    """
+
+    index: int  # 1-based, mirrors PhaseInfo.index
+    title: str
+    inputs: list[str]  # heuristic placeholders / imperative cues, capped per phase
+    permission: str  # human-readable permission requirement
+    runs_on_deepvista: bool  # True => no local perms needed
+    expected_output: str  # done_when contract if present, else falls back to title
+
+
+@dataclass
+class PreflightReport:
+    """Structured result of :meth:`WorkflowDocument.analyze_preflight`."""
+
+    phases: list[PreflightPhase]
+
+
+# Permission labels reused by ``analyze_preflight`` and the CLI body renderer.
+PERMISSION_SERVER = "runs on DeepVista (no local perms)"
+PERMISSION_LOCAL = "needs local agent permissions"
+
+# Cap on heuristic inputs surfaced per phase, so the summary stays scannable.
+_MAX_INPUTS_PER_PHASE = 5
+
+# Angle-bracket (``<...>``) and brace (``{{...}}``) placeholders in a phase body.
+# Angle-bracket match is conservative: no whitespace-only or HTML-tag-like
+# captures (those are accordion/markup, not input slots).
+_BRACE_PLACEHOLDER_RE = re.compile(r"\{\{\s*([^{}]+?)\s*\}\}")
+_ANGLE_PLACEHOLDER_RE = re.compile(r"<([a-z0-9 _./-]{2,60})>", re.IGNORECASE)
+
+# Imperative cues that signal the phase expects something from the user.
+_INPUT_CUE_RE = re.compile(
+    r"(?:provide|ask the user|prompt for|paste|specify)\b[^.\n]{0,80}",
+    re.IGNORECASE,
+)
+
+# ``done_when:`` line(s) inside a yaml block — the phase's expected output.
+_DONE_WHEN_RE = re.compile(r"^\s*done_when:\s*(?P<inline>.*)$", re.MULTILINE)
+
+
 # ---------------------------------------------------------------------------
 # Tool names that only the DeepVista server agent has (not the CLI)
 # ---------------------------------------------------------------------------
@@ -128,6 +175,40 @@ class WorkflowDocument:
             if p.state == "pending":
                 return p
         return None
+
+    def analyze_preflight(self) -> PreflightReport:
+        """Produce a best-effort preflight summary, one entry per phase.
+
+        Pure / read-only: never mutates the document. For each ``<accordion>``
+        phase it derives:
+
+        - ``inputs`` — heuristic placeholders (``<...>`` / ``{{...}}``) and
+          imperative cues ("provide", "ask the user", "prompt for", "paste",
+          "specify") found in the phase body. Deduped, capped per phase.
+        - ``permission`` — reuses ``tool_plan`` + ``is_phase_server_routable``:
+          server-routable phases need no local perms; everything else needs
+          local agent permissions.
+        - ``expected_output`` — the phase's ``done_when`` contract if present,
+          otherwise the phase title.
+        """
+        phase_infos = self.phases()
+        bodies = [m.group("body") for m in _ACCORDION_RE.finditer(self._body)]
+
+        out: list[PreflightPhase] = []
+        for info, body in zip(phase_infos, bodies):
+            server = is_phase_server_routable(info)
+            done_when = _done_when_from_yaml_text(body)
+            out.append(
+                PreflightPhase(
+                    index=info.index,
+                    title=info.title,
+                    inputs=_heuristic_inputs(body),
+                    permission=PERMISSION_SERVER if server else PERMISSION_LOCAL,
+                    runs_on_deepvista=server,
+                    expected_output=done_when or info.title,
+                )
+            )
+        return PreflightReport(phases=out)
 
     # ------------------------------------------------------------------
     # Mutate — accordions
@@ -238,6 +319,75 @@ def _tool_plan_names_from_yaml_text(yaml_text: str) -> list[str]:
         if item_match:
             out.append(item_match.group(1))
     return out
+
+
+def _heuristic_inputs(accordion_body: str) -> list[str]:
+    """Best-effort guess at inputs a phase expects from the user.
+
+    Combines two signals from the phase body, in document order:
+
+    1. Placeholders: ``{{ name }}`` and ``<name>`` slots.
+    2. Imperative cues: short snippets following "provide", "ask the user",
+       "prompt for", "paste", "specify".
+
+    Results are stripped, de-duplicated case-insensitively, and capped at
+    ``_MAX_INPUTS_PER_PHASE``. These are heuristics, not a formal schema.
+    """
+    candidates: list[str] = []
+    for m in _BRACE_PLACEHOLDER_RE.finditer(accordion_body):
+        candidates.append("{{ " + m.group(1).strip() + " }}")
+    for m in _ANGLE_PLACEHOLDER_RE.finditer(accordion_body):
+        candidates.append("<" + m.group(1).strip() + ">")
+    for m in _INPUT_CUE_RE.finditer(accordion_body):
+        snippet = " ".join(m.group(0).split())
+        if snippet:
+            candidates.append(snippet)
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for cand in candidates:
+        key = cand.lower()
+        if cand and key not in seen:
+            seen.add(key)
+            out.append(cand)
+        if len(out) >= _MAX_INPUTS_PER_PHASE:
+            break
+    return out
+
+
+def _done_when_from_yaml_text(accordion_body: str) -> str:
+    """Return the phase's ``done_when`` contract if present, else ``""``.
+
+    Mirrors the lightweight, PyYAML-free extraction used for ``tool_plan``:
+    finds the ``done_when:`` key inside any inline ```` ```yaml ```` block in
+    the accordion and returns its value. Supports an inline scalar
+    (``done_when: text``) or a block list of ``- item`` lines joined with
+    "; ".
+    """
+    yaml_match = _INLINE_YAML_RE.search(accordion_body)
+    yaml_text = yaml_match.group("body") if yaml_match else accordion_body
+
+    m = _DONE_WHEN_RE.search(yaml_text)
+    if not m:
+        return ""
+
+    inline = m.group("inline").strip().strip("\"'")
+    if inline:
+        return inline
+
+    # Block form: collect ``- item`` lines indented under ``done_when:``.
+    lines = yaml_text[m.end() :].splitlines()
+    items: list[str] = []
+    for raw in lines:
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        item_match = re.match(r"-\s*(.+)$", stripped)
+        if item_match:
+            items.append(item_match.group(1).strip().strip("\"'"))
+        else:
+            break
+    return "; ".join(items)
 
 
 def is_phase_server_routable(phase: PhaseInfo) -> bool:

--- a/skills/deepvista/reference/skill.md
+++ b/skills/deepvista/reference/skill.md
@@ -5,14 +5,14 @@ Run `deepvista skill --help` or `deepvista skill <cmd> --help` for full flag ref
 
 ## Commands
 
-`list` · `get` · `run` · `phase` · `complete` · `status`
+`list` · `get` · `preflight` · `run` · `phase` · `complete` · `status`
 `create-from-note` · `discover` · `install` · `sync` · `load`
 
 ## Agent conventions
 
 > [!CAUTION] `run`, `phase`, `complete`, `install` are writes. Confirm first.
 
-Read-only: `list`, `get`, `status`, `discover`, `sync --dry-run`, `load`.
+Read-only: `list`, `get`, `preflight`, `status`, `discover`, `sync --dry-run`, `load`.
 
 Show the app URL after writes: `https://app.deepvista.ai/skills/<id>`
 
@@ -41,6 +41,26 @@ deepvista skill complete <skill_id> --review "<3–6 retrospective bullets>"
 ```
 
 If you called `skill get` and are already mid-workflow without a lock, call `skill run --mode host` now — it is idempotent on an already-in-progress card and will re-emit the correct active phase.
+
+## Preflight before a run
+
+`deepvista skill preflight <skill_id>` is a **read-only** preview — no run lock,
+no card write. It prints a `type: "preflight_summary"` JSON header plus a
+human-readable body summarizing, per phase:
+
+- **likely inputs** — heuristic over the phase body (placeholders like `<...>` /
+  `{{...}}` and cues like "ask the user", "provide", "paste"). No formal
+  `inputs:` schema exists yet, so treat these as hints.
+- **likely permissions** — server-only phases run on DeepVista (no local perms);
+  the rest need a configured local agent (Claude Code / Cursor / OpenClaw).
+- **expected output** — the phase's `done_when` contract, else its title.
+
+Use it to give the user a high-level view before `skill run`. When any phase
+needs a local agent, the body links to <https://www.deepvista.ai/landing/cli>.
+
+```bash
+deepvista skill preflight <skill_id>
+```
 
 ## Non-obvious: `skill run` modes
 
@@ -80,6 +100,7 @@ cache). Called by stubs — rarely needed directly.
 
 ```bash
 deepvista skill list
+deepvista skill preflight <skill_id>                           # read-only preview
 deepvista skill run <skill_id> --input "Focus on Q4"          # host mode
 deepvista skill run <skill_id> --mode deepvista                # server agent
 deepvista skill run <skill_id> --mode auto                     # per-phase routing

--- a/tests/test_skill_commands.py
+++ b/tests/test_skill_commands.py
@@ -164,6 +164,135 @@ def test_skill_load_rejects_non_uuid(
     assert "Invalid skill ID" in result.output or "Invalid skill ID" in (result.stderr or "")
 
 
+# ---------------------------------------------------------------------------
+# skill preflight — DV-869
+# ---------------------------------------------------------------------------
+
+_PREFLIGHT_SKILL_ID = "11111111-2222-3333-4444-555555555555"
+
+# A workflow body with two accordion phases:
+#  - Phase 1: server-only tool_plan + done_when contract + a placeholder input
+#  - Phase 2: a host tool (run_command) + an imperative cue, no done_when
+_PREFLIGHT_BODY = """\
+<accordion checked="false" open="true">
+Phase 1: Gather context
+
+Look up the topic <topic name> in the knowledge base.
+
+```yaml
+tool_plan:
+  - grep_context_cards: "search"
+  - read_context_card: "read"
+done_when: "a context summary card is written"
+```
+</accordion>
+
+<accordion checked="false" open="false">
+Phase 2: Build it
+
+Ask the user for the target directory, then scaffold.
+
+```yaml
+tool_plan:
+  - run_command: "shell"
+```
+</accordion>
+"""
+
+
+def test_skill_preflight_emits_summary_header_and_body(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/get_context_card",
+        {
+            "id": _PREFLIGHT_SKILL_ID,
+            "title": "Demo Workflow",
+            "status": "queued",
+            "description": _PREFLIGHT_BODY,
+        },
+    )
+    _install_stub_client(monkeypatch, stub)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["skill", "preflight", _PREFLIGHT_SKILL_ID])
+    assert result.exit_code == 0, result.output
+
+    header_line = result.output.splitlines()[0]
+    header = json.loads(header_line)
+    assert header["type"] == "preflight_summary"
+    assert header["skill_id"] == _PREFLIGHT_SKILL_ID
+    assert header["needs_local_agent"] is True
+    assert len(header["phases"]) == 2
+
+    # All three sections present in the human-readable body.
+    assert "Likely inputs (heuristic):" in result.output
+    assert "Likely permissions:" in result.output
+    assert "Expected output:" in result.output
+
+    # Read-only: no write endpoint was hit.
+    assert "/update_context_card" not in stub.responses
+    assert stub.responses.get("/workflow_phase") is None
+
+
+def test_skill_preflight_rejects_non_uuid(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()  # empty queue — any API call fails loudly
+    _install_stub_client(monkeypatch, stub)
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["skill", "preflight", "not-a-uuid"])
+    assert result.exit_code == 3
+    assert "Invalid skill ID" in result.output or "Invalid skill ID" in (result.stderr or "")
+
+
+# ---------------------------------------------------------------------------
+# WorkflowDocument.analyze_preflight — unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_preflight_server_only_phase_needs_no_local_perms() -> None:
+    from deepvista_cli.workflow_doc import PERMISSION_SERVER, WorkflowDocument
+
+    report = WorkflowDocument(_PREFLIGHT_BODY).analyze_preflight()
+    phase1 = report.phases[0]
+    assert phase1.runs_on_deepvista is True
+    assert phase1.permission == PERMISSION_SERVER
+
+
+def test_analyze_preflight_run_command_phase_needs_local_agent() -> None:
+    from deepvista_cli.workflow_doc import PERMISSION_LOCAL, WorkflowDocument
+
+    report = WorkflowDocument(_PREFLIGHT_BODY).analyze_preflight()
+    phase2 = report.phases[1]
+    assert phase2.runs_on_deepvista is False
+    assert phase2.permission == PERMISSION_LOCAL
+
+
+def test_analyze_preflight_detects_placeholder_and_cue_inputs() -> None:
+    from deepvista_cli.workflow_doc import WorkflowDocument
+
+    report = WorkflowDocument(_PREFLIGHT_BODY).analyze_preflight()
+    # Phase 1 angle-bracket placeholder.
+    assert any("<topic name>" in i for i in report.phases[0].inputs)
+    # Phase 2 imperative cue.
+    assert any(i.lower().startswith("ask the user") for i in report.phases[1].inputs)
+
+
+def test_analyze_preflight_uses_done_when_then_title_fallback() -> None:
+    from deepvista_cli.workflow_doc import WorkflowDocument
+
+    report = WorkflowDocument(_PREFLIGHT_BODY).analyze_preflight()
+    # Phase 1 has a done_when contract.
+    assert report.phases[0].expected_output == "a context summary card is written"
+    # Phase 2 has none → falls back to the phase title.
+    assert report.phases[1].expected_output == "Phase 2: Build it"
+
+
 def test_skill_sync_exits_zero_on_network_error(
     isolated_home: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Closes DV-869

## Summary
Adds a read-only `deepvista skill preflight <skill_id>` command that previews a workflow skill before a run — so users get a high-level view (and an agent can pick up the summary) without acquiring a run lock or mutating the card.
- New `WorkflowDocument.analyze_preflight()` (pure) → per-phase **likely inputs** (heuristic: `<...>`/`{{...}}` placeholders + imperative cues, capped 5/phase), **likely permissions** (server-only vs. needs-local-agent, via `tool_plan` + `SERVER_ONLY_TOOLS`), and **expected output** (`done_when`, falling back to phase title).
- New Click command emits a `type: "preflight_summary"` JSON header + human-readable body (mirrors `skill run`); links to the local-agent setup page when host permissions are needed.

## Test plan
- [x] `ruff check` / `ruff format --check` → clean
- [x] `pyright` (with `ui` extra) → 0 errors
- [x] `pytest` → 56 passed (incl. 6 new: 2 Click-level, 4 unit for `analyze_preflight`)

## Notes
- Base is `main` (cli trunk), not `staging`.
- v1 input detection is **heuristic/advisory** by design — explicit `inputs:`/`permissions:` phase metadata and interactive input collection are deliberate non-goals for v1.
- Likely prerequisite for **DV-871** (daily-planning execution) — recommend sequencing this first.