### PR TITLE
feat(DV-941): add windows install script and trampoline troubleshooting docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,3 +47,29 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh skill publish --dry-run
+
+  windows-smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse install.ps1 (syntax check)
+        shell: pwsh
+        run: |
+          $errors = $null
+          [System.Management.Automation.Language.Parser]::ParseFile("$PWD/install.ps1", [ref]$null, [ref]$errors) | Out-Null
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Error $_.Message }
+            exit 1
+          }
+          Write-Host "install.ps1 parses cleanly"
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install deepvista CLI from checkout
+        run: uv tool install ".[ui]"
+
+      - name: Smoke test - deepvista --help
+        run: deepvista --help

--- a/README.md
+++ b/README.md
@@ -135,13 +135,51 @@ then `deepvista auth login`).
 
 ### For non-Claude-Code agents (Cursor, OpenCode, OpenClaw, …)
 
+**macOS / Linux (bash):**
+
 ```bash
 curl -sSL https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/install.sh | bash
+```
+
+**Windows (PowerShell):**
+
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/install.ps1 | iex"
 ```
 
 The script auto-detects your package manager (`uv`, `pipx`, or `pip`) and copies the consolidated `deepvista` skill into your agent's skill directory (Cursor, OpenCode, OpenClaw, and Claude Code as a fallback). If you upgraded from an earlier release, it also sweeps out the 12 legacy `deepvista-*` skills so you don't end up with both.
 
 Prefer GitHub's CLI? `gh skill install DeepVista-AI/deepvista-cli` works too (GitHub CLI ≥ 2.90, preview).
+
+#### Windows troubleshooting: `uv trampoline failed to canonicalize script path`
+
+On Windows, running `deepvista` may fail with:
+
+```
+error: uv trampoline failed to canonicalize script path
+```
+
+This is a [known uv-on-Windows issue](https://github.com/astral-sh/uv/issues): the launcher (trampoline) that `uv tool install` creates can fail to resolve its own path. It is aggravated by working directories that contain **spaces** (e.g. `C:\Users\you\Claude Folder`) or are inside **OneDrive**-synced folders.
+
+Fixes, in order of preference:
+
+1. **Update uv and reinstall the launcher:**
+
+   ```powershell
+   uv self update
+   uv tool install --reinstall "deepvista-cli[ui]"
+   ```
+
+2. **Run via `uv tool run` as a fallback** (bypasses the broken trampoline entirely):
+
+   ```powershell
+   uv tool run deepvista auth login
+   uv tool run deepvista notes +quick "My first note"
+   ```
+
+3. **Avoid spaces / OneDrive in your working directory.** Run from a path without spaces, e.g. `C:\dev`, rather than `C:\Users\you\Claude Folder`.
+
+The `install.ps1` script performs this check automatically: after installing it runs `deepvista --version`, and if it hits the trampoline error it falls back to `uv tool run deepvista` and prints the guidance above. It also adds `%USERPROFILE%\.local\bin` (uv's tool bin directory) to your user PATH if it isn't already there — restart your shell afterward so new terminals pick it up.
 
 ### Get Started
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,401 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Installs the DeepVista CLI and agent skills on Windows.
+
+.DESCRIPTION
+    PowerShell port of install.sh. Works in Windows PowerShell 5.1 and
+    PowerShell 7+ (pwsh). Mirrors the bash installer:
+      1. Ensure uv is installed (irm https://astral.sh/uv/install.ps1 | iex)
+      2. Install or upgrade the deepvista CLI
+      3. Deploy the consolidated `deepvista` skill to agent skill directories
+      4. Inject skill interpretation rules into agent config files
+      5. Register the skill-trigger hook in Claude Code settings.json
+      6. Verify the binary runs (with uv-trampoline troubleshooting)
+      7. Check / perform authentication
+      8. Print next-steps guidance
+
+.NOTES
+    Run with:
+      powershell -ExecutionPolicy ByPass -c "irm https://raw.githubusercontent.com/DeepVista-AI/deepvista-cli/main/install.ps1 | iex"
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$REPO  = 'DeepVista-AI/deepvista-cli'
+$SKILL = 'deepvista'
+
+function Write-Step { param([string]$Message) Write-Host "==> $Message" }
+function Write-Sub  { param([string]$Message) Write-Host "    $Message" }
+function Write-Warn { param([string]$Message) Write-Host "    WARNING: $Message" -ForegroundColor Yellow }
+
+function Test-Command {
+    param([string]$Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+# uv installs the tool launchers (shims) into %USERPROFILE%\.local\bin on Windows.
+$UvBinDir = Join-Path $env:USERPROFILE '.local\bin'
+
+function Add-UvBinToPath {
+    # Ensure the uv tool bin dir is on PATH for this session and persisted for the user.
+    if (Test-Path $UvBinDir) {
+        if (($env:PATH -split ';') -notcontains $UvBinDir) {
+            $env:PATH = "$UvBinDir;$env:PATH"
+        }
+        $userPath = [Environment]::GetEnvironmentVariable('PATH', 'User')
+        $userEntries = @()
+        if ($userPath) { $userEntries = $userPath -split ';' }
+        if ($userEntries -notcontains $UvBinDir) {
+            $newUserPath = if ($userPath) { "$userPath;$UvBinDir" } else { $UvBinDir }
+            [Environment]::SetEnvironmentVariable('PATH', $newUserPath, 'User')
+            Write-Sub "Added $UvBinDir to your user PATH (restart your shell for new terminals to pick it up)."
+        }
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 1. Ensure uv
+# ---------------------------------------------------------------------------
+Write-Step 'Installing deepvista CLI...'
+
+if (-not (Test-Command 'uv')) {
+    Write-Sub 'uv not found - installing uv...'
+    try {
+        Invoke-RestMethod 'https://astral.sh/uv/install.ps1' | Invoke-Expression
+    } catch {
+        Write-Error "Failed to install uv: $($_.Exception.Message)"
+        exit 1
+    }
+    # The uv installer puts uv in %USERPROFILE%\.local\bin; surface it now.
+    if (($env:PATH -split ';') -notcontains $UvBinDir) {
+        $env:PATH = "$UvBinDir;$env:PATH"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 2. Install or upgrade the CLI
+# ---------------------------------------------------------------------------
+if (Test-Command 'deepvista') {
+    Write-Sub 'deepvista already installed - running upgrade...'
+    deepvista upgrade
+} else {
+    if (Test-Command 'uv') {
+        uv tool install "deepvista-cli[ui]"
+    } elseif (Test-Command 'pipx') {
+        pipx install "deepvista-cli[ui]"
+    } elseif (Test-Command 'pip3') {
+        pip3 install --user "deepvista-cli[ui]"
+    } elseif (Test-Command 'pip') {
+        pip install --user "deepvista-cli[ui]"
+    } else {
+        Write-Error 'No Python package manager found (pip, pipx, or uv required)'
+        exit 1
+    }
+}
+
+# Make sure the freshly-installed launcher is reachable.
+Add-UvBinToPath
+
+# ---------------------------------------------------------------------------
+# 3. Install DeepVista skills
+# ---------------------------------------------------------------------------
+Write-Step 'Installing DeepVista skills...'
+
+# Detect which agent skill directories to install into.
+$SkillDirs = New-Object System.Collections.Generic.List[string]
+$home_ = $env:USERPROFILE
+if (Test-Path (Join-Path $home_ '.claude'))   { $SkillDirs.Add((Join-Path $home_ '.claude\skills')) }
+if (Test-Path (Join-Path $home_ '.agents'))   { $SkillDirs.Add((Join-Path $home_ '.agents\skills')) }
+if (Test-Path (Join-Path $home_ '.cursor'))   { $SkillDirs.Add((Join-Path $home_ '.cursor\skills')) }
+if (Test-Path (Join-Path $home_ '.opencode')) { $SkillDirs.Add((Join-Path $home_ '.opencode\skills')) }
+# OpenClaw: skills live in the workspace directory.
+if (Test-Path (Join-Path $home_ '.openclaw\workspace')) { $SkillDirs.Add((Join-Path $home_ '.openclaw\workspace\skills')) }
+
+# Default to Claude if no agent directory found.
+if ($SkillDirs.Count -eq 0) {
+    $SkillDirs.Add((Join-Path $home_ '.claude\skills'))
+}
+
+if (-not (Test-Command 'git')) {
+    Write-Error 'git required to install DeepVista skills'
+    exit 1
+}
+
+$Tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("deepvista-" + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $Tmp -Force | Out-Null
+try {
+    $RepoDir = Join-Path $Tmp 'repo'
+    git clone --depth 1 --quiet "https://github.com/$REPO.git" $RepoDir
+    $Src = Join-Path $RepoDir 'skills'
+
+    foreach ($dir in $SkillDirs) {
+        New-Item -ItemType Directory -Path $dir -Force | Out-Null
+        $dest = Join-Path $dir $SKILL
+        if (Test-Path $dest) { Remove-Item -Recurse -Force $dest }
+        Copy-Item -Recurse -Force (Join-Path $Src $SKILL) $dest
+        Write-Sub "Skill installed to $dest"
+    }
+} finally {
+    if (Test-Path $Tmp) { Remove-Item -Recurse -Force $Tmp -ErrorAction SilentlyContinue }
+}
+
+$OpenClawWorkspace = Join-Path $home_ '.openclaw\workspace'
+
+# ---------------------------------------------------------------------------
+# 4. Inject skill interpretation rules
+# ---------------------------------------------------------------------------
+$SkillRulesBlock = @'
+
+<!-- deepvista-skill-rules -->
+## Skill Interpretation Rules
+
+When you load or invoke any skill, check its frontmatter for two fields: `type` and `execution`.
+
+### Handling `type`
+
+**`type: persona`**
+Do not invoke this as a command. Load it as background context that shapes how you
+behave for the rest of the session. Apply its tone, expertise, and decision patterns silently.
+
+**`type: tool`**
+Treat this as a discrete capability. Invoke it when the task calls for it and return
+its result. No special handling needed.
+
+**`type: workflow`**
+Treat this as a self-contained sequence of steps. Work through them in order. Do not
+mix steps from other skills into this sequence unless explicitly instructed.
+
+### Handling `execution`
+
+**`execution: stateless`**
+Run freely. Retry on failure. No confirmation needed.
+
+**`execution: stateful`**
+Before executing, stop and do two things:
+1. If the skill or its underlying command supports `--dry-run`, run that first and show the output.
+2. Summarize what you are about to do and what will change, then ask for confirmation before proceeding.
+
+Never skip this checkpoint for stateful skills, even if the task seems straightforward.
+
+### Fallback rules
+- If `type` is missing, use the information in the skill to guess its type.
+- If `execution` is missing, treat as `stateful` and apply the checkpoint.
+- If a workflow is stateful, treat all its steps as stateful unless they declare otherwise.
+<!-- /deepvista-skill-rules -->
+'@
+
+function Install-SkillRules {
+    param([string]$ConfigFile)
+    $parent = Split-Path -Parent $ConfigFile
+    if ($parent -and -not (Test-Path $parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+    # Idempotent: skip if already installed.
+    if ((Test-Path $ConfigFile) -and (Select-String -Path $ConfigFile -Pattern 'deepvista-skill-rules' -Quiet)) {
+        return
+    }
+    Add-Content -Path $ConfigFile -Value $SkillRulesBlock
+    Write-Sub "Skill interpretation rules injected in $ConfigFile"
+}
+
+Write-Step 'Injecting skill interpretation rules...'
+
+if (Test-Path (Join-Path $home_ '.claude'))   { Install-SkillRules (Join-Path $home_ '.claude\CLAUDE.md') }
+if (Test-Path (Join-Path $home_ '.cursor'))   { Install-SkillRules (Join-Path $home_ '.cursor\rules') }
+if (Test-Path (Join-Path $home_ '.opencode')) { Install-SkillRules (Join-Path $home_ '.opencode\AGENTS.md') }
+if (Test-Path $OpenClawWorkspace)             { Install-SkillRules (Join-Path $OpenClawWorkspace 'AGENTS.md') }
+
+# ---------------------------------------------------------------------------
+# 5. Register the skill-trigger hook in Claude Code settings.json
+# ---------------------------------------------------------------------------
+Write-Step 'Installing DeepVista skill-trigger hook...'
+
+# Same shell command as the bash installer. The hook body is a bash snippet
+# executed by Claude Code's hook runner; it is stored verbatim as a string.
+$TriggerCmd = @'
+prompt=$(jq -r '.prompt // ""'); if echo "$prompt" | grep -qiE '\b(workflow|skill)'; then echo '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"IMPORTANT: The user mentioned workflow or skills. You MUST call the Skill tool with skill=\"deepvista\" before doing anything else. Do not search files, browse the web, or use any other tool first."}}'; fi  # deepvista-skill-trigger
+'@.Trim()
+
+function Install-SkillTriggerHook {
+    param([string]$SettingsFile)
+
+    $parent = Split-Path -Parent $SettingsFile
+    if ($parent -and -not (Test-Path $parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+
+    if (-not (Test-Path $SettingsFile)) {
+        Set-Content -Path $SettingsFile -Value '{}'
+    }
+
+    # Idempotent: skip if already installed.
+    if (Select-String -Path $SettingsFile -Pattern 'deepvista-skill-trigger' -Quiet) {
+        Write-Sub "Skill-trigger hook already registered in $SettingsFile"
+        return
+    }
+
+    $raw = Get-Content -Raw -Path $SettingsFile
+    if ([string]::IsNullOrWhiteSpace($raw)) { $raw = '{}' }
+    try {
+        $cfg = $raw | ConvertFrom-Json
+    } catch {
+        $cfg = [pscustomobject]@{}
+    }
+    if ($null -eq $cfg) { $cfg = [pscustomobject]@{} }
+
+    # Ensure cfg.hooks exists.
+    if (-not ($cfg.PSObject.Properties.Name -contains 'hooks') -or $null -eq $cfg.hooks) {
+        $cfg | Add-Member -NotePropertyName 'hooks' -NotePropertyValue ([pscustomobject]@{}) -Force
+    }
+    $hooks = $cfg.hooks
+
+    # Ensure hooks.UserPromptSubmit exists as an array.
+    if (-not ($hooks.PSObject.Properties.Name -contains 'UserPromptSubmit') -or $null -eq $hooks.UserPromptSubmit) {
+        $hooks | Add-Member -NotePropertyName 'UserPromptSubmit' -NotePropertyValue @() -Force
+    }
+    $uspList = @($hooks.UserPromptSubmit)
+
+    # Bail if already present (defensive; the Select-String check above usually catches it).
+    foreach ($entry in $uspList) {
+        if ($entry.PSObject.Properties.Name -contains 'hooks') {
+            foreach ($h in @($entry.hooks)) {
+                if ($h.PSObject.Properties.Name -contains 'command' -and "$($h.command)".Contains('deepvista-skill-trigger')) {
+                    Write-Sub "Skill-trigger hook already registered in $SettingsFile"
+                    return
+                }
+            }
+        }
+    }
+
+    $newEntry = [pscustomobject]@{
+        matcher = ''
+        hooks   = @(
+            [pscustomobject]@{
+                type    = 'command'
+                command = $TriggerCmd
+            }
+        )
+    }
+
+    $hooks.UserPromptSubmit = @($uspList + $newEntry)
+
+    $cfg | ConvertTo-Json -Depth 20 | Set-Content -Path $SettingsFile -Encoding UTF8
+    Write-Sub "Skill-trigger hook registered in $SettingsFile"
+}
+
+Install-SkillTriggerHook (Join-Path $home_ '.claude\settings.json')
+Write-Sub 'Skill-trigger hook active - deepvista skill will be suggested when you mention workflow or skills'
+
+# ---------------------------------------------------------------------------
+# 6. Verify the binary actually runs (uv trampoline check)
+# ---------------------------------------------------------------------------
+Write-Step 'Verifying deepvista runs...'
+
+# How to invoke deepvista for the auth step below. Defaults to the direct
+# launcher; falls back to `uv tool run` if the trampoline is broken.
+$DeepvistaRunner = @('deepvista')
+
+function Invoke-DeepvistaVersion {
+    # Returns a hashtable: @{ Ok = $bool; Output = $string }
+    param([string[]]$Prefix)
+    $out = ''
+    $ok = $false
+    try {
+        $exe = $Prefix[0]
+        $argList = @()
+        if ($Prefix.Count -gt 1) { $argList += $Prefix[1..($Prefix.Count - 1)] }
+        $argList += '--version'
+        $out = & $exe @argList 2>&1 | Out-String
+        $ok = ($LASTEXITCODE -eq 0)
+    } catch {
+        $out = $_.Exception.Message
+        $ok = $false
+    }
+    return @{ Ok = $ok; Output = $out }
+}
+
+$verify = Invoke-DeepvistaVersion -Prefix @('deepvista')
+if ($verify.Ok) {
+    Write-Sub ("deepvista OK: " + ($verify.Output.Trim()))
+} else {
+    $isTrampoline = $verify.Output -match 'trampoline failed to canonicalize'
+    if ($isTrampoline) {
+        Write-Warn 'Hit the known uv trampoline bug: "uv trampoline failed to canonicalize script path".'
+    } else {
+        Write-Warn ("`deepvista --version` did not run cleanly: " + ($verify.Output.Trim()))
+    }
+
+    # Fall back to `uv tool run deepvista`.
+    $fallback = Invoke-DeepvistaVersion -Prefix @('uv', 'tool', 'run', 'deepvista')
+    if ($fallback.Ok) {
+        Write-Sub ("Fallback works: `uv tool run deepvista` -> " + ($fallback.Output.Trim()))
+        $DeepvistaRunner = @('uv', 'tool', 'run', 'deepvista')
+        Write-Host ''
+        Write-Sub 'The `deepvista` launcher is broken but `uv tool run deepvista` works. To fix the launcher:'
+        Write-Sub '  uv self update'
+        Write-Sub '  uv tool install --reinstall "deepvista-cli[ui]"'
+        Write-Sub 'Until then, prefix commands with `uv tool run`, e.g. `uv tool run deepvista auth login`.'
+        Write-Sub 'Tip: paths with spaces or OneDrive-synced folders aggravate this bug - run from a path without spaces.'
+        Write-Host ''
+    } else {
+        Write-Warn 'Could not run deepvista via the launcher or `uv tool run`.'
+        Write-Sub 'Try the following, then re-run this installer:'
+        Write-Sub '  uv self update'
+        Write-Sub '  uv tool install --reinstall "deepvista-cli[ui]"'
+        Write-Sub 'Or invoke it directly with: uv tool run deepvista <args>'
+        Write-Sub 'Tip: avoid working directories with spaces or OneDrive sync, which trigger the uv trampoline bug.'
+    }
+}
+
+# ---------------------------------------------------------------------------
+# 7. Authentication
+# ---------------------------------------------------------------------------
+Write-Step 'Checking DeepVista authentication...'
+
+function Invoke-Deepvista {
+    param([string[]]$Arguments)
+    $exe = $DeepvistaRunner[0]
+    $prefixArgs = @()
+    if ($DeepvistaRunner.Count -gt 1) { $prefixArgs = $DeepvistaRunner[1..($DeepvistaRunner.Count - 1)] }
+    & $exe @($prefixArgs + $Arguments)
+    return $LASTEXITCODE
+}
+
+$authStatus = 1
+try {
+    $statusPrefixArgs = @()
+    if ($DeepvistaRunner.Count -gt 1) { $statusPrefixArgs = $DeepvistaRunner[1..($DeepvistaRunner.Count - 1)] }
+    $null = (& $DeepvistaRunner[0] @($statusPrefixArgs + @('auth', 'status')) 2>&1)
+    $authStatus = $LASTEXITCODE
+} catch {
+    $authStatus = 1
+}
+
+if ($authStatus -eq 0) {
+    Write-Sub 'Already authenticated.'
+} else {
+    Write-Sub 'Not authenticated - launching login...'
+    Invoke-Deepvista -Arguments @('auth', 'login') | Out-Null
+}
+
+# ---------------------------------------------------------------------------
+# 8. Next steps
+# ---------------------------------------------------------------------------
+Write-Host ''
+Write-Step 'DeepVista Claude Code plugin'
+Write-Host ''
+Write-Host '    Inside Claude Code, run:'
+Write-Host ''
+Write-Host '      /plugin marketplace add DeepVista-AI/deepvista-cli'
+Write-Host '      /plugin install deepvista@deepvista-ai'
+Write-Host ''
+Write-Host '    Using a different AI agent? Paste this prompt:'
+Write-Host ''
+Write-Host '      Help me install the deepvista plugin for Claude Code: https://github.com/DeepVista-AI/deepvista-cli#as-a-claude-code-plugin'
+Write-Host ''
+Write-Host 'DeepVista is ready. Open your AI agent and say:'
+Write-Host ''
+Write-Host '  Help me get started with DeepVista.'
+Write-Host ''

--- a/install.ps1
+++ b/install.ps1
@@ -324,13 +324,13 @@ if ($verify.Ok) {
     if ($isTrampoline) {
         Write-Warn 'Hit the known uv trampoline bug: "uv trampoline failed to canonicalize script path".'
     } else {
-        Write-Warn ("`deepvista --version` did not run cleanly: " + ($verify.Output.Trim()))
+        Write-Warn ('deepvista --version did not run cleanly: ' + ($verify.Output.Trim()))
     }
 
     # Fall back to `uv tool run deepvista`.
     $fallback = Invoke-DeepvistaVersion -Prefix @('uv', 'tool', 'run', 'deepvista')
     if ($fallback.Ok) {
-        Write-Sub ("Fallback works: `uv tool run deepvista` -> " + ($fallback.Output.Trim()))
+        Write-Sub ('Fallback works: uv tool run deepvista -> ' + ($fallback.Output.Trim()))
         $DeepvistaRunner = @('uv', 'tool', 'run', 'deepvista')
         Write-Host ''
         Write-Sub 'The `deepvista` launcher is broken but `uv tool run deepvista` works. To fix the launcher:'


### PR DESCRIPTION
Fixes DV-941 (part of DV-932 — Alex's onboarding follow-ups).

## Problem

Windows install is effectively unsupported: `install.sh` is bash-only, and a real user's first run hit `error: uv trampoline failed to canonicalize script path` when invoking `%USERPROFILE%\.local\bin\deepvista` directly (known uv-on-Windows path bug, aggravated by paths with spaces — the user's cwd was `C:\Users\asout\Claude Folder`). The only workaround was agent-improvised `uv run` / `Set-Alias`.

## Changes

- **`install.ps1`** (new, PS 5.1 + pwsh 7): full port of install.sh's 7-step sequence — ensure uv (`irm astral.sh/uv/install.ps1 | iex`), install/upgrade CLI (`uv tool install "deepvista-cli[ui]"` with pipx/pip fallbacks), deploy `skills/deepvista` to detected agent dirs, inject skill interpretation rules, register the Claude Code skill-trigger hook (native PowerShell JSON, no Python dependency), auth check, next-steps text. Plus Windows-specific hardening:
  - verifies `deepvista --version` actually runs; on the trampoline error it auto-falls back to `uv tool run deepvista` and prints remediation (`uv self update` + `uv tool install --reinstall`)
  - ensures `%USERPROFILE%\.local\bin` is on the user PATH
- **`README.md`**: Windows one-liner (`powershell -ExecutionPolicy ByPass -c "irm …/install.ps1 | iex"`) + Troubleshooting subsection for the trampoline error
- **`.github/workflows/ci.yml`**: `windows-smoke` job — parses `install.ps1` (AST syntax check), `uv tool install ".[ui]"` from checkout, `deepvista --help`

## Testing

- No pwsh available on the dev machine, so `install.ps1` couldn't be executed locally — the CI parse step + windows-smoke job are the validation gate; please watch the first run
- YAML validated; here-string/brace balance statically checked
- Review fix included: an inline `[1..($Count-1)]` slice in the auth-status check produced a descending `[1..0]` range when the runner array had one element (would have invoked `deepvista deepvista auth status`) — replaced with the guarded prefix pattern used elsewhere

## Note

The Claude Code hook command stored in settings.json is the same bash snippet as install.sh (it's executed by Claude Code's hook runner, which uses a POSIX shell via Git Bash on Windows). If native-Windows hook execution proves unreliable, that's follow-up scope.