### PR TITLE
fix(types): mark output_error as NoReturn to fix Pyright errors in schedule.py

### DIFF
--- a/deepvista_cli/output/formatter.py
+++ b/deepvista_cli/output/formatter.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import sys
-from typing import Any
+from typing import Any, NoReturn
 
 import click
 
@@ -170,7 +170,7 @@ def output_table(data: Any, columns: list[str] | None = None, title: str | None 
         output_json(data)
 
 
-def output_error(code: int, message: str, detail: str = "") -> None:
+def output_error(code: int, message: str, detail: str = "") -> NoReturn:
     """Write structured error to stderr and exit."""
     err = {"error": {"code": code, "message": message}}
     if detail:


### PR DESCRIPTION
## Summary
- `output_error` always calls `sys.exit` but was typed as `-> None`, so Pyright couldn't infer it never returns
- Changed return type to `-> NoReturn` and added `NoReturn` to the `typing` import
- Fixes 3 Pyright errors in `commands/schedule.py` (lines 117, 124, 160) where `existing` was used after a `None` guard

## Test plan
- [x] `uv run pyright deepvista_cli/` — 0 errors
- [x] `uv run ruff check --fix` + `ruff format` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)