### PR TITLE
feat(DV-1079): poll by default in task_queue run with single-instance lock

### DIFF
--- a/deepvista_cli/commands/task_queue.py
+++ b/deepvista_cli/commands/task_queue.py
@@ -3,10 +3,16 @@
 The web app enqueues DeepVista CLI commands onto a managed agent's
 `task_queue`; this command group lets the agent's machine poll and run them:
 
-  deepvista task_queue run      — claim pending tasks and execute them
+  deepvista task_queue run      — poll for pending tasks and execute them
   deepvista task_queue list     — show this machine's queue
   deepvista task_queue complete — report a workflow task's outcome (host agent)
   deepvista task_queue setup    — install a crontab entry that polls periodically
+
+Polling (DV-1079): `run` polls in the foreground by default (--poll-interval,
+bounded by --total-time when given); --run-once does a single claim/execute
+pass, which is what the cron entry installed by `setup` uses. A PID lock file
+allows only one `task_queue run` per machine at a time, so a foreground
+poller and cron ticks never double-claim.
 
 Workflow tasks (DV-955): webhook-queued `deepvista skill run` entries can't
 be subprocess-executed — a workflow needs the surrounding host agent (Claude
@@ -24,10 +30,12 @@ enqueue time; the check here guards against tampered queue rows.
 from __future__ import annotations
 
 import json as _json
+import os
 import shlex
 import shutil
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 import click
@@ -54,6 +62,12 @@ OUTPUT_TAIL_MAX_CHARS = 2000
 CRON_MARKER = "# deepvista-task-queue"
 
 CRON_LOG_PATH = CONFIG_DIR / "task_queue.log"
+
+# Seconds between polls when `run` is left in its default polling mode.
+DEFAULT_POLL_INTERVAL_SECONDS = 60
+
+# Single-instance lock for `task_queue run` (DV-1079) — holds the owner PID.
+RUN_LOCK_PATH = CONFIG_DIR / "task_queue.run.lock"
 
 
 # ---------------------------------------------------------------------------
@@ -238,6 +252,51 @@ def _emit_workflow_task(ctx: click.Context, agent_id: str, task: dict) -> dict:
     return {"task_id": task_id, "command": command, "status": "running", "exit_code": None}
 
 
+def _pid_alive(pid: int) -> bool:
+    """Best-effort liveness probe for a PID (signal 0, no actual signal sent)."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Exists but owned by someone else — still alive.
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _read_lock_pid() -> int | None:
+    try:
+        return int(RUN_LOCK_PATH.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _acquire_run_lock() -> bool:
+    """Take the machine-wide single-instance lock for `task_queue run` (DV-1079).
+
+    Overlapping pollers would double-claim the queue, so only one `run` may
+    be active at a time — a foreground poller and a cron tick included. A
+    lock whose owner PID is dead (crash, reboot) is stale and reclaimed.
+    """
+    pid = _read_lock_pid()
+    if pid is not None and pid != os.getpid() and _pid_alive(pid):
+        return False
+    RUN_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    RUN_LOCK_PATH.write_text(str(os.getpid()))
+    return True
+
+
+def _release_run_lock() -> None:
+    if _read_lock_pid() != os.getpid():
+        return
+    try:
+        RUN_LOCK_PATH.unlink()
+    except OSError:
+        pass
+
+
 def _execute_task(ctx: click.Context, agent_id: str, task: dict) -> dict:
     """Run one claimed task and report its terminal result to the backend."""
     task_id = str(task.get("id", ""))
@@ -290,6 +349,27 @@ def _detect_host_agent() -> bool:
     return bool(detected) and detected != "deepvista-cli"
 
 
+def _claim_and_run(ctx: click.Context, agent_id: str, host_mode: bool) -> tuple[list[dict], list[dict]]:
+    """One claim/execute pass; returns (command task results, workflow tasks)."""
+    data = _client(ctx).post(
+        f"/agents/{agent_id}/task-queue/claim",
+        None if host_mode else {"command_only": True},
+    )
+    if not data.get("success"):
+        output_error(1, "Failed to claim tasks", data.get("error", "Unknown error"))
+        raise SystemExit(1)
+
+    tasks = data.get("tasks") or []
+    command_tasks = [t for t in tasks if not _is_workflow_task(t)]
+    # Workflow tasks only reach this list in host mode (headless claims are
+    # command_only) — the guard below covers a backend that predates the
+    # filter, so a cron tick never swallows a packet nobody will read.
+    workflow_tasks = [t for t in tasks if _is_workflow_task(t)] if host_mode else []
+
+    results = [_execute_task(ctx, agent_id, task) for task in command_tasks]
+    return results, workflow_tasks
+
+
 @task_queue_group.command("run")
 @click.option("--type", "agent_type", default=None, help="Resolve agent by type from local storage.")
 @click.option("--role", "agent_role", default=None, help="Resolve agent by role (with --type).")
@@ -304,57 +384,117 @@ def _detect_host_agent() -> bool:
         "detected; headless runs claim command tasks only."
     ),
 )
+@click.option(
+    "--run-once",
+    "--run_once",
+    "run_once",
+    is_flag=True,
+    default=False,
+    help="Do a single claim/execute pass and exit (what the `setup` cron entry uses).",
+)
+@click.option(
+    "--poll-interval",
+    default=DEFAULT_POLL_INTERVAL_SECONDS,
+    show_default=True,
+    type=click.IntRange(1, 3600),
+    help="Seconds to wait between polls.",
+)
+@click.option(
+    "--total-time",
+    default=None,
+    type=click.IntRange(1),
+    help="Stop polling after this many seconds (default: poll until interrupted).",
+)
 @click.pass_context
-def task_queue_run(ctx: click.Context, agent_type: str | None, agent_role: str | None, host_mode: bool) -> None:
-    """Claim pending tasks for this machine's agent and execute them.
+def task_queue_run(
+    ctx: click.Context,
+    agent_type: str | None,
+    agent_role: str | None,
+    host_mode: bool,
+    run_once: bool,
+    poll_interval: int,
+    total_time: int | None,
+) -> None:
+    """Poll this machine's agent queue and execute claimed tasks (DV-1079).
 
-    Returns immediately when the queue is empty, so it's cheap as a cron
-    tick. Plain command tasks run sequentially via subprocess and their
-    results are reported back. Workflow tasks (webhook-queued skill runs)
-    are only claimed in host mode: their run packets are printed for the
-    surrounding agent to drive, and the entries stay ``running`` until the
-    agent calls ``task_queue complete``.
+    Default mode polls in the foreground — claim, execute, sleep
+    --poll-interval, repeat — until --total-time elapses (or forever when
+    unset), which keeps every registered agent on this machine picking up
+    work without a cron job. --run-once does a single pass and exits; the
+    cron entry installed by `task_queue setup` uses it.
+
+    Only one `task_queue run` may be active per machine — concurrent
+    invocations exit with an error instead of double-claiming the queue.
+
+    Plain command tasks run sequentially via subprocess and their results
+    are reported back. Workflow tasks (webhook-queued skill runs) are only
+    claimed in host mode: their run packets are printed for the surrounding
+    agent to drive — polling stops at that point so the host agent can act —
+    and the entries stay ``running`` until the agent calls
+    ``task_queue complete``.
     """
     agent_id = _require_machine_agent_id(agent_type, agent_role)
     host_mode = host_mode or _detect_host_agent()
 
-    data = _client(ctx).post(
-        f"/agents/{agent_id}/task-queue/claim",
-        None if host_mode else {"command_only": True},
-    )
-    if not data.get("success"):
-        output_error(1, "Failed to claim tasks", data.get("error", "Unknown error"))
-        raise SystemExit(1)
+    if not _acquire_run_lock():
+        output_error(
+            2,
+            "Another `task_queue run` is already active on this machine",
+            f"Stop it first or wait for it to finish (lock: {RUN_LOCK_PATH}, pid: {_read_lock_pid()}).",
+        )
+        raise SystemExit(2)
 
-    tasks = data.get("tasks") or []
-    if not tasks:
-        _output(ctx, {"agent_id": agent_id, "tasks_run": 0}, title="Task Queue")
-        return
+    started = time.monotonic()
+    polls = 0
+    total_results: list[dict] = []
+    try:
+        while True:
+            polls += 1
+            results, workflow_tasks = _claim_and_run(ctx, agent_id, host_mode)
+            total_results.extend(results)
 
-    command_tasks = [t for t in tasks if not _is_workflow_task(t)]
-    # Workflow tasks only reach this list in host mode (headless claims are
-    # command_only) — the guard below covers a backend that predates the
-    # filter, so a cron tick never swallows a packet nobody will read.
-    workflow_tasks = [t for t in tasks if _is_workflow_task(t)] if host_mode else []
+            # A polling loop stays quiet on empty passes; --run-once always
+            # reports so cron logs show every tick.
+            if run_once or results or workflow_tasks:
+                _output(
+                    ctx,
+                    {
+                        "agent_id": agent_id,
+                        "tasks_run": len(results),
+                        "failed": sum(1 for r in results if r["status"] == "failed"),
+                        "results": results,
+                        "workflow_tasks": len(workflow_tasks),
+                    },
+                    title="Task Queue",
+                )
 
-    results = [_execute_task(ctx, agent_id, task) for task in command_tasks]
-    failed = sum(1 for r in results if r["status"] == "failed")
-    _output(
-        ctx,
-        {
-            "agent_id": agent_id,
-            "tasks_run": len(results),
-            "failed": failed,
-            "results": results,
-            "workflow_tasks": len(workflow_tasks),
-        },
-        title="Task Queue",
-    )
+            # Workflow packets go last so the runtime contract (and its
+            # completion instructions) is the freshest thing in the host
+            # agent's context.
+            for task in workflow_tasks:
+                _emit_workflow_task(ctx, agent_id, task)
 
-    # Workflow packets go last so the runtime contract (and its completion
-    # instructions) is the freshest thing in the host agent's context.
-    for task in workflow_tasks:
-        _emit_workflow_task(ctx, agent_id, task)
+            if run_once:
+                return
+            if workflow_tasks:
+                # The host agent has packets to drive; blocking it inside the
+                # poll loop would deadlock the run. Hand control back.
+                return
+            if total_time is not None and (time.monotonic() - started) + poll_interval > total_time:
+                _output(
+                    ctx,
+                    {
+                        "agent_id": agent_id,
+                        "polls": polls,
+                        "tasks_run": len(total_results),
+                        "failed": sum(1 for r in total_results if r["status"] == "failed"),
+                    },
+                    title="Task Queue (polling finished)",
+                )
+                return
+            time.sleep(poll_interval)
+    finally:
+        _release_run_lock()
 
 
 @task_queue_group.command("list")
@@ -457,7 +597,9 @@ def _write_crontab(lines: list[str]) -> bool:
 def _cron_entry(interval: int, profile: str) -> str:
     binary = _deepvista_binary()
     profile_flag = f" --profile {profile}" if profile and profile != "default" else ""
-    return f"*/{interval} * * * * {binary}{profile_flag} task_queue run >> {CRON_LOG_PATH} 2>&1 {CRON_MARKER}"
+    return (
+        f"*/{interval} * * * * {binary}{profile_flag} task_queue run --run-once >> {CRON_LOG_PATH} 2>&1 {CRON_MARKER}"
+    )
 
 
 @task_queue_group.command("setup")
@@ -471,11 +613,14 @@ def _cron_entry(interval: int, profile: str) -> str:
 @click.option("--remove", is_flag=True, default=False, help="Uninstall the cron entry instead.")
 @click.pass_context
 def task_queue_setup(ctx: click.Context, interval: int, remove: bool) -> None:
-    """Install a crontab entry that runs `deepvista task_queue run` periodically.
+    """Install a crontab entry that runs `deepvista task_queue run --run-once` periodically.
 
-    Idempotent — re-running replaces any existing entry. Use --remove to
-    uninstall. Crontab only (macOS/Linux); on Windows, schedule
-    `deepvista task_queue run` with Task Scheduler instead.
+    An alternative to leaving a foreground `task_queue run` polling: cron
+    fires a single claim/execute pass per tick. The run lock keeps a tick
+    from overlapping a foreground poller. Idempotent — re-running replaces
+    any existing entry. Use --remove to uninstall. Crontab only
+    (macOS/Linux); on Windows, schedule `deepvista task_queue run
+    --run-once` with Task Scheduler instead.
 
     Cron runs are headless: they execute plain command tasks only and
     leave workflow tasks (webhook-queued skill runs) pending. Drive those

--- a/tests/test_task_queue_commands.py
+++ b/tests/test_task_queue_commands.py
@@ -1,4 +1,4 @@
-"""Click-level tests for `deepvista task_queue run` / `list` / `complete` / `setup` (DV-936/DV-955)."""
+"""Click-level tests for `deepvista task_queue run` / `list` / `complete` / `setup` (DV-936/DV-955/DV-1079)."""
 
 from __future__ import annotations
 
@@ -85,6 +85,46 @@ def _register_local_agent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, agent
 
     monkeypatch.setattr(agents_module, "AGENTS_DIR", agents_dir)
     monkeypatch.setattr(tq_module, "AGENTS_DIR", agents_dir)
+    # Keep the run lock inside the pytest tmp dir, away from ~/.config.
+    monkeypatch.setattr(tq_module, "RUN_LOCK_PATH", tmp_path / ".config" / "deepvista" / "task_queue.run.lock")
+
+
+class _FakeClock:
+    """Deterministic stand-in for the `time` module inside the poll loop."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.sleeps: list[int] = []
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: int) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+def _install_fake_clock(monkeypatch: pytest.MonkeyPatch) -> _FakeClock:
+    import deepvista_cli.commands.task_queue as tq_module
+
+    clock = _FakeClock()
+    monkeypatch.setattr(tq_module, "time", clock)
+    return clock
+
+
+def _parse_json_objects(output: str) -> list[dict]:
+    """Parse a stream of concatenated (pretty-printed) JSON objects."""
+    decoder = json.JSONDecoder()
+    text = output.strip()
+    objs: list[dict] = []
+    idx = 0
+    while idx < len(text):
+        obj, end = decoder.raw_decode(text, idx)
+        objs.append(obj)
+        while end < len(text) and text[end].isspace():
+            end += 1
+        idx = end
+    return objs
 
 
 # ---------------------------------------------------------------------------
@@ -104,7 +144,7 @@ def test_validate_command_allows_only_deepvista():
 # ---------------------------------------------------------------------------
 
 
-def test_run_exits_immediately_when_queue_empty(
+def test_run_once_exits_immediately_when_queue_empty(
     isolated_home: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -113,7 +153,7 @@ def test_run_exits_immediately_when_queue_empty(
     _install_stub_client(monkeypatch, stub)
     _register_local_agent(monkeypatch, isolated_home)
 
-    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["tasks_run"] == 0
@@ -149,7 +189,7 @@ def test_run_executes_claimed_task_and_reports_result(
 
     monkeypatch.setattr(tq_module.subprocess, "run", fake_run)
 
-    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["tasks_run"] == 1
@@ -185,7 +225,7 @@ def test_run_rejects_non_deepvista_command_without_executing(
 
     monkeypatch.setattr(tq_module.subprocess, "run", explode)
 
-    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
     payload = json.loads(result.output)
     assert payload["failed"] == 1
@@ -250,7 +290,7 @@ def test_run_headless_claims_command_only(
 
     monkeypatch.setattr(tq_module, "_detect_host_agent", lambda: False)
 
-    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
     method, path, body = stub.calls[0]
     assert (method, path) == ("POST", "/agents/agent-uuid-1/task-queue/claim")
@@ -357,11 +397,144 @@ def test_run_headless_ignores_workflow_tasks_that_slip_through(
 
     monkeypatch.setattr(tq_module.subprocess, "run", explode)
 
-    result = CliRunner().invoke(cli, ["task_queue", "run"])
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
     # No packet for a cron log, no subprocess, no terminal report.
     assert "DEEPVISTA WORKFLOW TASK" not in result.output
     assert all("/result" not in c[1] for c in stub.calls)
+
+
+# ---------------------------------------------------------------------------
+# polling + single-instance lock (DV-1079)
+# ---------------------------------------------------------------------------
+
+
+def test_run_polls_until_total_time(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    for _ in range(3):
+        stub.queue("/agents/agent-uuid-1/task-queue/claim", {"success": True, "tasks": []})
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+    clock = _install_fake_clock(monkeypatch)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--poll-interval", "10", "--total-time", "25"])
+    assert result.exit_code == 0, result.output
+
+    # Passes at t=0, 10, 20; a fourth pass would start past the 25s budget.
+    assert [c[1] for c in stub.calls] == ["/agents/agent-uuid-1/task-queue/claim"] * 3
+    assert clock.sleeps == [10, 10]
+
+    # Empty passes are quiet; only the final summary is printed.
+    payload = json.loads(result.output)
+    assert payload == {"agent_id": "agent-uuid-1", "polls": 3, "tasks_run": 0, "failed": 0}
+
+
+def test_run_polling_executes_tasks_across_passes(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/agents/agent-uuid-1/task-queue/claim",
+        {"success": True, "tasks": [{"id": "t-1", "command": "deepvista notes list", "status": "running"}]},
+    )
+    stub.queue("/agents/agent-uuid-1/task-queue/claim", {"success": True, "tasks": []})
+    stub.queue("/agents/agent-uuid-1/task-queue/t-1/result", {"success": True})
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+    _install_fake_clock(monkeypatch)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    class _FakeProc:
+        returncode = 0
+        stdout = "ok"
+        stderr = ""
+
+    monkeypatch.setattr(tq_module.subprocess, "run", lambda argv, **kwargs: _FakeProc())
+
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--poll-interval", "30", "--total-time", "45"])
+    assert result.exit_code == 0, result.output
+
+    # Pass 1 ran the task (and printed it); pass 2 was empty; summary totals 1.
+    payloads = _parse_json_objects(result.output)
+    assert payloads[0]["tasks_run"] == 1
+    assert payloads[-1] == {"agent_id": "agent-uuid-1", "polls": 2, "tasks_run": 1, "failed": 0}
+
+
+def test_run_host_polling_hands_back_after_workflow_packet(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/agents/agent-uuid-1/task-queue/claim",
+        {
+            "success": True,
+            "tasks": [{"id": "t-wf", "command": WORKFLOW_COMMAND, "status": "running", "source": "webhook"}],
+        },
+    )
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+    clock = _install_fake_clock(monkeypatch)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    monkeypatch.setattr(tq_module, "emit_host_run_packet", lambda *args, **kwargs: None)
+
+    # No --run-once: the loop must still exit so the host agent can drive
+    # the packet instead of sitting behind a blocked foreground poll.
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--host"])
+    assert result.exit_code == 0, result.output
+    assert [c[1] for c in stub.calls] == ["/agents/agent-uuid-1/task-queue/claim"]
+    assert clock.sleeps == []
+
+
+def test_run_refuses_when_another_run_holds_the_lock(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    # PID 1 (launchd/init) is always alive and never this process.
+    tq_module.RUN_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tq_module.RUN_LOCK_PATH.write_text("1")
+
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
+    assert result.exit_code == 2
+    # No claim — the queue must not be touched by a second instance.
+    assert stub.calls == []
+    # The foreign lock is left in place.
+    assert tq_module.RUN_LOCK_PATH.read_text() == "1"
+
+
+def test_run_reclaims_stale_lock_and_releases_on_exit(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    stub = _StubCtxClient()
+    stub.queue("/agents/agent-uuid-1/task-queue/claim", {"success": True, "tasks": []})
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    tq_module.RUN_LOCK_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tq_module.RUN_LOCK_PATH.write_text("99999999")
+    monkeypatch.setattr(tq_module, "_pid_alive", lambda pid: False)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
+    assert result.exit_code == 0, result.output
+    assert [c[1] for c in stub.calls] == ["/agents/agent-uuid-1/task-queue/claim"]
+    # Lock was reclaimed for the run and removed afterwards.
+    assert not tq_module.RUN_LOCK_PATH.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -517,3 +690,9 @@ def test_cron_entry_includes_profile_flag():
     entry = _cron_entry(5, "staging")
     assert "--profile staging" in entry
     assert _cron_entry(5, "default").find("--profile") == -1
+
+
+def test_cron_entry_runs_once_per_tick():
+    # Cron provides the schedule; each tick must be a single pass, not a
+    # second long-lived poller fighting the foreground one for the lock.
+    assert "task_queue run --run-once" in _cron_entry(5, "default")


### PR DESCRIPTION
## Summary

Implements the CLI side of [DV-1079](https://linear.app/deepvista/issue/DV-1079/follow-up-on-delegating-the-actions-to-local-agents): `deepvista task_queue run` no longer requires a cron job — it polls in the foreground by default.

- **Polling by default**: claim → execute → sleep `--poll-interval` (default 60s) → repeat, bounded by `--total-time` when given (otherwise runs until interrupted). Empty passes stay quiet; a final summary reports polls/tasks when a `--total-time` run finishes.
- **`--run-once`** (also accepts `--run_once`): single claim/execute pass — the old behavior, used by cron ticks.
- **Single-instance lock**: a PID lock file (`~/.config/deepvista/task_queue.run.lock`) allows only one `task_queue run` per machine, so a foreground poller and cron ticks never double-claim. Stale locks from dead processes are reclaimed; a held lock exits with code 2.
- **Host mode hands control back**: after emitting workflow run packets, the poll loop exits so the host agent can drive them instead of deadlocking behind the foreground poll.
- **`task_queue setup`** cron entries now use `--run-once`.

Pairs with the server-side PR on DeepVista-AI/deepvista that stamps the agent heartbeat on every claim, so a polling agent stays "online" and dims by last poll time.

## Test plan

- `uv run pytest tests/` — 74 passed; new coverage for the poll loop (fake clock), total-time budget, lock contention/staleness/release, host-mode hand-back, and the cron entry shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)