### PR TITLE
feat(DV-1128): add ASCII art banner + persona greeting on /deepvista load

### DIFF
--- a/skills/deepvista/SKILL.md
+++ b/skills/deepvista/SKILL.md
@@ -57,6 +57,37 @@ other reference file assumes you know it.
 | — import files | recursively importing a local folder as `type=file` cards | [skill-import-files.md](reference/skill-import-files.md) |
 | auto-capture for OpenClaw | automatically saving notable facts from conversations without confirmation | [openclaw.md](reference/openclaw.md) |
 
+## On load — greeting
+
+**Before doing anything else**, output the following banner and greeting verbatim (inside a code block so the alignment is preserved):
+
+```
+╔══════════════════════════════════════════════════════════╗
+║                                                          ║
+║    ██████╗ ███████╗███████╗██████╗                      ║
+║    ██╔══██╗██╔════╝██╔════╝██╔══██╗                     ║
+║    ██║  ██║█████╗  █████╗  ██████╔╝                     ║
+║    ██║  ██║██╔══╝  ██╔══╝  ██╔═══╝                      ║
+║    ██████╔╝███████╗███████╗██║                          ║
+║    ╚═════╝ ╚══════╝╚══════╝╚═╝                          ║
+║                                                          ║
+║    ██╗   ██╗██╗███████╗████████╗ █████╗                 ║
+║    ██║   ██║██║██╔════╝╚══██╔══╝██╔══██╗                ║
+║    ██║   ██║██║███████╗   ██║   ███████║                ║
+║    ╚██╗ ██╔╝██║╚════██║   ██║   ██╔══██║                ║
+║     ╚████╔╝ ██║███████║   ██║   ██║  ██║                ║
+║      ╚═══╝  ╚═╝╚══════╝   ╚═╝   ╚═╝  ╚═╝               ║
+║                                                          ║
+║    ─────────────────────────────────────────────────    ║
+║    Your Business Growth Partner                         ║
+║                                                          ║
+╚══════════════════════════════════════════════════════════╝
+```
+
+Then immediately follow with this line of plain text (outside the code block):
+
+> Now I am DeepVista, your business growth partner — tell me what you want me to help with?
+
 ## On load — update check
 
 Silently run this once when the skill is loaded:


### PR DESCRIPTION
## Summary

- Adds an "On load — greeting" section to `skills/deepvista/SKILL.md`
- When `/deepvista` is invoked, the agent now outputs a DEEP VISTA ASCII art banner (block-letter style) before anything else
- Follows the banner with the persona greeting: *"Now I am DeepVista, your business growth partner — tell me what you want me to help with?"*

## Why

Makes invoking `/deepvista` feel like switching into a dedicated persona mode rather than silently loading a tool. Creates a more immersive, branded experience in the terminal.

## Test plan

- [ ] Type `/deepvista` in Claude Code — banner should appear as the first output
- [ ] Verify the greeting line renders outside the code block (plain text, not monospace)
- [ ] Confirm upgrade check still runs silently after the greeting

Closes [DV-1128](https://linear.app/deepvista/issue/DV-1128)

🤖 Generated with [Claude Code](https://claude.com/claude-code)