### PR TITLE
feat(DV-936): task_queue run/list/setup commands

### DIFF
--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -133,9 +133,37 @@ def skill_get(ctx: click.Context, skill_id: str) -> None:
         "tool_plan."
     ),
 )
+@click.option(
+    "--webhook",
+    is_flag=True,
+    default=False,
+    help=(
+        "Mark this as a webhook-queued run (DV-955). Appends the task-queue "
+        "completion contract so the host agent reports the queue task after "
+        "`skill complete`. Set automatically on commands the webhook enqueues."
+    ),
+)
+@click.option(
+    "--best-effort",
+    is_flag=True,
+    default=False,
+    help=(
+        "Unattended run: instruct the host agent to answer open questions "
+        "from the vistabase instead of stalling, note assumptions, and only "
+        "pause on hard blockers (DV-955)."
+    ),
+)
 @click.option("--dry-run", is_flag=True, default=False, help="Preview what would happen without making any changes.")
 @click.pass_context
-def skill_run(ctx: click.Context, skill_id: str, user_input: str | None, mode: str, dry_run: bool) -> None:
+def skill_run(
+    ctx: click.Context,
+    skill_id: str,
+    user_input: str | None,
+    mode: str,
+    webhook: bool,
+    best_effort: bool,
+    dry_run: bool,
+) -> None:
     """Run a Skill — host mode by default; ``--mode deepvista`` delegates the whole run server-side.
 
     > [!CAUTION] This is a write command — host mode acquires the parent
@@ -160,6 +188,36 @@ def skill_run(ctx: click.Context, skill_id: str, user_input: str | None, mode: s
         _skill_run_deepvista(ctx, skill_id, user_input, dry_run=dry_run)
         return
 
+    emit_host_run_packet(
+        ctx,
+        skill_id,
+        user_input,
+        mode,
+        dry_run=dry_run,
+        webhook=webhook,
+        best_effort=best_effort,
+    )
+
+
+def emit_host_run_packet(
+    ctx: click.Context,
+    skill_id: str,
+    user_input: str | None,
+    mode: str = "host",
+    *,
+    dry_run: bool = False,
+    webhook: bool = False,
+    best_effort: bool = False,
+    task_id: str | None = None,
+) -> None:
+    """Fetch the skill, acquire the run lock, and print the host run packet.
+
+    Shared by ``skill run`` (host / auto modes) and ``task_queue run --host``
+    (DV-955), which emits packets for webhook-queued workflow tasks instead
+    of subprocess-executing them — a queued workflow needs the surrounding
+    host agent to drive it. ``task_id`` (only known on the task-queue path)
+    threads the queue entry into the completion contract.
+    """
     # host / auto: fetch the card, optionally acquire the lock, and emit a
     # run packet the host agent drives.
     card = _client(ctx).post("/get_context_card", {"card_id": skill_id, "card_type": "skill"})
@@ -196,7 +254,11 @@ def skill_run(ctx: click.Context, skill_id: str, user_input: str | None, mode: s
         "phase_routes": phase_routes,
         "user_input": user_input or "",
         "skill_status": card.get("status", ""),
+        "webhook": webhook,
+        "best_effort": best_effort,
     }
+    if task_id:
+        run_header["task_id"] = task_id
 
     if dry_run:
         format_output(
@@ -222,6 +284,12 @@ def skill_run(ctx: click.Context, skill_id: str, user_input: str | None, mode: s
     click.echo("---")
     click.echo()
     click.echo(_load_host_runtime_contract())
+    if best_effort:
+        click.echo()
+        click.echo(_BEST_EFFORT_STANZA)
+    if webhook:
+        click.echo()
+        click.echo(_webhook_task_stanza(task_id))
 
 
 def _skill_run_deepvista(
@@ -256,6 +324,45 @@ def _skill_run_deepvista(
 def _load_host_runtime_contract() -> str:
     """Return the embedded host-mode runtime contract markdown."""
     return resources.files("deepvista_cli.resources").joinpath("workflow_host_runtime.md").read_text(encoding="utf-8")
+
+
+# Appended to the runtime contract for unattended runs (DV-955). The run was
+# triggered by a webhook — there is no human in the loop to answer questions.
+_BEST_EFFORT_STANZA = """\
+## Best-effort mode (unattended run)
+
+This run was triggered without a human in the loop. Do NOT stall waiting
+for answers:
+
+- When a step needs information, search the vistabase first:
+  `deepvista card +search "…"`, `deepvista vistabase +search "…"`,
+  `deepvista notes list`. Prefer an answer found there over asking.
+- When nothing answers, make the most reasonable assumption, state it in
+  the phase's artifact note, and move to the next step.
+- Reserve `deepvista skill phase pause` for hard blockers only (missing
+  credentials, unavailable tools) — never for open questions.
+- Anything that would normally be sent externally (emails, invites) must
+  be left as a DRAFT for human review, never dispatched."""
+
+
+def _webhook_task_stanza(task_id: str | None) -> str:
+    """Completion contract for webhook-queued runs (DV-955).
+
+    The queue entry stays ``running`` until the host agent reports it —
+    nothing else will, so skipping this leaves a permanently stuck task.
+    """
+    task_ref = task_id or "<task_id from `deepvista task_queue list`>"
+    return f"""\
+## Webhook task completion
+
+This run came off the agent task queue. The queue entry stays `running`
+until YOU report it — after `deepvista skill complete` (or on failure):
+
+```
+deepvista task_queue complete {task_ref} --status completed
+# or, when the run could not finish:
+deepvista task_queue complete {task_ref} --status failed --note "<one short sentence>"
+```"""
 
 
 # ---------------------------------------------------------------------------

--- a/deepvista_cli/commands/task_queue.py
+++ b/deepvista_cli/commands/task_queue.py
@@ -3,9 +3,18 @@
 The web app enqueues DeepVista CLI commands onto a managed agent's
 `task_queue`; this command group lets the agent's machine poll and run them:
 
-  deepvista task_queue run    — claim pending tasks and execute them
-  deepvista task_queue list   — show this machine's queue
-  deepvista task_queue setup  — install a crontab entry that polls periodically
+  deepvista task_queue run      — claim pending tasks and execute them
+  deepvista task_queue list     — show this machine's queue
+  deepvista task_queue complete — report a workflow task's outcome (host agent)
+  deepvista task_queue setup    — install a crontab entry that polls periodically
+
+Workflow tasks (DV-955): webhook-queued `deepvista skill run` entries can't
+be subprocess-executed — a workflow needs the surrounding host agent (Claude
+Code etc.) to drive its phases. `task_queue run --host` claims them and
+emits their run packets to stdout for the host agent; headless runs (cron)
+claim command-only so workflow tasks stay pending until a host run. The
+host agent reports the outcome via `task_queue complete` after
+`skill complete`.
 
 Safety: only commands whose first token is `deepvista` are executed
 (shlex-parsed, shell=False). The backend enforces the same allowlist at
@@ -26,6 +35,7 @@ import click
 from deepvista_cli.client.http import DeepVistaClient
 from deepvista_cli.client.origin import detect_agent_tool
 from deepvista_cli.commands.agents import AGENTS_DIR, _load_agent_id
+from deepvista_cli.commands.skill import emit_host_run_packet
 from deepvista_cli.config import CONFIG_DIR
 from deepvista_cli.output.formatter import format_output, output_error
 
@@ -127,6 +137,107 @@ def _validate_command(command: str) -> str | None:
     return None
 
 
+def _is_workflow_task(task: dict) -> bool:
+    """True when the task is a webhook-queued workflow run (DV-955).
+
+    Primary signal is the advisory ``source: "webhook"`` key the backend
+    stamps at enqueue time; the command-shape fallback covers queues
+    written before that key existed.
+    """
+    if task.get("source") == "webhook":
+        return True
+    try:
+        tokens = shlex.split(str(task.get("command", "")))
+    except ValueError:
+        return False
+    return tokens[:3] == [ALLOWED_COMMAND_BINARY, "skill", "run"] and "--webhook" in tokens
+
+
+def _parse_workflow_command(command: str) -> dict | None:
+    """Extract skill_id / --input / --best-effort from a queued skill-run command.
+
+    The webhook composes these commands with a fixed shape
+    (``deepvista skill run --mode host <id> --input <json> --webhook
+    [--best-effort]``); parse defensively anyway since queue rows are data.
+    Returns None when the command isn't a recognizable skill run.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return None
+    if tokens[:3] != [ALLOWED_COMMAND_BINARY, "skill", "run"]:
+        return None
+
+    value_opts = {"--mode", "--input"}
+    values: dict[str, str] = {}
+    skill_id: str | None = None
+    i = 3
+    while i < len(tokens):
+        token = tokens[i]
+        if token in value_opts:
+            if i + 1 < len(tokens):
+                values[token] = tokens[i + 1]
+            i += 2
+        elif token.startswith("--"):
+            i += 1
+        elif skill_id is None:
+            skill_id = token
+            i += 1
+        else:
+            i += 1
+
+    if not skill_id:
+        return None
+    return {
+        "skill_id": skill_id,
+        "user_input": values.get("--input"),
+        "best_effort": "--best-effort" in tokens,
+    }
+
+
+def _emit_workflow_task(ctx: click.Context, agent_id: str, task: dict) -> dict:
+    """Print a claimed workflow task's run packet for the host agent (DV-955).
+
+    The task is left ``running`` on purpose — the host agent drives the
+    workflow and reports the outcome via ``task_queue complete``. Only an
+    unparseable/unloadable task is failed here, since no agent could ever
+    pick it up.
+    """
+    task_id = str(task.get("id", ""))
+    command = str(task.get("command", ""))
+
+    parsed = _parse_workflow_command(command)
+    if parsed is None:
+        _client(ctx).post(
+            f"/agents/{agent_id}/task-queue/{task_id}/result",
+            {"status": "failed", "exit_code": None, "output_tail": "Unparseable workflow task command"},
+        )
+        return {"task_id": task_id, "command": command, "status": "failed", "exit_code": None}
+
+    click.echo()
+    click.echo(f"=== DEEPVISTA WORKFLOW TASK {task_id} (skill {parsed['skill_id']}) ===")
+    click.echo()
+    try:
+        emit_host_run_packet(
+            ctx,
+            parsed["skill_id"],
+            parsed["user_input"],
+            "host",
+            webhook=True,
+            best_effort=parsed["best_effort"],
+            task_id=task_id,
+        )
+    except SystemExit:
+        # Skill gone / empty / phaseless — no host agent can ever run this
+        # task, so fail it instead of leaving it stuck in `running`.
+        _client(ctx).post(
+            f"/agents/{agent_id}/task-queue/{task_id}/result",
+            {"status": "failed", "exit_code": None, "output_tail": "Skill not found or not runnable"},
+        )
+        return {"task_id": task_id, "command": command, "status": "failed", "exit_code": None}
+    return {"task_id": task_id, "command": command, "status": "running", "exit_code": None}
+
+
 def _execute_task(ctx: click.Context, agent_id: str, task: dict) -> dict:
     """Run one claimed task and report its terminal result to the backend."""
     task_id = str(task.get("id", ""))
@@ -170,20 +281,47 @@ def task_queue_group() -> None:
     """Run CLI commands queued for this machine's agent."""
 
 
+def _detect_host_agent() -> bool:
+    """True when an AI agent host (Claude Code, OpenClaw, …) drives this CLI."""
+    try:
+        detected, _ = detect_agent_tool()
+    except Exception:
+        return False
+    return bool(detected) and detected != "deepvista-cli"
+
+
 @task_queue_group.command("run")
 @click.option("--type", "agent_type", default=None, help="Resolve agent by type from local storage.")
 @click.option("--role", "agent_role", default=None, help="Resolve agent by role (with --type).")
+@click.option(
+    "--host",
+    "host_mode",
+    is_flag=True,
+    default=False,
+    help=(
+        "Claim workflow tasks too and emit their run packets for the host "
+        "agent to drive (DV-955). Auto-enabled when an agent host is "
+        "detected; headless runs claim command tasks only."
+    ),
+)
 @click.pass_context
-def task_queue_run(ctx: click.Context, agent_type: str | None, agent_role: str | None) -> None:
+def task_queue_run(ctx: click.Context, agent_type: str | None, agent_role: str | None, host_mode: bool) -> None:
     """Claim pending tasks for this machine's agent and execute them.
 
     Returns immediately when the queue is empty, so it's cheap as a cron
-    tick. Each claimed task runs sequentially via subprocess and its result
-    (status, exit code, output tail) is reported back to the backend.
+    tick. Plain command tasks run sequentially via subprocess and their
+    results are reported back. Workflow tasks (webhook-queued skill runs)
+    are only claimed in host mode: their run packets are printed for the
+    surrounding agent to drive, and the entries stay ``running`` until the
+    agent calls ``task_queue complete``.
     """
     agent_id = _require_machine_agent_id(agent_type, agent_role)
+    host_mode = host_mode or _detect_host_agent()
 
-    data = _client(ctx).post(f"/agents/{agent_id}/task-queue/claim")
+    data = _client(ctx).post(
+        f"/agents/{agent_id}/task-queue/claim",
+        None if host_mode else {"command_only": True},
+    )
     if not data.get("success"):
         output_error(1, "Failed to claim tasks", data.get("error", "Unknown error"))
         raise SystemExit(1)
@@ -193,13 +331,30 @@ def task_queue_run(ctx: click.Context, agent_type: str | None, agent_role: str |
         _output(ctx, {"agent_id": agent_id, "tasks_run": 0}, title="Task Queue")
         return
 
-    results = [_execute_task(ctx, agent_id, task) for task in tasks]
+    command_tasks = [t for t in tasks if not _is_workflow_task(t)]
+    # Workflow tasks only reach this list in host mode (headless claims are
+    # command_only) — the guard below covers a backend that predates the
+    # filter, so a cron tick never swallows a packet nobody will read.
+    workflow_tasks = [t for t in tasks if _is_workflow_task(t)] if host_mode else []
+
+    results = [_execute_task(ctx, agent_id, task) for task in command_tasks]
     failed = sum(1 for r in results if r["status"] == "failed")
     _output(
         ctx,
-        {"agent_id": agent_id, "tasks_run": len(results), "failed": failed, "results": results},
+        {
+            "agent_id": agent_id,
+            "tasks_run": len(results),
+            "failed": failed,
+            "results": results,
+            "workflow_tasks": len(workflow_tasks),
+        },
         title="Task Queue",
     )
+
+    # Workflow packets go last so the runtime contract (and its completion
+    # instructions) is the freshest thing in the host agent's context.
+    for task in workflow_tasks:
+        _emit_workflow_task(ctx, agent_id, task)
 
 
 @task_queue_group.command("list")
@@ -223,6 +378,44 @@ def task_queue_list(ctx: click.Context, agent_type: str | None, agent_role: str 
         columns=TASK_COLUMNS,
         title="Task Queue",
     )
+
+
+@task_queue_group.command("complete")
+@click.argument("task_id")
+@click.option(
+    "--status",
+    type=click.Choice(["completed", "failed"]),
+    required=True,
+    help="Terminal outcome of the workflow task.",
+)
+@click.option("--note", default=None, help="Short outcome note stored as the task's output tail.")
+@click.option("--type", "agent_type", default=None, help="Resolve agent by type from local storage.")
+@click.option("--role", "agent_role", default=None, help="Resolve agent by role (with --type).")
+@click.pass_context
+def task_queue_complete(
+    ctx: click.Context,
+    task_id: str,
+    status: str,
+    note: str | None,
+    agent_type: str | None,
+    agent_role: str | None,
+) -> None:
+    """Report the terminal outcome of a claimed workflow task (DV-955).
+
+    Called by the host agent after driving a webhook-queued workflow run to
+    its end (`deepvista skill complete`) — or to its failure. Plain command
+    tasks report automatically; this is only needed for workflow tasks,
+    which stay ``running`` until someone reports them.
+    """
+    agent_id = _require_machine_agent_id(agent_type, agent_role)
+    data = _client(ctx).post(
+        f"/agents/{agent_id}/task-queue/{task_id}/result",
+        {"status": status, "exit_code": 0 if status == "completed" else 1, "output_tail": note},
+    )
+    if not data.get("success"):
+        output_error(1, "Failed to report task result", data.get("error", "Unknown error"))
+        raise SystemExit(1)
+    _output(ctx, {"agent_id": agent_id, "task": data.get("task")}, title="Task Queue")
 
 
 # ---------------------------------------------------------------------------
@@ -283,6 +476,10 @@ def task_queue_setup(ctx: click.Context, interval: int, remove: bool) -> None:
     Idempotent — re-running replaces any existing entry. Use --remove to
     uninstall. Crontab only (macOS/Linux); on Windows, schedule
     `deepvista task_queue run` with Task Scheduler instead.
+
+    Cron runs are headless: they execute plain command tasks only and
+    leave workflow tasks (webhook-queued skill runs) pending. Drive those
+    from an agent session with `deepvista task_queue run --host`.
 
     > [!CAUTION] This is a write command — confirm with the user before executing.
     """

--- a/deepvista_cli/commands/task_queue.py
+++ b/deepvista_cli/commands/task_queue.py
@@ -1,0 +1,327 @@
+"""deepvista task_queue — pull-based execution of queued CLI commands (DV-936).
+
+The web app enqueues DeepVista CLI commands onto a managed agent's
+`task_queue`; this command group lets the agent's machine poll and run them:
+
+  deepvista task_queue run    — claim pending tasks and execute them
+  deepvista task_queue list   — show this machine's queue
+  deepvista task_queue setup  — install a crontab entry that polls periodically
+
+Safety: only commands whose first token is `deepvista` are executed
+(shlex-parsed, shell=False). The backend enforces the same allowlist at
+enqueue time; the check here guards against tampered queue rows.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import shlex
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import click
+
+from deepvista_cli.client.http import DeepVistaClient
+from deepvista_cli.client.origin import detect_agent_tool
+from deepvista_cli.commands.agents import AGENTS_DIR, _load_agent_id
+from deepvista_cli.config import CONFIG_DIR
+from deepvista_cli.output.formatter import format_output, output_error
+
+TASK_COLUMNS = ["id", "status", "command", "created_at", "finished_at", "exit_code"]
+
+# Only the DeepVista CLI itself may be invoked from the queue.
+ALLOWED_COMMAND_BINARY = "deepvista"
+
+# Per-task execution budget; a hung task must not wedge the cron tick forever.
+TASK_TIMEOUT_SECONDS = 600
+
+# Reported output is truncated to a tail (mirrors the backend cap).
+OUTPUT_TAIL_MAX_CHARS = 2000
+
+# Marker comment identifying crontab entries owned by `task_queue setup`.
+CRON_MARKER = "# deepvista-task-queue"
+
+CRON_LOG_PATH = CONFIG_DIR / "task_queue.log"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _client(ctx: click.Context) -> DeepVistaClient:
+    return ctx.obj._client
+
+
+def _output(ctx: click.Context, data: object, **kwargs: object) -> None:
+    format_output(data, ctx.obj.output_format, **kwargs)  # type: ignore[arg-type]
+
+
+def _resolve_machine_agent_id(agent_type: str | None, agent_role: str | None) -> str | None:
+    """Find the registered agent this machine's queue belongs to.
+
+    Resolution order: explicit --type/--role, then the detected host tool,
+    then the most recently registered agent of any type on this machine.
+    """
+    if agent_type:
+        return _load_agent_id(agent_type, agent_role)
+
+    try:
+        detected, _ = detect_agent_tool()
+    except Exception:
+        detected = None
+    if detected:
+        agent_id = _load_agent_id(detected, agent_role)
+        if agent_id:
+            return agent_id
+
+    # Cron runs outside any agent host — fall back to the newest registration.
+    candidates: list[tuple[float, Path]] = []
+    if AGENTS_DIR.exists():
+        for path in AGENTS_DIR.glob("*.json"):
+            try:
+                candidates.append((path.stat().st_mtime, path))
+            except OSError:
+                continue
+    candidates.sort(reverse=True)
+    for _, path in candidates:
+        try:
+            agent_id = _json.loads(path.read_text()).get("agent_id")
+        except (OSError, _json.JSONDecodeError):
+            continue
+        if agent_id:
+            return agent_id
+    return None
+
+
+def _require_machine_agent_id(agent_type: str | None, agent_role: str | None) -> str:
+    agent_id = _resolve_machine_agent_id(agent_type, agent_role)
+    if not agent_id:
+        output_error(3, "No registered agent on this machine", "Run 'deepvista agents register' first.")
+        raise SystemExit(3)
+    return agent_id
+
+
+def _deepvista_binary() -> str:
+    """Absolute path to the `deepvista` entry point (cron has a minimal PATH)."""
+    binary = shutil.which(ALLOWED_COMMAND_BINARY)
+    if binary:
+        return binary
+    if sys.argv and Path(sys.argv[0]).name == ALLOWED_COMMAND_BINARY:
+        return str(Path(sys.argv[0]).resolve())
+    return ALLOWED_COMMAND_BINARY
+
+
+def _validate_command(command: str) -> str | None:
+    """Return an error message when `command` is not an allowed CLI invocation."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        return f"Command is not shell-parseable: {exc}"
+    if not tokens:
+        return "Command is empty"
+    if tokens[0] != ALLOWED_COMMAND_BINARY:
+        return f"Only '{ALLOWED_COMMAND_BINARY}' commands can run from the task queue"
+    return None
+
+
+def _execute_task(ctx: click.Context, agent_id: str, task: dict) -> dict:
+    """Run one claimed task and report its terminal result to the backend."""
+    task_id = str(task.get("id", ""))
+    command = str(task.get("command", ""))
+
+    validation_error = _validate_command(command)
+    if validation_error:
+        status, exit_code, output_tail = "failed", None, validation_error
+    else:
+        argv = shlex.split(command)
+        argv[0] = _deepvista_binary()
+        try:
+            proc = subprocess.run(  # noqa: S603 — argv is allowlist-validated, shell=False
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=TASK_TIMEOUT_SECONDS,
+            )
+            exit_code = proc.returncode
+            status = "completed" if exit_code == 0 else "failed"
+            output_tail = ((proc.stdout or "") + (proc.stderr or ""))[-OUTPUT_TAIL_MAX_CHARS:]
+        except subprocess.TimeoutExpired:
+            status, exit_code, output_tail = "failed", None, f"Timed out after {TASK_TIMEOUT_SECONDS}s"
+        except OSError as exc:
+            status, exit_code, output_tail = "failed", None, str(exc)
+
+    _client(ctx).post(
+        f"/agents/{agent_id}/task-queue/{task_id}/result",
+        {"status": status, "exit_code": exit_code, "output_tail": output_tail},
+    )
+    return {"task_id": task_id, "command": command, "status": status, "exit_code": exit_code}
+
+
+# ---------------------------------------------------------------------------
+# Command group
+# ---------------------------------------------------------------------------
+
+
+@click.group("task_queue")
+def task_queue_group() -> None:
+    """Run CLI commands queued for this machine's agent."""
+
+
+@task_queue_group.command("run")
+@click.option("--type", "agent_type", default=None, help="Resolve agent by type from local storage.")
+@click.option("--role", "agent_role", default=None, help="Resolve agent by role (with --type).")
+@click.pass_context
+def task_queue_run(ctx: click.Context, agent_type: str | None, agent_role: str | None) -> None:
+    """Claim pending tasks for this machine's agent and execute them.
+
+    Returns immediately when the queue is empty, so it's cheap as a cron
+    tick. Each claimed task runs sequentially via subprocess and its result
+    (status, exit code, output tail) is reported back to the backend.
+    """
+    agent_id = _require_machine_agent_id(agent_type, agent_role)
+
+    data = _client(ctx).post(f"/agents/{agent_id}/task-queue/claim")
+    if not data.get("success"):
+        output_error(1, "Failed to claim tasks", data.get("error", "Unknown error"))
+        raise SystemExit(1)
+
+    tasks = data.get("tasks") or []
+    if not tasks:
+        _output(ctx, {"agent_id": agent_id, "tasks_run": 0}, title="Task Queue")
+        return
+
+    results = [_execute_task(ctx, agent_id, task) for task in tasks]
+    failed = sum(1 for r in results if r["status"] == "failed")
+    _output(
+        ctx,
+        {"agent_id": agent_id, "tasks_run": len(results), "failed": failed, "results": results},
+        title="Task Queue",
+    )
+
+
+@task_queue_group.command("list")
+@click.option("--type", "agent_type", default=None, help="Resolve agent by type from local storage.")
+@click.option("--role", "agent_role", default=None, help="Resolve agent by role (with --type).")
+@click.pass_context
+def task_queue_list(ctx: click.Context, agent_type: str | None, agent_role: str | None) -> None:
+    """Show the task queue for this machine's agent.
+
+    Read-only.
+    """
+    agent_id = _require_machine_agent_id(agent_type, agent_role)
+    data = _client(ctx).get(f"/agents/{agent_id}/task-queue")
+    if data.get("error"):
+        output_error(1, "Failed to list tasks", data["error"])
+        raise SystemExit(1)
+    tasks = data.get("tasks", [])
+    _output(
+        ctx,
+        {"agent_id": agent_id, "tasks": tasks, "count": len(tasks)},
+        columns=TASK_COLUMNS,
+        title="Task Queue",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cron setup
+# ---------------------------------------------------------------------------
+
+
+def _read_crontab() -> list[str]:
+    """Current user crontab lines ([] when none exists)."""
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["crontab", "-l"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    if proc.returncode != 0:
+        return []
+    return proc.stdout.splitlines()
+
+
+def _write_crontab(lines: list[str]) -> bool:
+    content = "\n".join(lines) + ("\n" if lines else "")
+    try:
+        proc = subprocess.run(  # noqa: S603
+            ["crontab", "-"],  # noqa: S607
+            input=content,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+def _cron_entry(interval: int, profile: str) -> str:
+    binary = _deepvista_binary()
+    profile_flag = f" --profile {profile}" if profile and profile != "default" else ""
+    return f"*/{interval} * * * * {binary}{profile_flag} task_queue run >> {CRON_LOG_PATH} 2>&1 {CRON_MARKER}"
+
+
+@task_queue_group.command("setup")
+@click.option(
+    "--interval",
+    default=5,
+    show_default=True,
+    type=click.IntRange(1, 1440),
+    help="Poll interval in minutes.",
+)
+@click.option("--remove", is_flag=True, default=False, help="Uninstall the cron entry instead.")
+@click.pass_context
+def task_queue_setup(ctx: click.Context, interval: int, remove: bool) -> None:
+    """Install a crontab entry that runs `deepvista task_queue run` periodically.
+
+    Idempotent — re-running replaces any existing entry. Use --remove to
+    uninstall. Crontab only (macOS/Linux); on Windows, schedule
+    `deepvista task_queue run` with Task Scheduler instead.
+
+    > [!CAUTION] This is a write command — confirm with the user before executing.
+    """
+    if sys.platform == "win32":
+        output_error(1, "Unsupported platform", "Crontab setup is macOS/Linux only.")
+        raise SystemExit(1)
+
+    existing = _read_crontab()
+    kept = [line for line in existing if CRON_MARKER not in line]
+    entry = None if remove else _cron_entry(interval, getattr(ctx.obj, "profile", "default"))
+    updated = kept + ([entry] if entry else [])
+
+    if ctx.obj.dry_run:
+        _output(
+            ctx,
+            {
+                "dry_run": True,
+                "would": "remove cron entry" if remove else "install cron entry",
+                "entry": entry,
+                "removed_entries": [line for line in existing if CRON_MARKER in line],
+            },
+            title="Dry Run: Task Queue Setup",
+        )
+        return
+
+    if remove and len(kept) == len(existing):
+        _output(ctx, {"removed": False, "message": "No task-queue cron entry installed."}, title="Task Queue Setup")
+        return
+
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    if not _write_crontab(updated):
+        output_error(1, "Failed to update crontab", "Is `crontab` available on this machine?")
+        raise SystemExit(1)
+
+    if remove:
+        _output(ctx, {"removed": True}, title="Task Queue Setup")
+    else:
+        _output(
+            ctx,
+            {"installed": True, "interval_minutes": interval, "entry": entry, "log": str(CRON_LOG_PATH)},
+            title="Task Queue Setup",
+        )

--- a/deepvista_cli/main.py
+++ b/deepvista_cli/main.py
@@ -34,6 +34,7 @@ from deepvista_cli.commands.notes import notes_group
 from deepvista_cli.commands.schedule import schedule_group
 from deepvista_cli.commands.session import session_group
 from deepvista_cli.commands.skill import skill_group
+from deepvista_cli.commands.task_queue import task_queue_group
 from deepvista_cli.commands.upgrade import upgrade_command
 from deepvista_cli.config import DEFAULT_API_URL, CLIConfig
 
@@ -92,6 +93,8 @@ cli.add_command(agents_group)
 cli.add_command(schedule_group)
 # Agent session transcripts (DV-742) — `init` / `tick` / `finalize`
 cli.add_command(session_group)
+# Pull-based task queue for this machine's agent (DV-936)
+cli.add_command(task_queue_group)
 # Supporting commands
 cli.add_command(auth_group)
 cli.add_command(config_group)

--- a/tests/test_task_queue_commands.py
+++ b/tests/test_task_queue_commands.py
@@ -1,0 +1,317 @@
+"""Click-level tests for `deepvista task_queue run` / `list` / `setup` (DV-936)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from deepvista_cli.commands.task_queue import CRON_MARKER, _cron_entry, _validate_command
+from deepvista_cli.main import cli
+
+
+class _StubCtxClient:
+    """Minimal stand-in for the real client attached to ctx.obj._client."""
+
+    def __init__(self) -> None:
+        self.responses: dict[str, list[Any]] = {}
+        self.calls: list[tuple[str, str, dict | None]] = []
+
+    def queue(self, path: str, response: Any) -> None:
+        self.responses.setdefault(path, []).append(response)
+
+    def _pop(self, method: str, path: str, body: dict | None = None) -> Any:
+        self.calls.append((method, path, body))
+        q = self.responses.get(path)
+        if not q:
+            raise AssertionError(f"no response queued for {method} {path}")
+        return q.pop(0)
+
+    def post(self, path: str, body: dict | None = None) -> Any:
+        return self._pop("POST", path, body)
+
+    def get(self, path: str, params: dict | None = None) -> Any:
+        return self._pop("GET", path, params)
+
+
+@pytest.fixture()
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect CLI state dirs into a pytest tmp dir."""
+    monkeypatch.setenv("DEEPVISTA_CONFIG_DIR", str(tmp_path / ".config" / "deepvista"))
+    import importlib
+
+    import deepvista_cli.config as cfg_module
+
+    importlib.reload(cfg_module)
+    return tmp_path
+
+
+def _install_stub_client(monkeypatch: pytest.MonkeyPatch, stub: _StubCtxClient) -> None:
+    """Swap the real DeepVistaClient for our stub on the CLI context."""
+
+    def fake_init(self, config):  # type: ignore[no-untyped-def]
+        self.config = config
+
+    from deepvista_cli.client import http as http_module
+
+    monkeypatch.setattr(http_module.DeepVistaClient, "__init__", fake_init)
+    monkeypatch.setattr(http_module.DeepVistaClient, "post", lambda self, path, body=None: stub.post(path, body))
+    monkeypatch.setattr(http_module.DeepVistaClient, "get", lambda self, path, params=None: stub.get(path, params))
+
+
+def _register_local_agent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, agent_id: str = "agent-uuid-1") -> None:
+    """Write a local agent registration file and point the command module at it."""
+    agents_dir = tmp_path / ".config" / "deepvista" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / "deepvista-cli__misc.json").write_text(
+        json.dumps({"agent_id": agent_id, "agent_type": "deepvista-cli", "agent_role": "misc"})
+    )
+    import deepvista_cli.commands.agents as agents_module
+    import deepvista_cli.commands.task_queue as tq_module
+
+    monkeypatch.setattr(agents_module, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(tq_module, "AGENTS_DIR", agents_dir)
+
+
+# ---------------------------------------------------------------------------
+# command validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_command_allows_only_deepvista():
+    assert _validate_command("deepvista notes list") is None
+    assert _validate_command("rm -rf /") is not None
+    assert _validate_command("") is not None
+    assert _validate_command('deepvista "unterminated') is not None
+
+
+# ---------------------------------------------------------------------------
+# run
+# ---------------------------------------------------------------------------
+
+
+def test_run_exits_immediately_when_queue_empty(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue("/agents/agent-uuid-1/task-queue/claim", {"success": True, "tasks": []})
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["tasks_run"] == 0
+    # Only the claim call — no execution, no result reports.
+    assert [c[1] for c in stub.calls] == ["/agents/agent-uuid-1/task-queue/claim"]
+
+
+def test_run_executes_claimed_task_and_reports_result(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/agents/agent-uuid-1/task-queue/claim",
+        {"success": True, "tasks": [{"id": "t-1", "command": "deepvista notes list", "status": "running"}]},
+    )
+    stub.queue("/agents/agent-uuid-1/task-queue/t-1/result", {"success": True})
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    class _FakeProc:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    executed: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        executed.append(argv)
+        return _FakeProc()
+
+    monkeypatch.setattr(tq_module.subprocess, "run", fake_run)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["tasks_run"] == 1
+    assert payload["failed"] == 0
+    assert payload["results"][0]["status"] == "completed"
+
+    # Executed argv keeps the CLI args, binary resolved to an absolute path or name.
+    assert executed[0][1:] == ["notes", "list"]
+
+    # Result was reported to the backend.
+    method, path, body = stub.calls[-1]
+    assert (method, path) == ("POST", "/agents/agent-uuid-1/task-queue/t-1/result")
+    assert body == {"status": "completed", "exit_code": 0, "output_tail": "ok"}
+
+
+def test_run_rejects_non_deepvista_command_without_executing(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/agents/agent-uuid-1/task-queue/claim",
+        {"success": True, "tasks": [{"id": "t-1", "command": "rm -rf /", "status": "running"}]},
+    )
+    stub.queue("/agents/agent-uuid-1/task-queue/t-1/result", {"success": True})
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    def explode(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("subprocess.run must not be called for disallowed commands")
+
+    monkeypatch.setattr(tq_module.subprocess, "run", explode)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["failed"] == 1
+    assert payload["results"][0]["status"] == "failed"
+
+    method, path, body = stub.calls[-1]
+    assert (method, path) == ("POST", "/agents/agent-uuid-1/task-queue/t-1/result")
+    assert body is not None and body["status"] == "failed"
+
+
+def test_run_errors_when_no_agent_registered(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    _install_stub_client(monkeypatch, stub)
+    import deepvista_cli.commands.agents as agents_module
+    import deepvista_cli.commands.task_queue as tq_module
+
+    empty = isolated_home / ".config" / "deepvista" / "agents"
+    monkeypatch.setattr(agents_module, "AGENTS_DIR", empty)
+    monkeypatch.setattr(tq_module, "AGENTS_DIR", empty)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    assert result.exit_code == 3
+    assert stub.calls == []
+
+
+# ---------------------------------------------------------------------------
+# list
+# ---------------------------------------------------------------------------
+
+
+def test_list_shows_queue(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/agents/agent-uuid-1/task-queue",
+        {"tasks": [{"id": "t-1", "command": "deepvista notes list", "status": "pending"}]},
+    )
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    result = CliRunner().invoke(cli, ["task_queue", "list"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["count"] == 1
+    assert payload["tasks"][0]["id"] == "t-1"
+
+
+# ---------------------------------------------------------------------------
+# setup
+# ---------------------------------------------------------------------------
+
+
+def test_setup_dry_run_previews_cron_entry(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    _install_stub_client(monkeypatch, stub)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    monkeypatch.setattr(tq_module, "_read_crontab", lambda: ["0 0 * * * /bin/true"])
+
+    def explode(lines):  # type: ignore[no-untyped-def]
+        raise AssertionError("crontab must not be written in dry-run")
+
+    monkeypatch.setattr(tq_module, "_write_crontab", explode)
+
+    result = CliRunner().invoke(cli, ["--dry-run", "task_queue", "setup", "--interval", "10"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["dry_run"] is True
+    assert "*/10 * * * *" in payload["entry"]
+    assert CRON_MARKER in payload["entry"]
+
+
+def test_setup_installs_and_replaces_entry_idempotently(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    _install_stub_client(monkeypatch, stub)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    written: list[list[str]] = []
+    monkeypatch.setattr(
+        tq_module,
+        "_read_crontab",
+        lambda: ["0 0 * * * /bin/true", f"*/5 * * * * /old/deepvista task_queue run {CRON_MARKER}"],
+    )
+    monkeypatch.setattr(tq_module, "_write_crontab", lambda lines: written.append(lines) or True)
+
+    result = CliRunner().invoke(cli, ["task_queue", "setup", "--interval", "15"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["installed"] is True
+    assert payload["interval_minutes"] == 15
+
+    lines = written[0]
+    # Unrelated entry preserved, old marker entry replaced, exactly one marker line.
+    assert lines[0] == "0 0 * * * /bin/true"
+    marker_lines = [line for line in lines if CRON_MARKER in line]
+    assert len(marker_lines) == 1
+    assert "*/15 * * * *" in marker_lines[0]
+
+
+def test_setup_remove_uninstalls_entry(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    _install_stub_client(monkeypatch, stub)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    written: list[list[str]] = []
+    monkeypatch.setattr(
+        tq_module,
+        "_read_crontab",
+        lambda: ["0 0 * * * /bin/true", f"*/5 * * * * /usr/local/bin/deepvista task_queue run {CRON_MARKER}"],
+    )
+    monkeypatch.setattr(tq_module, "_write_crontab", lambda lines: written.append(lines) or True)
+
+    result = CliRunner().invoke(cli, ["task_queue", "setup", "--remove"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["removed"] is True
+    assert written[0] == ["0 0 * * * /bin/true"]
+
+
+def test_cron_entry_includes_profile_flag():
+    entry = _cron_entry(5, "staging")
+    assert "--profile staging" in entry
+    assert _cron_entry(5, "default").find("--profile") == -1

--- a/tests/test_task_queue_commands.py
+++ b/tests/test_task_queue_commands.py
@@ -1,4 +1,4 @@
-"""Click-level tests for `deepvista task_queue run` / `list` / `setup` (DV-936)."""
+"""Click-level tests for `deepvista task_queue run` / `list` / `complete` / `setup` (DV-936/DV-955)."""
 
 from __future__ import annotations
 
@@ -9,8 +9,19 @@ from typing import Any
 import pytest
 from click.testing import CliRunner
 
-from deepvista_cli.commands.task_queue import CRON_MARKER, _cron_entry, _validate_command
+from deepvista_cli.commands.task_queue import (
+    CRON_MARKER,
+    _cron_entry,
+    _is_workflow_task,
+    _parse_workflow_command,
+    _validate_command,
+)
 from deepvista_cli.main import cli
+
+WORKFLOW_COMMAND = (
+    "deepvista skill run --mode host 00000000-0000-0000-0000-000000000001 "
+    '--input \'{"name": "Ada"}\' --webhook --best-effort'
+)
 
 
 class _StubCtxClient:
@@ -200,6 +211,197 @@ def test_run_errors_when_no_agent_registered(
 
     result = CliRunner().invoke(cli, ["task_queue", "run"])
     assert result.exit_code == 3
+    assert stub.calls == []
+
+
+# ---------------------------------------------------------------------------
+# workflow tasks (DV-955)
+# ---------------------------------------------------------------------------
+
+
+def test_is_workflow_task_by_source_and_command_shape():
+    assert _is_workflow_task({"source": "webhook", "command": "deepvista notes list"})
+    assert _is_workflow_task({"command": WORKFLOW_COMMAND})
+    assert not _is_workflow_task({"command": "deepvista notes list"})
+    assert not _is_workflow_task({"command": "deepvista skill run abc"})  # no --webhook
+
+
+def test_parse_workflow_command_extracts_fields():
+    parsed = _parse_workflow_command(WORKFLOW_COMMAND)
+    assert parsed == {
+        "skill_id": "00000000-0000-0000-0000-000000000001",
+        "user_input": '{"name": "Ada"}',
+        "best_effort": True,
+    }
+    assert _parse_workflow_command("deepvista notes list") is None
+    assert _parse_workflow_command("deepvista skill run --webhook") is None  # no skill id
+
+
+def test_run_headless_claims_command_only(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue("/agents/agent-uuid-1/task-queue/claim", {"success": True, "tasks": []})
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    monkeypatch.setattr(tq_module, "_detect_host_agent", lambda: False)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    assert result.exit_code == 0, result.output
+    method, path, body = stub.calls[0]
+    assert (method, path) == ("POST", "/agents/agent-uuid-1/task-queue/claim")
+    # Headless cron ticks must leave workflow tasks pending for a host run.
+    assert body == {"command_only": True}
+
+
+def test_run_host_emits_workflow_packet_and_leaves_task_running(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/agents/agent-uuid-1/task-queue/claim",
+        {
+            "success": True,
+            "tasks": [{"id": "t-wf", "command": WORKFLOW_COMMAND, "status": "running", "source": "webhook"}],
+        },
+    )
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    emitted: list[dict] = []
+
+    def fake_emit(ctx, skill_id, user_input, mode="host", **kwargs):  # type: ignore[no-untyped-def]
+        emitted.append({"skill_id": skill_id, "user_input": user_input, **kwargs})
+
+    monkeypatch.setattr(tq_module, "emit_host_run_packet", fake_emit)
+
+    def explode(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("workflow tasks must not be subprocess-executed")
+
+    monkeypatch.setattr(tq_module.subprocess, "run", explode)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--host"])
+    assert result.exit_code == 0, result.output
+
+    # Claim body None (full claim), packet emitted with task threading.
+    assert stub.calls[0][2] is None
+    assert emitted == [
+        {
+            "skill_id": "00000000-0000-0000-0000-000000000001",
+            "user_input": '{"name": "Ada"}',
+            "webhook": True,
+            "best_effort": True,
+            "task_id": "t-wf",
+        }
+    ]
+    assert "=== DEEPVISTA WORKFLOW TASK t-wf" in result.output
+
+    # No result report: the task stays `running` until `task_queue complete`.
+    assert all("/result" not in c[1] for c in stub.calls)
+
+
+def test_run_host_fails_unparseable_workflow_task(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/agents/agent-uuid-1/task-queue/claim",
+        {
+            "success": True,
+            # source says webhook but the command isn't a skill run — nobody
+            # could ever drive this; it must be failed, not left running.
+            "tasks": [{"id": "t-bad", "command": "deepvista notes list", "status": "running", "source": "webhook"}],
+        },
+    )
+    stub.queue("/agents/agent-uuid-1/task-queue/t-bad/result", {"success": True})
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--host"])
+    assert result.exit_code == 0, result.output
+
+    method, path, body = stub.calls[-1]
+    assert (method, path) == ("POST", "/agents/agent-uuid-1/task-queue/t-bad/result")
+    assert body is not None and body["status"] == "failed"
+
+
+def test_run_headless_ignores_workflow_tasks_that_slip_through(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/agents/agent-uuid-1/task-queue/claim",
+        {
+            "success": True,
+            "tasks": [{"id": "t-wf", "command": WORKFLOW_COMMAND, "status": "running", "source": "webhook"}],
+        },
+    )
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    monkeypatch.setattr(tq_module, "_detect_host_agent", lambda: False)
+
+    def explode(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise AssertionError("workflow tasks must not be subprocess-executed")
+
+    monkeypatch.setattr(tq_module.subprocess, "run", explode)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    assert result.exit_code == 0, result.output
+    # No packet for a cron log, no subprocess, no terminal report.
+    assert "DEEPVISTA WORKFLOW TASK" not in result.output
+    assert all("/result" not in c[1] for c in stub.calls)
+
+
+# ---------------------------------------------------------------------------
+# complete
+# ---------------------------------------------------------------------------
+
+
+def test_complete_reports_terminal_status(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/agents/agent-uuid-1/task-queue/t-wf/result",
+        {"success": True, "task": {"id": "t-wf", "status": "completed"}},
+    )
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    result = CliRunner().invoke(
+        cli,
+        ["task_queue", "complete", "t-wf", "--status", "completed", "--note", "lead brief shipped"],
+    )
+    assert result.exit_code == 0, result.output
+
+    method, path, body = stub.calls[-1]
+    assert (method, path) == ("POST", "/agents/agent-uuid-1/task-queue/t-wf/result")
+    assert body == {"status": "completed", "exit_code": 0, "output_tail": "lead brief shipped"}
+
+
+def test_complete_rejects_unknown_status(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    result = CliRunner().invoke(cli, ["task_queue", "complete", "t-wf", "--status", "running"])
+    assert result.exit_code != 0
     assert stub.calls == []
 
 


### PR DESCRIPTION
Implements the CLI half of [DV-936](https://linear.app/deepvista/issue/DV-936/local-agent-periodic-run). Companion backend PR (task_queue column + `/agents/{id}/task-queue` endpoints + Tasks tab) lands in `deepvista`.

## What

New `deepvista task_queue` command group — pull-based execution of CLI commands queued on this machine's managed agent:

- **`task_queue run`** — resolves the machine's registered agent (explicit `--type/--role` → detected host tool → newest local registration), claims pending tasks via `POST /agents/{id}/task-queue/claim`, and **exits immediately when the queue is empty** so a cron tick is cheap. Claimed tasks run sequentially via subprocess; each result (`status`, `exit_code`, 2 KB output tail) is reported back.
- **`task_queue list`** — read-only view of the queue.
- **`task_queue setup [--interval N] [--remove]`** — idempotently installs (or removes) a crontab entry running `task_queue run` every N minutes (default 5), using the absolute `deepvista` binary path and `--profile` when non-default. Output logs to `~/.config/deepvista/task_queue.log`. Honors global `--dry-run`. macOS/Linux only; Windows users can schedule `task_queue run` themselves.

### Safety

- Only commands whose first shlex token is `deepvista` are executed (`shell=False`, allowlist-validated argv; binary resolved to absolute path for cron's minimal PATH). Disallowed commands are reported as `failed` without executing — guards against tampered queue rows even though the backend enforces the same rule at enqueue time.
- Per-task 10-minute timeout so a hung task can't wedge the cron tick.

## Testing

- `tests/test_task_queue_commands.py` — 10 Click-level tests with a stubbed client: allowlist validation, empty-queue fast path, execute+report flow, disallowed-command refusal (asserts no subprocess), unregistered-machine error, list, setup dry-run/idempotent-replace/remove, profile flag.
- Full suite: 60 passed. `ruff check`/`format`, `pyright` (0 errors), `bandit -ll` all clean.

---

## DV-955 additions: host-driven workflow tasks

Webhook-queued workflow runs (`deepvista skill run … --webhook`, see backend PR DeepVista-AI/deepvista#2225) can't be subprocess-executed — a workflow needs the surrounding host agent (Claude Code etc.) to drive its phases. This PR now handles them:

- `skill run` grows `--webhook` / `--best-effort`; the host-packet emission is refactored into a reusable `emit_host_run_packet()` that appends a **best-effort stanza** (answer open questions from the vistabase, never stall, drafts only — never send) and a **task-completion contract**.
- `task_queue run --host` (auto-detected from the agent host): claims everything and emits workflow run packets to stdout for the host agent, leaving those tasks `running`. Headless runs claim `command_only` so workflow tasks stay `pending` for a later host run.
- New `task_queue complete <task_id> --status completed|failed [--note …]` — how the host agent reports the queue entry after `deepvista skill complete`.
- `task_queue setup` help documents the headless/command-only cron behavior.
