### PR TITLE
fix(DV-955): parse <accordion-plain> phases so task_queue run --host emits packets

### DIFF
--- a/deepvista_cli/workflow_doc.py
+++ b/deepvista_cli/workflow_doc.py
@@ -16,9 +16,13 @@ from dataclasses import dataclass
 # ---------------------------------------------------------------------------
 
 # Match a full <accordion ...>...</accordion> block, capturing attrs + body.
-# Non-greedy body so multiple accordions in a body each match.
+# Non-greedy body so multiple accordions in a body each match. The backend
+# normalizes phase accordions to the chevron-only `<accordion-plain>` variant
+# (DV-1084), so accept both spellings — without `-plain` the close tag
+# `</accordion-plain>` never matched `</accordion>`, so `phases()` came back
+# empty and `task_queue run --host` couldn't emit packets for normalized skills.
 _ACCORDION_RE = re.compile(
-    r"<accordion(?P<attrs>[^>]*)>(?P<body>.*?)</accordion>",
+    r"<accordion(?:-plain)?(?P<attrs>[^>]*)>(?P<body>.*?)</accordion(?:-plain)?>",
     re.DOTALL,
 )
 

--- a/tests/test_workflow_doc_phases.py
+++ b/tests/test_workflow_doc_phases.py
@@ -1,0 +1,84 @@
+"""Tests for WorkflowDocument phase parsing across accordion spellings.
+
+Regression guard (DV-955): the backend normalizes phase accordions to the
+chevron-only ``<accordion-plain>`` shortcode (DV-1084). The phase regex must
+accept that spelling — otherwise ``phases()`` returns empty and
+``task_queue run --host`` fails to emit a run packet ("Skill has no
+<accordion> phases") for any normalized workflow skill, silently breaking
+webhook-queued local runs.
+"""
+
+from __future__ import annotations
+
+from deepvista_cli.workflow_doc import WorkflowDocument
+
+_PLAIN = """---
+name: workflow-demo
+type: workflow
+---
+
+## Workflow
+
+```mermaid
+flowchart TD
+  A --> B
+```
+
+## Node Description
+
+<accordion-plain>
+Phase 1: Capture & Log
+
+Do the capture.
+</accordion-plain>
+
+<accordion-plain open="true">
+Phase 2: Enrich
+
+Do the enrichment.
+</accordion-plain>
+"""
+
+_CHECKBOX = """---
+name: workflow-demo
+type: workflow
+---
+
+## Node Description
+
+<accordion checked="true">
+Phase 1: Capture & Log
+
+Done.
+</accordion>
+
+<accordion checked="false">
+Phase 2: Enrich
+
+Pending.
+</accordion>
+"""
+
+
+def test_phases_parsed_from_accordion_plain():
+    phases = WorkflowDocument(_PLAIN).phases()
+    assert [p.title for p in phases] == ["Phase 1: Capture & Log", "Phase 2: Enrich"]
+    # `open="true"` on a plain accordion marks the active phase.
+    assert phases[0].state == "pending"
+    assert phases[1].state == "active"
+
+
+def test_phases_parsed_from_legacy_checkbox_accordion():
+    phases = WorkflowDocument(_CHECKBOX).phases()
+    assert [p.title for p in phases] == ["Phase 1: Capture & Log", "Phase 2: Enrich"]
+    assert phases[0].state == "done"
+    assert phases[1].state == "pending"
+
+
+def test_mixed_spellings_do_not_swallow_across_blocks():
+    # A plain open tag must not pair with a legacy close tag (and vice versa),
+    # which would merge two phases into one over-greedy match.
+    body = _PLAIN + _CHECKBOX
+    titles = [p.title for p in WorkflowDocument(body).phases()]
+    assert titles.count("Phase 1: Capture & Log") == 2
+    assert titles.count("Phase 2: Enrich") == 2


### PR DESCRIPTION
## What

Fixes `task_queue run --host` for webhook-queued workflow runs (DV-955): the host-mode run-packet emitter parses the skill body's phase accordions via `WorkflowDocument.phases()`, but the regex only matched the **checkbox** `<accordion …>…</accordion>` spelling.

The backend normalizes phase accordions to the chevron-only **`<accordion-plain>`** variant (DV-1084). `</accordion-plain>` doesn't contain the literal `</accordion>` the close pattern required, so on any normalized skill `phases()` returned **empty** and the host runner aborted with:

```
Skill has no <accordion> phases
```

→ webhook-queued local runs could never be driven by the host agent.

## Reproduced

Submitting the GTM inbound demo form queued the task fine, but `deepvista task_queue run --host` failed to emit the packet (and marked the task failed). The stored skill body had 11 `<accordion-plain>` phase blocks; `phases()` returned 0.

## Fix

`_ACCORDION_RE` now accepts both spellings (`(?:-plain)?` on the open and close tags). `_state_from_accordion_attrs` already reads both `checked` (legacy) and `open` (plain), so state derivation is unchanged. Verified against the real stored skill body → 11 phases parse.

## Tests

`tests/test_workflow_doc_phases.py`: plain parsing (incl. `open="true"` → active), legacy checkbox parsing, and a mixed-body case proving the open/close spellings don't pair across blocks. `uv run pytest tests/test_workflow_doc_phases.py` → 3 passed; ruff clean.

## Follow-up (not in this PR)

`phases()` scans the whole document, so it also returns any `## Log` run accordions as phases — it should be scoped to the `## Node Description` section to match the backend parser. Filed as a note; orthogonal to this regex break.
