### PR TITLE
feat(DV-1247): `tasks` group runs web-chat task cards via claude -p

### DIFF
--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -153,9 +153,9 @@ class DeepVistaClient:
             self._handle_error(resp)
         return resp.json()
 
-    def get(self, path: str, params: dict | None = None) -> Any:
+    def get(self, path: str, params: dict | None = None, extra_headers: dict[str, str] | None = None) -> Any:
         """HTTP GET, returns parsed JSON."""
-        return self._request("GET", path, params=params)
+        return self._request("GET", path, params=params, extra_headers=extra_headers)
 
     def post(self, path: str, body: dict | None = None, extra_headers: dict[str, str] | None = None) -> Any:
         """HTTP POST, returns parsed JSON."""

--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -111,9 +111,18 @@ class DeepVistaClient:
 
     # -- Public request methods -----------------------------------------------
 
-    def _request(self, method: str, path: str, body: dict | None = None, params: dict | None = None) -> Any:
+    def _request(
+        self,
+        method: str,
+        path: str,
+        body: dict | None = None,
+        params: dict | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> Any:
         """Unified request method with network error handling."""
         headers = self._auth_headers()
+        if extra_headers:
+            headers.update(extra_headers)
         self._log_request(method, path, body)
         if self.config.dry_run:
             click.echo(
@@ -148,9 +157,9 @@ class DeepVistaClient:
         """HTTP GET, returns parsed JSON."""
         return self._request("GET", path, params=params)
 
-    def post(self, path: str, body: dict | None = None) -> Any:
+    def post(self, path: str, body: dict | None = None, extra_headers: dict[str, str] | None = None) -> Any:
         """HTTP POST, returns parsed JSON."""
-        return self._request("POST", path, body=body)
+        return self._request("POST", path, body=body, extra_headers=extra_headers)
 
     def patch(self, path: str, body: dict | None = None) -> Any:
         """HTTP PATCH, returns parsed JSON."""

--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -161,6 +161,36 @@ class DeepVistaClient:
         """HTTP POST, returns parsed JSON."""
         return self._request("POST", path, body=body, extra_headers=extra_headers)
 
+    def post_nofatal(self, path: str, body: dict | None = None, extra_headers: dict[str, str] | None = None) -> Any:
+        """HTTP POST that returns the parsed response body for both success and API errors.
+
+        Unlike post(), 4xx/5xx responses are returned as-is (the server's JSON body) rather
+        than printed to stderr and raised as SystemExit. Network errors still raise SystemExit.
+        """
+        headers = self._auth_headers()
+        if extra_headers:
+            headers.update(extra_headers)
+        self._log_request("POST", path, body)
+        if self.config.dry_run:
+            click.echo(
+                json.dumps({"dry_run": True, "method": "POST", "path": path, "body": body}, default=str),
+                err=True,
+            )
+            sys.exit(0)
+        try:
+            client = self._get_client()
+            resp = client.post(path, headers=headers, json=body or {})
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            self._handle_network_error(exc)
+        self._log_response(resp)
+        try:
+            data = resp.json()
+            if isinstance(data, dict):
+                data["_status_code"] = resp.status_code
+            return data
+        except Exception:
+            return {"error": resp.text, "status_code": resp.status_code, "_status_code": resp.status_code}
+
     def patch(self, path: str, body: dict | None = None) -> Any:
         """HTTP PATCH, returns parsed JSON."""
         return self._request("PATCH", path, body=body)

--- a/deepvista_cli/commands/agents.py
+++ b/deepvista_cli/commands/agents.py
@@ -78,6 +78,7 @@ def _save_agent_id(
     agent_id: str,
     agent_role: str = DEFAULT_AGENT_ROLE,
     project_id: str | None = None,
+    project_name: str | None = None,
 ) -> None:
     """Persist agent ID locally after registration."""
     AGENTS_DIR.mkdir(parents=True, exist_ok=True)
@@ -85,6 +86,8 @@ def _save_agent_id(
     data: dict = {"agent_id": agent_id, "agent_type": agent_type, "agent_role": agent_role}
     if project_id:
         data["project_id"] = project_id
+    if project_name:
+        data["project_name"] = project_name
     path.write_text(_json.dumps(data))
     os.chmod(path, 0o600)
 

--- a/deepvista_cli/commands/agents.py
+++ b/deepvista_cli/commands/agents.py
@@ -56,48 +56,99 @@ _AGENT_TYPE_LABELS = {
 # ---------------------------------------------------------------------------
 
 
-def _agent_id_path(agent_type: str, agent_role: str | None = None) -> Path:
-    """Path to the local agent registration file for a given (type, role).
+def _agent_id_path(agent_type: str, agent_role: str | None = None, project_id: str | None = None) -> Path:
+    """Path to the local agent registration file for a given (type, role[, project]).
 
-    DV-832: cache key is now ``<type>__<role>.json`` so a single machine can
-    host multiple roles (e.g. an engineering Claude and a marketing Claude
-    against different projects). When ``agent_role`` is omitted we fall back
-    to the legacy ``<type>.json`` filename for read-only adoption — see
-    ``_load_agent_id``.
+    DV-832: cache key is ``<type>__<role>.json`` so a single machine can host
+    multiple roles. When ``project_id`` is supplied the key becomes
+    ``<type>__<role>__<project_id>.json`` so a machine can also host the same
+    role for multiple projects without one overwriting the other. When
+    ``agent_role`` is omitted we fall back to the legacy ``<type>.json``
+    filename for read-only adoption — see ``_load_agent_id``.
     """
+    if agent_role and project_id:
+        return AGENTS_DIR / f"{agent_type}__{agent_role}__{project_id}.json"
     if agent_role:
         return AGENTS_DIR / f"{agent_type}__{agent_role}.json"
     return AGENTS_DIR / f"{agent_type}.json"
 
 
-def _save_agent_id(agent_type: str, agent_id: str, agent_role: str = DEFAULT_AGENT_ROLE) -> None:
+def _save_agent_id(
+    agent_type: str,
+    agent_id: str,
+    agent_role: str = DEFAULT_AGENT_ROLE,
+    project_id: str | None = None,
+) -> None:
     """Persist agent ID locally after registration."""
     AGENTS_DIR.mkdir(parents=True, exist_ok=True)
-    path = _agent_id_path(agent_type, agent_role)
-    path.write_text(_json.dumps({"agent_id": agent_id, "agent_type": agent_type, "agent_role": agent_role}))
+    path = _agent_id_path(agent_type, agent_role, project_id)
+    data: dict = {"agent_id": agent_id, "agent_type": agent_type, "agent_role": agent_role}
+    if project_id:
+        data["project_id"] = project_id
+    path.write_text(_json.dumps(data))
     os.chmod(path, 0o600)
 
 
-def _load_agent_id(agent_type: str, agent_role: str | None = None) -> str | None:
-    """Load locally stored agent ID for a given (type, [role]).
+def _load_agent_id(
+    agent_type: str,
+    agent_role: str | None = None,
+    project_id: str | None = None,
+) -> str | None:
+    """Load locally stored agent ID for a given (type, [role], [project_id]).
 
-    DV-832: prefers the new ``<type>__<role>.json`` cache key. When
-    ``agent_role`` is None, returns the most recently modified
-    registration for this type (covers Stop hook calls that don't yet
-    pass --role). Migrates the legacy ``<type>.json`` file on first read
-    by treating it as the ``misc`` role.
+    Resolution order:
+    1. Exact ``<type>__<role>__<project_id>.json`` when both role and project_id given.
+    2. ``<type>__<role>.json`` when only role given (DV-832).
+    3. Most-recently-modified file matching the type (no role/project filter).
+
+    When ``project_id`` is supplied without a role the scan is filtered to
+    files whose JSON content has a matching ``project_id``.
+    Migrates the legacy ``<type>.json`` file on first read by treating it as
+    the ``misc`` role.
     """
+    if agent_role and project_id:
+        # Prefer the project-keyed file; fall back to the role-only file (old
+        # registrations that pre-date project_id storage).
+        for path in [
+            _agent_id_path(agent_type, agent_role, project_id),
+            _agent_id_path(agent_type, agent_role),
+        ]:
+            if not path.exists():
+                continue
+            try:
+                data = _json.loads(path.read_text())
+                stored_project = data.get("project_id")
+                # Accept role-only files only when their project_id matches or is absent.
+                if stored_project and stored_project != project_id:
+                    continue
+                if aid := data.get("agent_id"):
+                    return aid
+            except (_json.JSONDecodeError, KeyError):
+                continue
+        return None
+
     if agent_role:
-        path = _agent_id_path(agent_type, agent_role)
-        if not path.exists():
-            return None
-        try:
-            return _json.loads(path.read_text()).get("agent_id")
-        except (_json.JSONDecodeError, KeyError):
-            return None
+        # Any project for this role — prefer the newest project-keyed file,
+        # fall back to the role-only file.
+        candidates: list[tuple[float, Path]] = []
+        if AGENTS_DIR.exists():
+            for p in AGENTS_DIR.glob(f"{agent_type}__{agent_role}*.json"):
+                try:
+                    candidates.append((p.stat().st_mtime, p))
+                except OSError:
+                    continue
+        candidates.sort(reverse=True)
+        for _, path in candidates:
+            try:
+                if aid := _json.loads(path.read_text()).get("agent_id"):
+                    return aid
+            except (_json.JSONDecodeError, KeyError):
+                continue
+        return None
 
     # No role specified — scan all per-role files for this type, prefer newest.
-    candidates: list[tuple[float, Path]] = []
+    # When project_id is given, filter to matching entries.
+    candidates = []
     if AGENTS_DIR.exists():
         for p in AGENTS_DIR.glob(f"{agent_type}__*.json"):
             try:
@@ -119,7 +170,13 @@ def _load_agent_id(agent_type: str, agent_role: str | None = None) -> str | None
     candidates.sort(reverse=True)
     for _, path in candidates:
         try:
-            return _json.loads(path.read_text()).get("agent_id")
+            data = _json.loads(path.read_text())
+            if project_id:
+                stored = data.get("project_id")
+                if stored and stored != project_id:
+                    continue
+            if aid := data.get("agent_id"):
+                return aid
         except (_json.JSONDecodeError, KeyError):
             continue
     return None
@@ -144,22 +201,34 @@ def load_agent_id_for_active_agent() -> str | None:
     return _load_agent_id(agent_type)
 
 
-def _remove_agent_id(agent_type: str, agent_role: str | None = None) -> None:
+def _remove_agent_id(
+    agent_type: str,
+    agent_role: str | None = None,
+    project_id: str | None = None,
+) -> None:
     """Remove local agent registration file(s) for this type.
 
-    When ``agent_role`` is given, only that role's cache file is removed.
-    Without a role, every cache for this type (including the legacy
-    ``<type>.json``) is cleared — used when a stale local record needs to
-    be wiped before re-registration (DV-751).
+    When ``agent_role`` and ``project_id`` are both given, only that exact
+    project-keyed file is removed. When only ``agent_role`` is given, all
+    files for that role (across all projects) are removed. Without either,
+    every cache for this type (including the legacy ``<type>.json``) is
+    cleared — used when a stale local record needs to be wiped before
+    re-registration (DV-751).
     """
-    if agent_role:
-        path = _agent_id_path(agent_type, agent_role)
-        if path.exists():
-            path.unlink()
+    if agent_role and project_id:
+        _agent_id_path(agent_type, agent_role, project_id).unlink(missing_ok=True)
         return
 
-    for path in AGENTS_DIR.glob(f"{agent_type}__*.json"):
-        path.unlink(missing_ok=True)
+    if agent_role:
+        # Remove all project-keyed and role-only files for this role.
+        if AGENTS_DIR.exists():
+            for path in AGENTS_DIR.glob(f"{agent_type}__{agent_role}*.json"):
+                path.unlink(missing_ok=True)
+        return
+
+    if AGENTS_DIR.exists():
+        for path in AGENTS_DIR.glob(f"{agent_type}__*.json"):
+            path.unlink(missing_ok=True)
     legacy = AGENTS_DIR / f"{agent_type}.json"
     if legacy.exists():
         legacy.unlink(missing_ok=True)
@@ -597,7 +666,7 @@ def _register_agent_via_api(
     )
     agent = data.get("agent")
     if agent and agent.get("id"):
-        _save_agent_id(agent_type, agent["id"], agent.get("agent_role", agent_role))
+        _save_agent_id(agent_type, agent["id"], agent.get("agent_role", agent_role), agent.get("project_id"))
         return agent["id"], None
     return None, data.get("error", "Registration failed")
 
@@ -763,7 +832,7 @@ def agents_register(
         output_error(1, "Registration failed", "Backend did not return an agent")
         return
 
-    _save_agent_id(agent_type, agent["id"], agent.get("agent_role", agent_role))
+    _save_agent_id(agent_type, agent["id"], agent.get("agent_role", agent_role), agent.get("project_id"))
 
     # Auto-install heartbeat hooks
     profile = ctx.obj.profile if hasattr(ctx.obj, "profile") else "default"

--- a/deepvista_cli/commands/task_queue.py
+++ b/deepvista_cli/commands/task_queue.py
@@ -375,13 +375,117 @@ def _execute_task(ctx: click.Context, agent_id: str, task: dict) -> dict:
 
 
 # ---------------------------------------------------------------------------
+# Task cards (DV-1247) — plain prompts dispatched from the web chat, run
+# headlessly via `claude -p "/deepvista <prompt>"`.
+# ---------------------------------------------------------------------------
+
+# A task prompt may legitimately drive a long Claude Code session (research,
+# multi-tool work), so it gets a more generous budget than a queued CLI command.
+TASK_RUN_TIMEOUT_SECONDS = 1800
+
+# Headless permission posture for unattended task runs. ``bypassPermissions``
+# skips every approval prompt — appropriate for a Machine the user has
+# deliberately set polling. Override per-machine with the env var.
+DEFAULT_TASK_PERMISSION_MODE = "bypassPermissions"
+
+
+def _claude_binary() -> str:
+    """Resolve the Claude Code binary (override with DEEPVISTA_CLAUDE_BIN).
+
+    The override doubles as the test seam: point it at a stub script to drive
+    the whole claim -> run -> report loop without a real Claude Code install.
+    """
+    override = os.environ.get("DEEPVISTA_CLAUDE_BIN", "").strip()
+    if override:
+        return override
+    return shutil.which("claude") or "claude"
+
+
+def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, task: dict) -> dict:
+    """Run one claimed task card via `claude -p` and report the result back.
+
+    The prompt is handed to Claude Code as ``/deepvista <prompt>`` so the run
+    boots with the DeepVista skill context (knowledge base, notes, the CLI).
+    stdout becomes the run's output (a linked output card is created backend-side
+    when non-empty); the exit code decides completed vs. failed.
+    """
+    task_id = str(task.get("id", ""))
+    prompt = str(task.get("prompt", "")).strip()
+    headers = {"X-Project-Id": project_id} if project_id else None
+
+    if not prompt:
+        _client(ctx).post(
+            f"/agents/{agent_id}/tasks/{task_id}/result",
+            {"status": "failed", "exit_code": None, "output": "Task has an empty prompt."},
+            extra_headers=headers,
+        )
+        return {"task_id": task_id, "status": "failed", "title": task.get("title")}
+
+    permission_mode = os.environ.get("DEEPVISTA_TASK_PERMISSION_MODE", DEFAULT_TASK_PERMISSION_MODE)
+    cwd = os.environ.get("DEEPVISTA_TASK_CWD") or os.getcwd()
+    argv = [_claude_binary(), "-p", f"/deepvista {prompt}", "--permission-mode", permission_mode]
+
+    click.echo(f"  ▶ running task {task_id} via claude -p (project {project_id or '?'})", err=True)
+    try:
+        proc = subprocess.run(  # noqa: S603 — argv built from a fixed binary + literal flags
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=TASK_RUN_TIMEOUT_SECONDS,
+            cwd=cwd,
+        )
+        exit_code = proc.returncode
+        status = "completed" if exit_code == 0 else "failed"
+        output = (proc.stdout or "").strip()
+        if not output and proc.stderr:
+            output = proc.stderr.strip()
+    except subprocess.TimeoutExpired:
+        status, exit_code, output = "failed", None, f"claude run timed out after {TASK_RUN_TIMEOUT_SECONDS}s"
+    except FileNotFoundError:
+        status, exit_code, output = (
+            "failed",
+            None,
+            "Claude Code binary not found. Install it or set DEEPVISTA_CLAUDE_BIN.",
+        )
+    except OSError as exc:
+        status, exit_code, output = "failed", None, str(exc)
+
+    _client(ctx).post(
+        f"/agents/{agent_id}/tasks/{task_id}/result",
+        {"status": status, "exit_code": exit_code, "output": output, "output_title": task.get("title")},
+        extra_headers=headers,
+    )
+    return {"task_id": task_id, "title": task.get("title"), "status": status, "exit_code": exit_code}
+
+
+def _claim_and_run_task_cards(ctx: click.Context, agent_id: str, project_id: str | None) -> list[dict]:
+    """Claim this Machine's pending task cards in ``project_id`` and run each headless."""
+    headers = {"X-Project-Id": project_id} if project_id else None
+    data = _client(ctx).post(f"/agents/{agent_id}/tasks/claim", None, extra_headers=headers)
+    if not data.get("success", True):
+        click.echo(
+            f"  [warn] could not claim task cards for agent {agent_id}: {data.get('error', 'unknown')}",
+            err=True,
+        )
+        return []
+    tasks = data.get("tasks") or []
+    return [_run_task_card(ctx, agent_id, project_id, task) for task in tasks]
+
+
+# ---------------------------------------------------------------------------
 # Command group
 # ---------------------------------------------------------------------------
 
 
-@click.group("task_queue")
+@click.group("tasks")
 def task_queue_group() -> None:
-    """Run CLI commands queued for this machine's agent."""
+    """Run tasks dispatched to this Machine (DV-1247).
+
+    `tasks run` polls for work and executes it: **task cards** (plain prompts
+    enqueued from the web chat) are run headless via `claude -p`; queued CLI
+    commands and host-driven workflow runs are handled as before. Registered as
+    `tasks`; `task_queue` remains as a deprecated alias for existing cron jobs.
+    """
 
 
 def _detect_host_agent() -> bool:
@@ -472,7 +576,12 @@ def _ensure_agents_for_all_projects(ctx: click.Context) -> list[tuple[str, str |
             config = _build_config_snapshot(agent_type)
             data = _client(ctx).post(
                 "/agents",
-                {"name": _default_agent_name(agent_type), "agent_type": agent_type, "agent_role": DEFAULT_AGENT_ROLE, "config": config},
+                {
+                    "name": _default_agent_name(agent_type),
+                    "agent_type": agent_type,
+                    "agent_role": DEFAULT_AGENT_ROLE,
+                    "config": config,
+                },
                 extra_headers={"X-Project-Id": project_id},
             )
             agent = data.get("agent")
@@ -587,7 +696,15 @@ def _claim_and_run_all(
     """
     all_results: list[dict] = []
     all_workflow_tasks: list[tuple[str, dict]] = []
-    for agent_id, _ in agents:
+    for agent_id, project_id in agents:
+        # DV-1247: task cards (plain prompts run via `claude -p`) — independent
+        # of host mode; a Machine runs them headless without a host agent.
+        try:
+            all_results.extend(_claim_and_run_task_cards(ctx, agent_id, project_id))
+        except SystemExit:
+            click.echo(f"  [warn] failed to claim task cards for agent {agent_id} — skipping", err=True)
+
+        # DV-936 / DV-955: queued CLI commands + host-driven workflow runs.
         try:
             results, wf_tasks = _claim_and_run(ctx, agent_id, host_mode)
         except SystemExit:
@@ -763,27 +880,42 @@ def task_queue_run(
         _release_run_lock()
 
 
+TASK_CARD_COLUMNS = ["id", "status", "title", "agent_id", "created_at"]
+
+
 @task_queue_group.command("list")
 @click.option("--type", "agent_type", default=None, help="Resolve agent by type from local storage.")
 @click.option("--role", "agent_role", default=None, help="Resolve agent by role (with --type).")
 @click.option("--project", "project_id", default=None, help="Restrict to the agent registered for this project ID.")
+@click.option(
+    "--status", "status_filter", default=None, help="Filter task cards by status (pending/running/completed/failed)."
+)
 @click.pass_context
-def task_queue_list(ctx: click.Context, agent_type: str | None, agent_role: str | None, project_id: str | None) -> None:
-    """Show the task queue for this machine's agent.
+def task_queue_list(
+    ctx: click.Context,
+    agent_type: str | None,
+    agent_role: str | None,
+    project_id: str | None,
+    status_filter: str | None,
+) -> None:
+    """Show the tasks dispatched to this Machine (DV-1247).
 
-    Read-only.
+    Lists **task cards** (web-chat prompts) claimable by this Machine in its
+    project. Read-only.
     """
-    agent_id, _ = _require_machine_agent_id(agent_type, agent_role, project_id)
-    data = _client(ctx).get(f"/agents/{agent_id}/task-queue")
+    agent_id, resolved_project_id = _require_machine_agent_id(agent_type, agent_role, project_id)
+    headers = {"X-Project-Id": resolved_project_id} if resolved_project_id else None
+    params = {"status": status_filter} if status_filter else None
+    data = _client(ctx).get(f"/agents/{agent_id}/tasks", params=params, extra_headers=headers)
     if data.get("error"):
         output_error(1, "Failed to list tasks", data["error"])
         raise SystemExit(1)
     tasks = data.get("tasks", [])
     _output(
         ctx,
-        {"agent_id": agent_id, "tasks": tasks, "count": len(tasks)},
-        columns=TASK_COLUMNS,
-        title="Task Queue",
+        {"agent_id": agent_id, "project_id": resolved_project_id, "tasks": tasks, "count": len(tasks)},
+        columns=TASK_CARD_COLUMNS,
+        title="Tasks",
     )
 
 
@@ -866,9 +998,7 @@ def _write_crontab(lines: list[str]) -> bool:
 def _cron_entry(interval: int, profile: str) -> str:
     binary = _deepvista_binary()
     profile_flag = f" --profile {profile}" if profile and profile != "default" else ""
-    return (
-        f"*/{interval} * * * * {binary}{profile_flag} task_queue run --run-once >> {CRON_LOG_PATH} 2>&1 {CRON_MARKER}"
-    )
+    return f"*/{interval} * * * * {binary}{profile_flag} tasks run --run-once >> {CRON_LOG_PATH} 2>&1 {CRON_MARKER}"
 
 
 @task_queue_group.command("setup")

--- a/deepvista_cli/commands/task_queue.py
+++ b/deepvista_cli/commands/task_queue.py
@@ -43,7 +43,15 @@ import click
 from deepvista_cli.auth.tokens import get_valid_token
 from deepvista_cli.client.http import DeepVistaClient
 from deepvista_cli.client.origin import detect_agent_tool
-from deepvista_cli.commands.agents import AGENTS_DIR, _load_agent_id
+from deepvista_cli.commands.agents import (
+    AGENTS_DIR,
+    DEFAULT_AGENT_ROLE,
+    _build_config_snapshot,
+    _default_agent_name,
+    _install_hooks,
+    _load_agent_id,
+    _save_agent_id,
+)
 from deepvista_cli.commands.skill import emit_host_run_packet
 from deepvista_cli.config import CONFIG_DIR, credentials_path
 from deepvista_cli.output.formatter import format_output, output_error
@@ -65,7 +73,7 @@ CRON_MARKER = "# deepvista-task-queue"
 CRON_LOG_PATH = CONFIG_DIR / "task_queue.log"
 
 # Seconds between polls when `run` is left in its default polling mode.
-DEFAULT_POLL_INTERVAL_SECONDS = 60
+DEFAULT_POLL_INTERVAL_SECONDS = 10
 
 # Single-instance lock for `task_queue run` (DV-1079) — holds the owner PID.
 RUN_LOCK_PATH = CONFIG_DIR / "task_queue.run.lock"
@@ -385,16 +393,139 @@ def _detect_host_agent() -> bool:
     return bool(detected) and detected != "deepvista-cli"
 
 
+def _list_all_machine_agents() -> list[tuple[str, str | None]]:
+    """Return (agent_id, project_id) for every locally registered agent.
+
+    Deduplicates by agent_id so a registration file collision never causes
+    double-claiming.
+    """
+    seen: set[str] = set()
+    results: list[tuple[str, str | None]] = []
+    if not AGENTS_DIR.exists():
+        return results
+    candidates: list[tuple[float, Path]] = []
+    for path in AGENTS_DIR.glob("*.json"):
+        try:
+            candidates.append((path.stat().st_mtime, path))
+        except OSError:
+            continue
+    candidates.sort(reverse=True)
+    for _, path in candidates:
+        try:
+            data = _json.loads(path.read_text())
+        except (OSError, _json.JSONDecodeError):
+            continue
+        aid = data.get("agent_id")
+        if not aid or aid in seen:
+            continue
+        seen.add(aid)
+        results.append((aid, data.get("project_id")))
+    return results
+
+
+def _ensure_agents_for_all_projects(ctx: click.Context) -> list[tuple[str, str | None]]:
+    """Fetch all projects and ensure a local agent is registered for each one.
+
+    For projects that already have a local registration the existing agent_id
+    is reused; for new projects a fresh agent is registered on-the-fly using
+    the detected host agent type (or ``deepvista-cli`` as a fallback).  Any
+    locally registered agents whose project no longer appears in the API
+    response are appended at the end so nothing is silently dropped.
+
+    Returns ``(agent_id, project_id)`` for every project, deduped by agent_id.
+    On network failure falls back to the local-only list so offline/cron runs
+    still work.
+    """
+    try:
+        detected, _ = detect_agent_tool()
+    except Exception:
+        detected = None
+    agent_type = detected or "deepvista-cli"
+
+    try:
+        projects_raw = _client(ctx).get("/projects")
+    except SystemExit:
+        click.echo("  [warn] could not fetch projects — using locally registered agents only", err=True)
+        return _list_all_machine_agents()
+
+    # Backend returns a JSON array directly for GET /projects.
+    projects: list[dict] = projects_raw if isinstance(projects_raw, list) else projects_raw.get("projects", [])
+
+    seen_agent_ids: set[str] = set()
+    result: list[tuple[str, str | None]] = []
+
+    for project in projects:
+        project_id = project.get("id")
+        if not project_id:
+            continue
+
+        # Reuse an existing local registration for this project.
+        existing_id = _load_agent_id(agent_type, DEFAULT_AGENT_ROLE, project_id)
+        if existing_id:
+            if existing_id not in seen_agent_ids:
+                seen_agent_ids.add(existing_id)
+                result.append((existing_id, project_id))
+            continue
+
+        # No local record — register a new agent for this project.
+        try:
+            config = _build_config_snapshot(agent_type)
+            data = _client(ctx).post(
+                "/agents",
+                {"name": _default_agent_name(agent_type), "agent_type": agent_type, "agent_role": DEFAULT_AGENT_ROLE, "config": config},
+                extra_headers={"X-Project-Id": project_id},
+            )
+            agent = data.get("agent")
+            if not agent or not agent.get("id"):
+                click.echo(
+                    f"  [warn] could not register agent for project {project_id}: {data.get('error', 'unknown')}",
+                    err=True,
+                )
+                continue
+            agent_id: str = agent["id"]
+            agent_role_saved = agent.get("agent_role", DEFAULT_AGENT_ROLE)
+            _save_agent_id(agent_type, agent_id, agent_role_saved, project_id)
+
+            # Mirror what `agents register` does: install hooks + initial sync.
+            profile = getattr(ctx.obj, "profile", "default")
+            _install_hooks(agent_type, profile)
+            try:
+                _client(ctx).post(
+                    f"/agents/{agent_id}/sync",
+                    {"status": "online", "sync_type": "manual", "config_patch": config},
+                    extra_headers={"X-Project-Id": project_id},
+                )
+            except SystemExit:
+                pass  # sync failure is non-fatal
+
+            click.echo(f"  registered agent {agent_id} for project {project_id}", err=True)
+        except SystemExit:
+            click.echo(f"  [warn] could not register agent for project {project_id} — skipping", err=True)
+            continue
+
+        if agent_id not in seen_agent_ids:
+            seen_agent_ids.add(agent_id)
+            result.append((agent_id, project_id))
+
+    # Append any locally registered agents whose project wasn't in the API
+    # response (e.g. old registrations, shared projects that were later removed).
+    for agent_id, proj_id in _list_all_machine_agents():
+        if agent_id not in seen_agent_ids:
+            seen_agent_ids.add(agent_id)
+            result.append((agent_id, proj_id))
+
+    return result
+
+
 def _print_run_header(
     ctx: click.Context,
-    agent_id: str,
-    project_id: str | None,
+    agents: list[tuple[str, str | None]],
     host_mode: bool,
     run_once: bool,
     poll_interval: int,
     total_time: int | None,
 ) -> None:
-    """Print a startup banner summarising the account, agent, and polling config."""
+    """Print a startup banner summarising the account, agents, and polling config."""
     tokens = get_valid_token(credentials_path(getattr(ctx.obj, "profile", "default")))
     account = (tokens.email or tokens.user_id or "unknown") if tokens else "not authenticated"
     profile = getattr(ctx.obj, "profile", "default")
@@ -407,12 +538,18 @@ def _print_run_header(
     else:
         mode = f"every {poll_interval}s until interrupted"
 
-    click.echo(f"account : {account}")
-    click.echo(f"agent   : {agent_id}")
-    click.echo(f"project : {project_id or '(unknown — re-register to capture)'}")
-    click.echo(f"profile : {profile}  ({api_url})")
-    click.echo(f"mode    : {mode}")
-    click.echo(f"host    : {'yes (workflow tasks included)' if host_mode else 'no (command tasks only)'}")
+    click.echo(f"account  : {account}")
+    if len(agents) == 1:
+        agent_id, project_id = agents[0]
+        click.echo(f"agent    : {agent_id}")
+        click.echo(f"project  : {project_id or '(unknown — re-register to capture)'}")
+    else:
+        click.echo(f"agents   : {len(agents)} (all registered on this machine)")
+        for agent_id, project_id in agents:
+            click.echo(f"  {agent_id}  project={project_id or 'unknown'}")
+    click.echo(f"profile  : {profile}  ({api_url})")
+    click.echo(f"mode     : {mode}")
+    click.echo(f"host     : {'yes (workflow tasks included)' if host_mode else 'no (command tasks only)'}")
     click.echo("")
 
 
@@ -435,6 +572,30 @@ def _claim_and_run(ctx: click.Context, agent_id: str, host_mode: bool) -> tuple[
 
     results = [_execute_task(ctx, agent_id, task) for task in command_tasks]
     return results, workflow_tasks
+
+
+def _claim_and_run_all(
+    ctx: click.Context,
+    agents: list[tuple[str, str | None]],
+    host_mode: bool,
+) -> tuple[list[dict], list[tuple[str, dict]]]:
+    """Claim and execute tasks for all agents in one poll pass.
+
+    Returns ``(command_results, [(agent_id, workflow_task)])``.
+    Per-agent claim failures are logged and skipped so a single stale
+    registration does not prevent the others from being serviced.
+    """
+    all_results: list[dict] = []
+    all_workflow_tasks: list[tuple[str, dict]] = []
+    for agent_id, _ in agents:
+        try:
+            results, wf_tasks = _claim_and_run(ctx, agent_id, host_mode)
+        except SystemExit:
+            click.echo(f"  [warn] failed to claim tasks for agent {agent_id} — skipping", err=True)
+            continue
+        all_results.extend(results)
+        all_workflow_tasks.extend((agent_id, t) for t in wf_tasks)
+    return all_results, all_workflow_tasks
 
 
 @task_queue_group.command("run")
@@ -484,7 +645,11 @@ def task_queue_run(
     poll_interval: int,
     total_time: int | None,
 ) -> None:
-    """Poll this machine's agent queue and execute claimed tasks (DV-1079).
+    """Poll task queues for all registered agents and execute claimed tasks (DV-1079).
+
+    By default (no --type/--role/--project filter) polls EVERY agent registered
+    on this machine, so tasks across all projects are serviced in one run.
+    Pass --type/--role/--project to restrict to a single matching agent.
 
     Default mode polls in the foreground — claim, execute, sleep
     --poll-interval, repeat — until --total-time elapses (or forever when
@@ -502,9 +667,6 @@ def task_queue_run(
     and the entries stay ``running`` until the agent calls
     ``task_queue complete``.
     """
-    agent_id, resolved_project_id = _require_machine_agent_id(agent_type, agent_role, project_id)
-    host_mode = host_mode or _detect_host_agent()
-
     if not _acquire_run_lock():
         output_error(
             2,
@@ -513,7 +675,21 @@ def task_queue_run(
         )
         raise SystemExit(2)
 
-    _print_run_header(ctx, agent_id, resolved_project_id, host_mode, run_once, poll_interval, total_time)
+    if agent_type or agent_role or project_id:
+        # Explicit filter — single-agent mode (backward-compatible).
+        agent_id, resolved_project_id = _require_machine_agent_id(agent_type, agent_role, project_id)
+        agents = [(agent_id, resolved_project_id)]
+    else:
+        # No filter — auto-register for every project the user has access to,
+        # then poll all of them so nothing is missed.
+        agents = _ensure_agents_for_all_projects(ctx)
+        if not agents:
+            output_error(3, "No projects or registered agents found", "Run 'deepvista auth login' then retry.")
+            raise SystemExit(3)
+
+    host_mode = host_mode or _detect_host_agent()
+
+    _print_run_header(ctx, agents, host_mode, run_once, poll_interval, total_time)
 
     started = time.monotonic()
     polls = 0
@@ -522,7 +698,7 @@ def task_queue_run(
         while True:
             polls += 1
             ts = time.strftime("%H:%M:%S")
-            results, workflow_tasks = _claim_and_run(ctx, agent_id, host_mode)
+            results, workflow_tasks = _claim_and_run_all(ctx, agents, host_mode)
             total_results.extend(results)
 
             # Print a per-poll status line so the operator can see the poller
@@ -542,10 +718,11 @@ def task_queue_run(
             # Emit structured output for non-empty passes (and always for
             # --run-once so cron logs capture every tick).
             if run_once or results or workflow_tasks:
+                agent_ids = agents[0][0] if len(agents) == 1 else [a[0] for a in agents]
                 _output(
                     ctx,
                     {
-                        "agent_id": agent_id,
+                        "agent_id": agent_ids,
                         "tasks_run": len(results),
                         "failed": sum(1 for r in results if r["status"] == "failed"),
                         "results": results,
@@ -557,8 +734,8 @@ def task_queue_run(
             # Workflow packets go last so the runtime contract (and its
             # completion instructions) is the freshest thing in the host
             # agent's context.
-            for task in workflow_tasks:
-                _emit_workflow_task(ctx, agent_id, task)
+            for wf_agent_id, task in workflow_tasks:
+                _emit_workflow_task(ctx, wf_agent_id, task)
 
             if run_once:
                 return
@@ -567,10 +744,11 @@ def task_queue_run(
                 # poll loop would deadlock the run. Hand control back.
                 return
             if total_time is not None and (time.monotonic() - started) + poll_interval > total_time:
+                agent_ids = agents[0][0] if len(agents) == 1 else [a[0] for a in agents]
                 _output(
                     ctx,
                     {
-                        "agent_id": agent_id,
+                        "agent_id": agent_ids,
                         "polls": polls,
                         "tasks_run": len(total_results),
                         "failed": sum(1 for r in total_results if r["status"] == "failed"),

--- a/deepvista_cli/commands/task_queue.py
+++ b/deepvista_cli/commands/task_queue.py
@@ -40,11 +40,12 @@ from pathlib import Path
 
 import click
 
+from deepvista_cli.auth.tokens import get_valid_token
 from deepvista_cli.client.http import DeepVistaClient
 from deepvista_cli.client.origin import detect_agent_tool
 from deepvista_cli.commands.agents import AGENTS_DIR, _load_agent_id
 from deepvista_cli.commands.skill import emit_host_run_packet
-from deepvista_cli.config import CONFIG_DIR
+from deepvista_cli.config import CONFIG_DIR, credentials_path
 from deepvista_cli.output.formatter import format_output, output_error
 
 TASK_COLUMNS = ["id", "status", "command", "created_at", "finished_at", "exit_code"]
@@ -349,6 +350,30 @@ def _detect_host_agent() -> bool:
     return bool(detected) and detected != "deepvista-cli"
 
 
+def _print_run_header(
+    ctx: click.Context, agent_id: str, host_mode: bool, run_once: bool, poll_interval: int, total_time: int | None
+) -> None:
+    """Print a startup banner summarising the account, agent, and polling config."""
+    tokens = get_valid_token(credentials_path(getattr(ctx.obj, "profile", "default")))
+    account = (tokens.email or tokens.user_id or "unknown") if tokens else "not authenticated"
+    profile = getattr(ctx.obj, "profile", "default")
+    api_url = getattr(ctx.obj, "api_url", "")
+
+    if run_once:
+        mode = "single pass (--run-once)"
+    elif total_time:
+        mode = f"every {poll_interval}s for up to {total_time}s"
+    else:
+        mode = f"every {poll_interval}s until interrupted"
+
+    click.echo(f"account : {account}")
+    click.echo(f"agent   : {agent_id}")
+    click.echo(f"profile : {profile}  ({api_url})")
+    click.echo(f"mode    : {mode}")
+    click.echo(f"host    : {'yes (workflow tasks included)' if host_mode else 'no (command tasks only)'}")
+    click.echo("")
+
+
 def _claim_and_run(ctx: click.Context, agent_id: str, host_mode: bool) -> tuple[list[dict], list[dict]]:
     """One claim/execute pass; returns (command task results, workflow tasks)."""
     data = _client(ctx).post(
@@ -444,17 +469,34 @@ def task_queue_run(
         )
         raise SystemExit(2)
 
+    _print_run_header(ctx, agent_id, host_mode, run_once, poll_interval, total_time)
+
     started = time.monotonic()
     polls = 0
     total_results: list[dict] = []
     try:
         while True:
             polls += 1
+            ts = time.strftime("%H:%M:%S")
             results, workflow_tasks = _claim_and_run(ctx, agent_id, host_mode)
             total_results.extend(results)
 
-            # A polling loop stays quiet on empty passes; --run-once always
-            # reports so cron logs show every tick.
+            # Print a per-poll status line so the operator can see the poller
+            # is alive and whether new events arrived.
+            if results or workflow_tasks:
+                failed = sum(1 for r in results if r["status"] == "failed")
+                task_count = len(results) + len(workflow_tasks)
+                detail = f"{task_count} task(s) claimed"
+                if workflow_tasks:
+                    detail += f" ({len(workflow_tasks)} workflow)"
+                if failed:
+                    detail += f", {failed} failed"
+                click.echo(f"[{ts}] poll #{polls} → {detail}")
+            else:
+                click.echo(f"[{ts}] poll #{polls} → no new tasks")
+
+            # Emit structured output for non-empty passes (and always for
+            # --run-once so cron logs capture every tick).
             if run_once or results or workflow_tasks:
                 _output(
                     ctx,
@@ -492,6 +534,8 @@ def task_queue_run(
                     title="Task Queue (polling finished)",
                 )
                 return
+            next_ts = time.strftime("%H:%M:%S", time.localtime(time.time() + poll_interval))
+            click.echo(f"  sleeping {poll_interval}s — next poll at {next_ts}")
             time.sleep(poll_interval)
     finally:
         _release_run_lock()

--- a/deepvista_cli/commands/task_queue.py
+++ b/deepvista_cli/commands/task_queue.py
@@ -35,6 +35,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -82,6 +83,10 @@ RUN_LOCK_PATH = CONFIG_DIR / "task_queue.run.lock"
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+class _StaleAgentError(Exception):
+    """Raised when an agent's project no longer exists and its local file has been deleted."""
 
 
 def _client(ctx: click.Context) -> DeepVistaClient:
@@ -425,7 +430,19 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
     cwd = os.environ.get("DEEPVISTA_TASK_CWD") or os.getcwd()
     argv = [_claude_binary(), "-p", f"/deepvista {prompt}", "--permission-mode", permission_mode]
 
-    click.echo(f"  ▶ running task {task_id} via claude -p (project {project_id or '?'})", err=True)
+    short_id = task_id[:8]
+    click.echo(f"  ▶ running task {short_id}… via claude -p (project {project_id or '?'})", err=True)
+
+    _done = threading.Event()
+    _start = time.monotonic()
+
+    def _progress() -> None:
+        while not _done.wait(10):
+            elapsed = int(time.monotonic() - _start)
+            click.echo(f"    task {short_id}… still running ({elapsed}s elapsed)", err=True)
+
+    _t = threading.Thread(target=_progress, daemon=True)
+    _t.start()
     try:
         proc = subprocess.run(  # noqa: S603 — argv built from a fixed binary + literal flags
             argv,
@@ -449,6 +466,13 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
         )
     except OSError as exc:
         status, exit_code, output = "failed", None, str(exc)
+    finally:
+        _done.set()
+        _t.join()
+
+    elapsed = int(time.monotonic() - _start)
+    icon = "✓" if status == "completed" else "✗"
+    click.echo(f"  {icon} task {short_id}… {status} (exit {exit_code}, {elapsed}s)", err=True)
 
     _client(ctx).post(
         f"/agents/{agent_id}/tasks/{task_id}/result",
@@ -459,12 +483,35 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
 
 
 def _claim_and_run_task_cards(ctx: click.Context, agent_id: str, project_id: str | None) -> list[dict]:
-    """Claim this Machine's pending task cards in ``project_id`` and run each headless."""
+    """Claim this Machine's pending task cards in ``project_id`` and run each headless.
+
+    Raises ``_StaleAgentError`` when the server returns ``project_not_found`` and the
+    local registration file has been deleted, so the caller can drop this agent_id
+    from the live poll list and avoid repeated 404 warnings.
+    """
     headers = {"X-Project-Id": project_id} if project_id else None
-    data = _client(ctx).post(f"/agents/{agent_id}/tasks/claim", None, extra_headers=headers)
-    if not data.get("success", True):
+    data = _client(ctx).post_nofatal(f"/agents/{agent_id}/tasks/claim", None, extra_headers=headers)
+    status_code = data.get("_status_code", 200) if isinstance(data, dict) else 200
+    error_code = data.get("error") if isinstance(data.get("error"), str) else None
+    # FastAPI 4xx errors use "detail" not "error"; treat any non-2xx as failure.
+    if not error_code and status_code >= 400:
+        error_code = data.get("detail") or str(status_code)
+    if error_code or not data.get("success", True):
+        if error_code == "project_not_found":
+            for aid, _, path in _iter_agent_files():
+                if aid == agent_id:
+                    try:
+                        path.unlink()
+                    except OSError:
+                        pass
+                    break
+            click.echo(
+                f"  removed stale agent {agent_id} (project {project_id} no longer accessible)",
+                err=True,
+            )
+            raise _StaleAgentError(agent_id)
         click.echo(
-            f"  [warn] could not claim task cards for agent {agent_id}: {data.get('error', 'unknown')}",
+            f"  [warn] could not claim task cards for agent {agent_id}: {error_code or 'unknown'}",
             err=True,
         )
         return []
@@ -497,24 +544,23 @@ def _detect_host_agent() -> bool:
     return bool(detected) and detected != "deepvista-cli"
 
 
-def _list_all_machine_agents() -> list[tuple[str, str | None]]:
-    """Return (agent_id, project_id) for every locally registered agent.
+def _iter_agent_files() -> list[tuple[str, str | None, Path]]:
+    """Return (agent_id, project_id, path) for every locally registered agent, newest-first.
 
     Deduplicates by agent_id so a registration file collision never causes
     double-claiming.
     """
-    seen: set[str] = set()
-    results: list[tuple[str, str | None]] = []
     if not AGENTS_DIR.exists():
-        return results
+        return []
+    seen: set[str] = set()
     candidates: list[tuple[float, Path]] = []
     for path in AGENTS_DIR.glob("*.json"):
         try:
             candidates.append((path.stat().st_mtime, path))
         except OSError:
             continue
-    candidates.sort(reverse=True)
-    for _, path in candidates:
+    result: list[tuple[str, str | None, Path]] = []
+    for _, path in sorted(candidates, reverse=True):
         try:
             data = _json.loads(path.read_text())
         except (OSError, _json.JSONDecodeError):
@@ -523,22 +569,31 @@ def _list_all_machine_agents() -> list[tuple[str, str | None]]:
         if not aid or aid in seen:
             continue
         seen.add(aid)
-        results.append((aid, data.get("project_id")))
-    return results
+        result.append((aid, data.get("project_id"), path))
+    return result
 
 
-def _ensure_agents_for_all_projects(ctx: click.Context) -> list[tuple[str, str | None]]:
+def _list_all_machine_agents() -> list[tuple[str, str | None]]:
+    """Return (agent_id, project_id) for every locally registered agent."""
+    return [(aid, proj_id) for aid, proj_id, _ in _iter_agent_files()]
+
+
+def _ensure_agents_for_all_projects(
+    ctx: click.Context,
+) -> tuple[list[tuple[str, str | None]], dict[str, str]]:
     """Fetch all projects and ensure a local agent is registered for each one.
 
     For projects that already have a local registration the existing agent_id
     is reused; for new projects a fresh agent is registered on-the-fly using
-    the detected host agent type (or ``deepvista-cli`` as a fallback).  Any
-    locally registered agents whose project no longer appears in the API
-    response are appended at the end so nothing is silently dropped.
+    the detected host agent type (or ``deepvista-cli`` as a fallback).
 
-    Returns ``(agent_id, project_id)`` for every project, deduped by agent_id.
-    On network failure falls back to the local-only list so offline/cron runs
-    still work.
+    Stale local registrations whose project_id no longer appears in the API
+    response are deleted so they stop producing 404 warnings on every poll.
+    Agents with no project_id (legacy global registrations) are kept.
+
+    Returns ``((agent_id, project_id), project_names)`` where ``project_names``
+    maps project_id → human-readable name.  On network failure falls back to
+    the local-only list with an empty name map so offline/cron runs still work.
     """
     try:
         detected, _ = detect_agent_tool()
@@ -550,10 +605,18 @@ def _ensure_agents_for_all_projects(ctx: click.Context) -> list[tuple[str, str |
         projects_raw = _client(ctx).get("/projects")
     except SystemExit:
         click.echo("  [warn] could not fetch projects — using locally registered agents only", err=True)
-        return _list_all_machine_agents()
+        return _list_all_machine_agents(), {}
 
     # Backend returns a JSON array directly for GET /projects.
     projects: list[dict] = projects_raw if isinstance(projects_raw, list) else projects_raw.get("projects", [])
+
+    # Build project_id → name map from the API response.
+    project_names: dict[str, str] = {}
+    for project in projects:
+        pid = project.get("id")
+        name = project.get("name") or project.get("title") or ""
+        if pid and name:
+            project_names[pid] = name
 
     seen_agent_ids: set[str] = set()
     result: list[tuple[str, str | None]] = []
@@ -562,6 +625,7 @@ def _ensure_agents_for_all_projects(ctx: click.Context) -> list[tuple[str, str |
         project_id = project.get("id")
         if not project_id:
             continue
+        project_name = project_names.get(project_id, "")
 
         # Reuse an existing local registration for this project.
         existing_id = _load_agent_id(agent_type, DEFAULT_AGENT_ROLE, project_id)
@@ -593,7 +657,7 @@ def _ensure_agents_for_all_projects(ctx: click.Context) -> list[tuple[str, str |
                 continue
             agent_id: str = agent["id"]
             agent_role_saved = agent.get("agent_role", DEFAULT_AGENT_ROLE)
-            _save_agent_id(agent_type, agent_id, agent_role_saved, project_id)
+            _save_agent_id(agent_type, agent_id, agent_role_saved, project_id, project_name or None)
 
             # Mirror what `agents register` does: install hooks + initial sync.
             profile = getattr(ctx.obj, "profile", "default")
@@ -616,19 +680,57 @@ def _ensure_agents_for_all_projects(ctx: click.Context) -> list[tuple[str, str |
             seen_agent_ids.add(agent_id)
             result.append((agent_id, project_id))
 
-    # Append any locally registered agents whose project wasn't in the API
-    # response (e.g. old registrations, shared projects that were later removed).
-    for agent_id, proj_id in _list_all_machine_agents():
-        if agent_id not in seen_agent_ids:
-            seen_agent_ids.add(agent_id)
-            result.append((agent_id, proj_id))
+    # Prune stale registrations and append any remaining local agents.
+    # An agent file is stale if it has a project_id that no longer appears in
+    # the API response; deleting it prevents repeated 404 warnings each poll.
+    # Agents with no project_id (legacy global registrations) are kept.
+    api_project_ids = {p.get("id") for p in projects if p.get("id")}
+    for agent_id, proj_id, path in _iter_agent_files():
+        if agent_id in seen_agent_ids:
+            continue
+        if proj_id and proj_id not in api_project_ids:
+            try:
+                path.unlink()
+                click.echo(
+                    f"  removed stale agent {agent_id} (project {proj_id} no longer accessible)",
+                    err=True,
+                )
+            except OSError:
+                pass
+            continue
+        seen_agent_ids.add(agent_id)
+        result.append((agent_id, proj_id))
 
-    return result
+    return result, project_names
+
+
+def _agent_type_label(agent_id: str) -> str:
+    """Return the agent_type stored in the local registration file for this agent."""
+    if not AGENTS_DIR.exists():
+        return ""
+    for path in AGENTS_DIR.glob("*.json"):
+        try:
+            data = _json.loads(path.read_text())
+            if data.get("agent_id") == agent_id:
+                return data.get("agent_type", "")
+        except (OSError, _json.JSONDecodeError):
+            continue
+    return ""
+
+
+def _project_display(project_id: str | None, project_names: dict[str, str]) -> str:
+    """Format a project ID as 'Name (short-id)' when a name is known, else just the ID."""
+    if not project_id:
+        return "unknown"
+    name = project_names.get(project_id, "")
+    short = project_id[:8] + "…"
+    return f"{name}  ({short})" if name else project_id
 
 
 def _print_run_header(
     ctx: click.Context,
     agents: list[tuple[str, str | None]],
+    project_names: dict[str, str],
     host_mode: bool,
     run_once: bool,
     poll_interval: int,
@@ -650,12 +752,16 @@ def _print_run_header(
     click.echo(f"account  : {account}")
     if len(agents) == 1:
         agent_id, project_id = agents[0]
-        click.echo(f"agent    : {agent_id}")
-        click.echo(f"project  : {project_id or '(unknown — re-register to capture)'}")
+        agent_type = _agent_type_label(agent_id)
+        click.echo(f"agent    : {agent_id}" + (f"  [{agent_type}]" if agent_type else ""))
+        click.echo(f"project  : {_project_display(project_id, project_names)}")
     else:
         click.echo(f"agents   : {len(agents)} (all registered on this machine)")
         for agent_id, project_id in agents:
-            click.echo(f"  {agent_id}  project={project_id or 'unknown'}")
+            agent_type = _agent_type_label(agent_id)
+            proj = _project_display(project_id, project_names)
+            type_tag = f"  [{agent_type}]" if agent_type else ""
+            click.echo(f"  {agent_id[:8]}…{type_tag}  →  {proj}")
     click.echo(f"profile  : {profile}  ({api_url})")
     click.echo(f"mode     : {mode}")
     click.echo(f"host     : {'yes (workflow tasks included)' if host_mode else 'no (command tasks only)'}")
@@ -687,20 +793,27 @@ def _claim_and_run_all(
     ctx: click.Context,
     agents: list[tuple[str, str | None]],
     host_mode: bool,
-) -> tuple[list[dict], list[tuple[str, dict]]]:
+) -> tuple[list[dict], list[tuple[str, dict]], set[str]]:
     """Claim and execute tasks for all agents in one poll pass.
 
-    Returns ``(command_results, [(agent_id, workflow_task)])``.
+    Returns ``(command_results, [(agent_id, workflow_task)], pruned_agent_ids)``.
+    ``pruned_agent_ids`` contains agent_ids whose local registration was deleted
+    because the project no longer exists; the caller should remove them from the
+    live agents list so they are not retried on subsequent polls.
     Per-agent claim failures are logged and skipped so a single stale
     registration does not prevent the others from being serviced.
     """
     all_results: list[dict] = []
     all_workflow_tasks: list[tuple[str, dict]] = []
+    pruned: set[str] = set()
     for agent_id, project_id in agents:
         # DV-1247: task cards (plain prompts run via `claude -p`) — independent
         # of host mode; a Machine runs them headless without a host agent.
         try:
             all_results.extend(_claim_and_run_task_cards(ctx, agent_id, project_id))
+        except _StaleAgentError:
+            pruned.add(agent_id)
+            continue  # skip the CLI-command claim for a pruned agent
         except SystemExit:
             click.echo(f"  [warn] failed to claim task cards for agent {agent_id} — skipping", err=True)
 
@@ -712,7 +825,7 @@ def _claim_and_run_all(
             continue
         all_results.extend(results)
         all_workflow_tasks.extend((agent_id, t) for t in wf_tasks)
-    return all_results, all_workflow_tasks
+    return all_results, all_workflow_tasks, pruned
 
 
 @task_queue_group.command("run")
@@ -792,6 +905,7 @@ def task_queue_run(
         )
         raise SystemExit(2)
 
+    project_names: dict[str, str] = {}
     if agent_type or agent_role or project_id:
         # Explicit filter — single-agent mode (backward-compatible).
         agent_id, resolved_project_id = _require_machine_agent_id(agent_type, agent_role, project_id)
@@ -799,14 +913,14 @@ def task_queue_run(
     else:
         # No filter — auto-register for every project the user has access to,
         # then poll all of them so nothing is missed.
-        agents = _ensure_agents_for_all_projects(ctx)
+        agents, project_names = _ensure_agents_for_all_projects(ctx)
         if not agents:
             output_error(3, "No projects or registered agents found", "Run 'deepvista auth login' then retry.")
             raise SystemExit(3)
 
     host_mode = host_mode or _detect_host_agent()
 
-    _print_run_header(ctx, agents, host_mode, run_once, poll_interval, total_time)
+    _print_run_header(ctx, agents, project_names, host_mode, run_once, poll_interval, total_time)
 
     started = time.monotonic()
     polls = 0
@@ -815,7 +929,9 @@ def task_queue_run(
         while True:
             polls += 1
             ts = time.strftime("%H:%M:%S")
-            results, workflow_tasks = _claim_and_run_all(ctx, agents, host_mode)
+            results, workflow_tasks, pruned = _claim_and_run_all(ctx, agents, host_mode)
+            if pruned:
+                agents = [(aid, pid) for aid, pid in agents if aid not in pruned]
             total_results.extend(results)
 
             # Print a per-poll status line so the operator can see the poller

--- a/deepvista_cli/commands/task_queue.py
+++ b/deepvista_cli/commands/task_queue.py
@@ -84,23 +84,51 @@ def _output(ctx: click.Context, data: object, **kwargs: object) -> None:
     format_output(data, ctx.obj.output_format, **kwargs)  # type: ignore[arg-type]
 
 
-def _resolve_machine_agent_id(agent_type: str | None, agent_role: str | None) -> str | None:
+def _resolve_machine_agent_id(
+    agent_type: str | None,
+    agent_role: str | None,
+    project_id: str | None = None,
+) -> tuple[str, str | None] | None:
     """Find the registered agent this machine's queue belongs to.
 
-    Resolution order: explicit --type/--role, then the detected host tool,
-    then the most recently registered agent of any type on this machine.
+    Resolution order: explicit --type/--role/--project, then the detected host
+    tool, then the most recently registered agent of any type on this machine.
+
+    Returns ``(agent_id, project_id)`` so callers can surface the project in
+    banners without a second file read, or ``None`` when nothing is found.
     """
+
+    def _read(path: Path) -> tuple[str, str | None] | None:
+        try:
+            data = _json.loads(path.read_text())
+            aid = data.get("agent_id")
+            return (aid, data.get("project_id")) if aid else None
+        except (OSError, _json.JSONDecodeError):
+            return None
+
     if agent_type:
-        return _load_agent_id(agent_type, agent_role)
+        agent_id = _load_agent_id(agent_type, agent_role, project_id)
+        if not agent_id:
+            return None
+        # Re-read the file to get project_id alongside the agent_id.
+        for path in AGENTS_DIR.glob(f"{agent_type}__*.json"):
+            result = _read(path)
+            if result and result[0] == agent_id:
+                return result
+        return (agent_id, project_id)
 
     try:
         detected, _ = detect_agent_tool()
     except Exception:
         detected = None
     if detected:
-        agent_id = _load_agent_id(detected, agent_role)
+        agent_id = _load_agent_id(detected, agent_role, project_id)
         if agent_id:
-            return agent_id
+            for path in AGENTS_DIR.glob(f"{detected}__*.json"):
+                result = _read(path)
+                if result and result[0] == agent_id:
+                    return result
+            return (agent_id, project_id)
 
     # Cron runs outside any agent host — fall back to the newest registration.
     candidates: list[tuple[float, Path]] = []
@@ -113,20 +141,27 @@ def _resolve_machine_agent_id(agent_type: str | None, agent_role: str | None) ->
     candidates.sort(reverse=True)
     for _, path in candidates:
         try:
-            agent_id = _json.loads(path.read_text()).get("agent_id")
+            data = _json.loads(path.read_text())
         except (OSError, _json.JSONDecodeError):
             continue
-        if agent_id:
-            return agent_id
+        if project_id and data.get("project_id") and data["project_id"] != project_id:
+            continue
+        aid = data.get("agent_id")
+        if aid:
+            return (aid, data.get("project_id"))
     return None
 
 
-def _require_machine_agent_id(agent_type: str | None, agent_role: str | None) -> str:
-    agent_id = _resolve_machine_agent_id(agent_type, agent_role)
-    if not agent_id:
+def _require_machine_agent_id(
+    agent_type: str | None,
+    agent_role: str | None,
+    project_id: str | None = None,
+) -> tuple[str, str | None]:
+    result = _resolve_machine_agent_id(agent_type, agent_role, project_id)
+    if not result:
         output_error(3, "No registered agent on this machine", "Run 'deepvista agents register' first.")
         raise SystemExit(3)
-    return agent_id
+    return result
 
 
 def _deepvista_binary() -> str:
@@ -351,7 +386,13 @@ def _detect_host_agent() -> bool:
 
 
 def _print_run_header(
-    ctx: click.Context, agent_id: str, host_mode: bool, run_once: bool, poll_interval: int, total_time: int | None
+    ctx: click.Context,
+    agent_id: str,
+    project_id: str | None,
+    host_mode: bool,
+    run_once: bool,
+    poll_interval: int,
+    total_time: int | None,
 ) -> None:
     """Print a startup banner summarising the account, agent, and polling config."""
     tokens = get_valid_token(credentials_path(getattr(ctx.obj, "profile", "default")))
@@ -368,6 +409,7 @@ def _print_run_header(
 
     click.echo(f"account : {account}")
     click.echo(f"agent   : {agent_id}")
+    click.echo(f"project : {project_id or '(unknown — re-register to capture)'}")
     click.echo(f"profile : {profile}  ({api_url})")
     click.echo(f"mode    : {mode}")
     click.echo(f"host    : {'yes (workflow tasks included)' if host_mode else 'no (command tasks only)'}")
@@ -398,6 +440,7 @@ def _claim_and_run(ctx: click.Context, agent_id: str, host_mode: bool) -> tuple[
 @task_queue_group.command("run")
 @click.option("--type", "agent_type", default=None, help="Resolve agent by type from local storage.")
 @click.option("--role", "agent_role", default=None, help="Resolve agent by role (with --type).")
+@click.option("--project", "project_id", default=None, help="Restrict to the agent registered for this project ID.")
 @click.option(
     "--host",
     "host_mode",
@@ -435,6 +478,7 @@ def task_queue_run(
     ctx: click.Context,
     agent_type: str | None,
     agent_role: str | None,
+    project_id: str | None,
     host_mode: bool,
     run_once: bool,
     poll_interval: int,
@@ -458,7 +502,7 @@ def task_queue_run(
     and the entries stay ``running`` until the agent calls
     ``task_queue complete``.
     """
-    agent_id = _require_machine_agent_id(agent_type, agent_role)
+    agent_id, resolved_project_id = _require_machine_agent_id(agent_type, agent_role, project_id)
     host_mode = host_mode or _detect_host_agent()
 
     if not _acquire_run_lock():
@@ -469,7 +513,7 @@ def task_queue_run(
         )
         raise SystemExit(2)
 
-    _print_run_header(ctx, agent_id, host_mode, run_once, poll_interval, total_time)
+    _print_run_header(ctx, agent_id, resolved_project_id, host_mode, run_once, poll_interval, total_time)
 
     started = time.monotonic()
     polls = 0
@@ -544,13 +588,14 @@ def task_queue_run(
 @task_queue_group.command("list")
 @click.option("--type", "agent_type", default=None, help="Resolve agent by type from local storage.")
 @click.option("--role", "agent_role", default=None, help="Resolve agent by role (with --type).")
+@click.option("--project", "project_id", default=None, help="Restrict to the agent registered for this project ID.")
 @click.pass_context
-def task_queue_list(ctx: click.Context, agent_type: str | None, agent_role: str | None) -> None:
+def task_queue_list(ctx: click.Context, agent_type: str | None, agent_role: str | None, project_id: str | None) -> None:
     """Show the task queue for this machine's agent.
 
     Read-only.
     """
-    agent_id = _require_machine_agent_id(agent_type, agent_role)
+    agent_id, _ = _require_machine_agent_id(agent_type, agent_role, project_id)
     data = _client(ctx).get(f"/agents/{agent_id}/task-queue")
     if data.get("error"):
         output_error(1, "Failed to list tasks", data["error"])
@@ -575,6 +620,7 @@ def task_queue_list(ctx: click.Context, agent_type: str | None, agent_role: str 
 @click.option("--note", default=None, help="Short outcome note stored as the task's output tail.")
 @click.option("--type", "agent_type", default=None, help="Resolve agent by type from local storage.")
 @click.option("--role", "agent_role", default=None, help="Resolve agent by role (with --type).")
+@click.option("--project", "project_id", default=None, help="Restrict to the agent registered for this project ID.")
 @click.pass_context
 def task_queue_complete(
     ctx: click.Context,
@@ -583,6 +629,7 @@ def task_queue_complete(
     note: str | None,
     agent_type: str | None,
     agent_role: str | None,
+    project_id: str | None,
 ) -> None:
     """Report the terminal outcome of a claimed workflow task (DV-955).
 
@@ -591,7 +638,7 @@ def task_queue_complete(
     tasks report automatically; this is only needed for workflow tasks,
     which stay ``running`` until someone reports them.
     """
-    agent_id = _require_machine_agent_id(agent_type, agent_role)
+    agent_id, _ = _require_machine_agent_id(agent_type, agent_role, project_id)
     data = _client(ctx).post(
         f"/agents/{agent_id}/task-queue/{task_id}/result",
         {"status": status, "exit_code": 0 if status == "completed" else 1, "output_tail": note},

--- a/deepvista_cli/main.py
+++ b/deepvista_cli/main.py
@@ -93,8 +93,11 @@ cli.add_command(agents_group)
 cli.add_command(schedule_group)
 # Agent session transcripts (DV-742) — `init` / `tick` / `finalize`
 cli.add_command(session_group)
-# Pull-based task queue for this machine's agent (DV-936)
+# Tasks dispatched to this Machine: web-chat task cards (DV-1247) + the
+# pull-based CLI-command / workflow queue (DV-936). Primary name is `tasks`;
+# `task_queue` stays registered as a deprecated alias for existing cron jobs.
 cli.add_command(task_queue_group)
+cli.add_command(task_queue_group, name="task_queue")
 # Supporting commands
 cli.add_command(auth_group)
 cli.add_command(config_group)

--- a/deepvista_cli/workflow_doc.py
+++ b/deepvista_cli/workflow_doc.py
@@ -16,9 +16,13 @@ from dataclasses import dataclass
 # ---------------------------------------------------------------------------
 
 # Match a full <accordion ...>...</accordion> block, capturing attrs + body.
-# Non-greedy body so multiple accordions in a body each match.
+# Non-greedy body so multiple accordions in a body each match. The backend
+# normalizes phase accordions to the chevron-only `<accordion-plain>` variant
+# (DV-1084), so accept both spellings — without `-plain` the close tag
+# `</accordion-plain>` never matched `</accordion>`, so `phases()` came back
+# empty and `task_queue run --host` couldn't emit packets for normalized skills.
 _ACCORDION_RE = re.compile(
-    r"<accordion(?P<attrs>[^>]*)>(?P<body>.*?)</accordion>",
+    r"<accordion(?:-plain)?(?P<attrs>[^>]*)>(?P<body>.*?)</accordion(?:-plain)?>",
     re.DOTALL,
 )
 

--- a/skills/deepvista/SKILL.md
+++ b/skills/deepvista/SKILL.md
@@ -51,6 +51,7 @@ other reference file assumes you know it.
 | `deepvista vistabase` (alias: `memory`) | viewing or semantic-searching implicit memory accumulated from chat | [vistabase.md](reference/vistabase.md) · [memory.md](reference/memory.md) |
 | `deepvista chat` | sending a message to the AI agent, listing / deleting chat sessions, continuing a conversation | [chat.md](reference/chat.md) |
 | `deepvista skill` | listing, running, installing, discovering, **creating new skills**, or **catalog-syncing** (`sync` / `load`) structured Skill workflows | [skill.md](reference/skill.md) |
+| `deepvista tasks` | running this **Machine**'s dispatched work: `tasks run` polls for tasks (web-chat prompts run headless via `claude -p`, plus queued CLI commands / workflow runs) and `tasks list` shows them | [tasks.md](reference/tasks.md) |
 | — analyze notes | searching → reading → synthesizing notes to surface themes / patterns | [skill-analyze-notes.md](reference/skill-analyze-notes.md) |
 | — research → run | finding context in the knowledge base, then running a Skill with synthesized input | [skill-research-to-skill.md](reference/skill-research-to-skill.md) |
 | — create from note | synthesizing a workflow skill from a podcast / interview / book note; batch-converting a corpus | [skill-create-from-note.md](reference/skill-create-from-note.md) |

--- a/skills/deepvista/reference/tasks.md
+++ b/skills/deepvista/reference/tasks.md
@@ -1,0 +1,65 @@
+# `deepvista tasks` — run work dispatched to this Machine (DV-1247)
+
+> Read [shared.md](shared.md) first (auth, profiles, global-flags-before-resource).
+
+## Concepts
+
+- **Machine** — a device running the DeepVista CLI (this one). Registered with
+  `deepvista agents register`; a user can have several (a laptop, a cloud VM).
+  Machines are a *user-level* concept and live in the `managed_agents` table.
+- **Task** — a one-off prompt the web chat (or another agent) enqueues for a
+  Machine. Stored as a project-scoped `task` context card. The Machine claims it
+  and runs it **headless** with `claude -p "/deepvista <prompt>"`; stdout becomes
+  the task's output (saved as a linked output card) and the exit code decides
+  completed vs. failed. The run log accretes on the task card under `## Run`.
+
+This is different from a *workflow run* (a structured multi-phase Skill) — a task
+is just a prompt. `tasks run` handles both: task cards **and** the legacy
+pull-based queue (queued `deepvista …` CLI commands + host-driven workflow runs).
+
+## Commands
+
+| Command | Use when |
+|---|---|
+| `deepvista tasks run` | Start the poll loop on this Machine. Claims pending tasks across **every project** you can access (Owner/Editor), runs each, reports results. |
+| `deepvista tasks list` | Show the tasks dispatched to this Machine (optionally `--status pending\|running\|completed\|failed`). Read-only. |
+
+> `task_queue` remains as a deprecated alias of `tasks` so existing cron jobs
+> keep working — prefer `tasks`.
+
+### `tasks run` — the poll loop
+
+```bash
+deepvista tasks run                 # poll forever (Ctrl-C to stop)
+deepvista tasks run --run-once      # one pass then exit (what `setup`'s cron uses)
+deepvista tasks run --poll-interval 30
+deepvista tasks run --total-time 600   # poll for up to 10 minutes
+deepvista tasks run --project <id>     # restrict to one project's Machine
+```
+
+- **All projects by default**: with no `--type/--role/--project`, the loop
+  ensures this Machine is registered in every project you can access and polls
+  all of them, so nothing is missed. Each claim stamps the Machine's
+  `last_polled`, so it shows **online** in Settings → Machines while polling.
+- **Single instance**: a PID lock (`~/.config/deepvista/task_queue.run.lock`)
+  means only one `tasks run` is active per Machine — a foreground poller and a
+  cron tick never double-claim.
+- **Headless execution**: each task runs `claude -p "/deepvista <prompt>"`.
+  - Override the binary with `DEEPVISTA_CLAUDE_BIN` (also the test seam).
+  - Permission posture defaults to `bypassPermissions` (unattended); override
+    with `DEEPVISTA_TASK_PERMISSION_MODE`.
+  - Working directory defaults to the poller's CWD; override with
+    `DEEPVISTA_TASK_CWD`.
+
+## How a task gets here
+
+On DeepVista web chat, ask the agent to delegate — e.g.
+*"add a task to the local agent queue to reply hello world"*. The chat agent
+calls the `enqueue_task` tool, which creates a pending `task` card targeting one
+of your Machines (auto-selected when you have exactly one). The next
+`deepvista tasks run` poll on that Machine claims and runs it.
+
+## Cron
+
+`deepvista tasks setup --interval 5` installs a crontab entry that runs
+`deepvista tasks run --run-once` every 5 minutes (macOS/Linux).

--- a/skills/deepvista/reference/tasks.md
+++ b/skills/deepvista/reference/tasks.md
@@ -40,7 +40,7 @@ deepvista tasks run --project <id>     # restrict to one project's Machine
 - **All projects by default**: with no `--type/--role/--project`, the loop
   ensures this Machine is registered in every project you can access and polls
   all of them, so nothing is missed. Each claim stamps the Machine's
-  `last_polled`, so it shows **online** in Settings → Machines while polling.
+  `last_heartbeat_at`, so it shows **online** in Settings → Machines while polling.
 - **Single instance**: a PID lock (`~/.config/deepvista/task_queue.run.lock`)
   means only one `tasks run` is active per Machine — a foreground poller and a
   cron tick never double-claim.

--- a/tests/test_task_queue_commands.py
+++ b/tests/test_task_queue_commands.py
@@ -99,9 +99,20 @@ class _FakeClock:
     def monotonic(self) -> float:
         return self.now
 
+    def time(self) -> float:
+        return self.now
+
     def sleep(self, seconds: int) -> None:
         self.sleeps.append(seconds)
         self.now += seconds
+
+    def strftime(self, fmt: str, t: object = None) -> str:  # type: ignore[override]
+        return "00:00:00"
+
+    def localtime(self, secs: float | None = None) -> object:
+        import time as _time
+
+        return _time.localtime(0)
 
 
 def _install_fake_clock(monkeypatch: pytest.MonkeyPatch) -> _FakeClock:
@@ -113,18 +124,36 @@ def _install_fake_clock(monkeypatch: pytest.MonkeyPatch) -> _FakeClock:
 
 
 def _parse_json_objects(output: str) -> list[dict]:
-    """Parse a stream of concatenated (pretty-printed) JSON objects."""
+    """Parse a stream of (pretty-printed) JSON objects, skipping non-JSON lines.
+
+    Non-JSON text (e.g. the startup banner printed by `task_queue run`) is
+    silently skipped by advancing to the next ``{`` character before each
+    decode attempt.
+    """
     decoder = json.JSONDecoder()
     text = output.strip()
     objs: list[dict] = []
     idx = 0
     while idx < len(text):
-        obj, end = decoder.raw_decode(text, idx)
-        objs.append(obj)
-        while end < len(text) and text[end].isspace():
-            end += 1
-        idx = end
+        brace = text.find("{", idx)
+        if brace == -1:
+            break
+        try:
+            obj, end = decoder.raw_decode(text, brace)
+            objs.append(obj)
+            idx = end
+            while idx < len(text) and text[idx].isspace():
+                idx += 1
+        except json.JSONDecodeError:
+            idx = brace + 1
     return objs
+
+
+def _parse_first_json(output: str) -> dict:
+    """Return the first JSON object from output (banner lines are ignored)."""
+    objs = _parse_json_objects(output)
+    assert objs, f"No JSON object found in output:\n{output}"
+    return objs[0]
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +184,7 @@ def test_run_once_exits_immediately_when_queue_empty(
 
     result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = _parse_first_json(result.output)
     assert payload["tasks_run"] == 0
     # Only the claim call — no execution, no result reports.
     assert [c[1] for c in stub.calls] == ["/agents/agent-uuid-1/task-queue/claim"]
@@ -191,7 +220,7 @@ def test_run_executes_claimed_task_and_reports_result(
 
     result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = _parse_first_json(result.output)
     assert payload["tasks_run"] == 1
     assert payload["failed"] == 0
     assert payload["results"][0]["status"] == "completed"
@@ -227,7 +256,7 @@ def test_run_rejects_non_deepvista_command_without_executing(
 
     result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = _parse_first_json(result.output)
     assert payload["failed"] == 1
     assert payload["results"][0]["status"] == "failed"
 
@@ -428,7 +457,7 @@ def test_run_polls_until_total_time(
     assert clock.sleeps == [10, 10]
 
     # Empty passes are quiet; only the final summary is printed.
-    payload = json.loads(result.output)
+    payload = _parse_first_json(result.output)
     assert payload == {"agent_id": "agent-uuid-1", "polls": 3, "tasks_run": 0, "failed": 0}
 
 
@@ -597,7 +626,7 @@ def test_list_shows_queue(
 
     result = CliRunner().invoke(cli, ["task_queue", "list"])
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = _parse_first_json(result.output)
     assert payload["count"] == 1
     assert payload["tasks"][0]["id"] == "t-1"
 
@@ -625,7 +654,7 @@ def test_setup_dry_run_previews_cron_entry(
 
     result = CliRunner().invoke(cli, ["--dry-run", "task_queue", "setup", "--interval", "10"])
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = _parse_first_json(result.output)
     assert payload["dry_run"] is True
     assert "*/10 * * * *" in payload["entry"]
     assert CRON_MARKER in payload["entry"]
@@ -650,7 +679,7 @@ def test_setup_installs_and_replaces_entry_idempotently(
 
     result = CliRunner().invoke(cli, ["task_queue", "setup", "--interval", "15"])
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = _parse_first_json(result.output)
     assert payload["installed"] is True
     assert payload["interval_minutes"] == 15
 
@@ -681,7 +710,7 @@ def test_setup_remove_uninstalls_entry(
 
     result = CliRunner().invoke(cli, ["task_queue", "setup", "--remove"])
     assert result.exit_code == 0, result.output
-    payload = json.loads(result.output)
+    payload = _parse_first_json(result.output)
     assert payload["removed"] is True
     assert written[0] == ["0 0 * * * /bin/true"]
 

--- a/tests/test_task_queue_commands.py
+++ b/tests/test_task_queue_commands.py
@@ -38,6 +38,13 @@ class _StubCtxClient:
         self.calls.append((method, path, body))
         q = self.responses.get(path)
         if not q:
+            # DV-1247 task-card endpoints are claimed on every poll pass; tests
+            # that don't exercise task cards get an empty default so the legacy
+            # task-queue assertions stay focused.
+            if "/tasks/claim" in path:
+                return {"success": True, "tasks": []}
+            if path.endswith("/tasks") or "/tasks/" in path:
+                return {"success": True, "tasks": []}
             raise AssertionError(f"no response queued for {method} {path}")
         return q.pop(0)
 
@@ -74,7 +81,11 @@ def _install_stub_client(monkeypatch: pytest.MonkeyPatch, stub: _StubCtxClient) 
         "post",
         lambda self, path, body=None, extra_headers=None: stub.post(path, body),
     )
-    monkeypatch.setattr(http_module.DeepVistaClient, "get", lambda self, path, params=None: stub.get(path, params))
+    monkeypatch.setattr(
+        http_module.DeepVistaClient,
+        "get",
+        lambda self, path, params=None, extra_headers=None: stub.get(path, params),
+    )
 
 
 def _register_local_agent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path, agent_id: str = "agent-uuid-1") -> None:
@@ -191,7 +202,7 @@ def test_run_once_exits_immediately_when_queue_empty(
     assert result.exit_code == 0, result.output
     payload = _parse_first_json(result.output)
     assert payload["tasks_run"] == 0
-    non_setup_calls = [c[1] for c in stub.calls if c[1] != "/projects"]
+    non_setup_calls = [c[1] for c in stub.calls if c[1] != "/projects" and "/tasks" not in c[1]]
     assert non_setup_calls == ["/agents/agent-uuid-1/task-queue/claim"]
 
 
@@ -238,6 +249,57 @@ def test_run_executes_claimed_task_and_reports_result(
     method, path, body = stub.calls[-1]
     assert (method, path) == ("POST", "/agents/agent-uuid-1/task-queue/t-1/result")
     assert body == {"status": "completed", "exit_code": 0, "output_tail": "ok"}
+
+
+def test_run_executes_task_card_via_claude_and_reports_output(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DV-1247: a claimed task card runs `claude -p "/deepvista <prompt>"`; stdout
+    is reported as the output and the run completes."""
+    stub = _StubCtxClient()
+    stub.queue("/projects", [])
+    stub.queue(
+        "/agents/agent-uuid-1/tasks/claim",
+        {"success": True, "tasks": [{"id": "tc-1", "prompt": "reply hello world", "title": "Say hello"}]},
+    )
+    stub.queue("/agents/agent-uuid-1/task-queue/claim", {"success": True, "tasks": []})
+    stub.queue("/agents/agent-uuid-1/tasks/tc-1/result", {"success": True, "output_card_id": "out-1"})
+    _install_stub_client(monkeypatch, stub)
+    _register_local_agent(monkeypatch, isolated_home)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    class _FakeProc:
+        returncode = 0
+        stdout = "Hello, world!"
+        stderr = ""
+
+    executed: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):  # type: ignore[no-untyped-def]
+        executed.append(argv)
+        return _FakeProc()
+
+    monkeypatch.setattr(tq_module.subprocess, "run", fake_run)
+
+    result = CliRunner().invoke(cli, ["tasks", "run", "--run-once"])
+    assert result.exit_code == 0, result.output
+
+    # Claude was invoked headless with the /deepvista-prefixed prompt.
+    assert executed, "claude was not launched"
+    argv = executed[0]
+    assert argv[1] == "-p"
+    assert argv[2] == "/deepvista reply hello world"
+    assert "--permission-mode" in argv
+
+    # The result (with captured stdout) was reported to the task-card endpoint.
+    result_calls = [c for c in stub.calls if c[1] == "/agents/agent-uuid-1/tasks/tc-1/result"]
+    assert result_calls, "no result reported"
+    _, _, body = result_calls[-1]
+    assert body["status"] == "completed"
+    assert body["exit_code"] == 0
+    assert body["output"] == "Hello, world!"
 
 
 def test_run_rejects_non_deepvista_command_without_executing(
@@ -468,7 +530,7 @@ def test_run_polls_until_total_time(
     assert result.exit_code == 0, result.output
 
     # Passes at t=0, 10, 20; a fourth pass would start past the 25s budget.
-    claim_calls = [c[1] for c in stub.calls if c[1] != "/projects"]
+    claim_calls = [c[1] for c in stub.calls if c[1] != "/projects" and "/tasks" not in c[1]]
     assert claim_calls == ["/agents/agent-uuid-1/task-queue/claim"] * 3
     assert clock.sleeps == [10, 10]
 
@@ -536,7 +598,7 @@ def test_run_host_polling_hands_back_after_workflow_packet(
     # the packet instead of sitting behind a blocked foreground poll.
     result = CliRunner().invoke(cli, ["task_queue", "run", "--host"])
     assert result.exit_code == 0, result.output
-    assert [c[1] for c in stub.calls if c[1] != "/projects"] == ["/agents/agent-uuid-1/task-queue/claim"]
+    assert [c[1] for c in stub.calls if c[1] != "/projects" and "/tasks" not in c[1]] == ["/agents/agent-uuid-1/task-queue/claim"]
     assert clock.sleeps == []
 
 
@@ -580,7 +642,7 @@ def test_run_reclaims_stale_lock_and_releases_on_exit(
 
     result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
-    assert [c[1] for c in stub.calls if c[1] != "/projects"] == ["/agents/agent-uuid-1/task-queue/claim"]
+    assert [c[1] for c in stub.calls if c[1] != "/projects" and "/tasks" not in c[1]] == ["/agents/agent-uuid-1/task-queue/claim"]
     # Lock was reclaimed for the run and removed afterwards.
     assert not tq_module.RUN_LOCK_PATH.exists()
 
@@ -636,14 +698,15 @@ def test_list_shows_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    # DV-1247: `tasks list` now lists task cards (GET /agents/{id}/tasks).
     stub.queue(
-        "/agents/agent-uuid-1/task-queue",
-        {"tasks": [{"id": "t-1", "command": "deepvista notes list", "status": "pending"}]},
+        "/agents/agent-uuid-1/tasks",
+        {"success": True, "tasks": [{"id": "t-1", "title": "Say hello", "status": "pending"}]},
     )
     _install_stub_client(monkeypatch, stub)
     _register_local_agent(monkeypatch, isolated_home)
 
-    result = CliRunner().invoke(cli, ["task_queue", "list"])
+    result = CliRunner().invoke(cli, ["tasks", "list"])
     assert result.exit_code == 0, result.output
     payload = _parse_first_json(result.output)
     assert payload["count"] == 1
@@ -743,7 +806,7 @@ def test_cron_entry_includes_profile_flag():
 def test_cron_entry_runs_once_per_tick():
     # Cron provides the schedule; each tick must be a single pass, not a
     # second long-lived poller fighting the foreground one for the lock.
-    assert "task_queue run --run-once" in _cron_entry(5, "default")
+    assert "tasks run --run-once" in _cron_entry(5, "default")
 
 
 # ---------------------------------------------------------------------------
@@ -873,7 +936,7 @@ def test_run_type_filter_restricts_to_single_agent(
     result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once", "--type", "claude-code", "--project", "proj-1"])
     assert result.exit_code == 0, result.output
 
-    claimed_paths = [c[1] for c in stub.calls]
+    claimed_paths = [c[1] for c in stub.calls if "/tasks" not in c[1]]
     assert claimed_paths == ["/agents/agent-proj-1/task-queue/claim"]
 
 

--- a/tests/test_task_queue_commands.py
+++ b/tests/test_task_queue_commands.py
@@ -83,6 +83,11 @@ def _install_stub_client(monkeypatch: pytest.MonkeyPatch, stub: _StubCtxClient) 
     )
     monkeypatch.setattr(
         http_module.DeepVistaClient,
+        "post_nofatal",
+        lambda self, path, body=None, extra_headers=None: stub.post(path, body),
+    )
+    monkeypatch.setattr(
+        http_module.DeepVistaClient,
         "get",
         lambda self, path, params=None, extra_headers=None: stub.get(path, params),
     )
@@ -852,7 +857,7 @@ def test_run_once_polls_all_registered_agents(
     monkeypatch.setattr(
         tq_module,
         "_ensure_agents_for_all_projects",
-        lambda ctx: [("agent-proj-1", "proj-1"), ("agent-proj-2", "proj-2")],
+        lambda ctx: ([("agent-proj-1", "proj-1"), ("agent-proj-2", "proj-2")], {}),
     )
 
     result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
@@ -904,7 +909,8 @@ def test_ensure_agents_for_all_projects_registers_missing_and_reuses_existing(
     @_cli.command("_test_ensure")
     @click.pass_context
     def _test_cmd(ctx):  # type: ignore[no-untyped-def]
-        captured.extend(tq_module._ensure_agents_for_all_projects(ctx))
+        agents, _ = tq_module._ensure_agents_for_all_projects(ctx)
+        captured.extend(agents)
 
     result = _CliRunner().invoke(_cli, ["_test_ensure"])
     assert result.exit_code == 0, result.output
@@ -958,7 +964,7 @@ def test_run_skips_stale_agent_and_continues(
     monkeypatch.setattr(
         tq_module,
         "_ensure_agents_for_all_projects",
-        lambda ctx: [("agent-proj-1", "proj-1"), ("agent-proj-2", "proj-2")],
+        lambda ctx: ([("agent-proj-1", "proj-1"), ("agent-proj-2", "proj-2")], {}),
     )
 
     result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])

--- a/tests/test_task_queue_commands.py
+++ b/tests/test_task_queue_commands.py
@@ -69,7 +69,11 @@ def _install_stub_client(monkeypatch: pytest.MonkeyPatch, stub: _StubCtxClient) 
     from deepvista_cli.client import http as http_module
 
     monkeypatch.setattr(http_module.DeepVistaClient, "__init__", fake_init)
-    monkeypatch.setattr(http_module.DeepVistaClient, "post", lambda self, path, body=None: stub.post(path, body))
+    monkeypatch.setattr(
+        http_module.DeepVistaClient,
+        "post",
+        lambda self, path, body=None, extra_headers=None: stub.post(path, body),
+    )
     monkeypatch.setattr(http_module.DeepVistaClient, "get", lambda self, path, params=None: stub.get(path, params))
 
 
@@ -178,6 +182,7 @@ def test_run_once_exits_immediately_when_queue_empty(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     stub.queue("/agents/agent-uuid-1/task-queue/claim", {"success": True, "tasks": []})
     _install_stub_client(monkeypatch, stub)
     _register_local_agent(monkeypatch, isolated_home)
@@ -186,8 +191,8 @@ def test_run_once_exits_immediately_when_queue_empty(
     assert result.exit_code == 0, result.output
     payload = _parse_first_json(result.output)
     assert payload["tasks_run"] == 0
-    # Only the claim call — no execution, no result reports.
-    assert [c[1] for c in stub.calls] == ["/agents/agent-uuid-1/task-queue/claim"]
+    non_setup_calls = [c[1] for c in stub.calls if c[1] != "/projects"]
+    assert non_setup_calls == ["/agents/agent-uuid-1/task-queue/claim"]
 
 
 def test_run_executes_claimed_task_and_reports_result(
@@ -195,6 +200,7 @@ def test_run_executes_claimed_task_and_reports_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     stub.queue(
         "/agents/agent-uuid-1/task-queue/claim",
         {"success": True, "tasks": [{"id": "t-1", "command": "deepvista notes list", "status": "running"}]},
@@ -239,6 +245,7 @@ def test_run_rejects_non_deepvista_command_without_executing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     stub.queue(
         "/agents/agent-uuid-1/task-queue/claim",
         {"success": True, "tasks": [{"id": "t-1", "command": "rm -rf /", "status": "running"}]},
@@ -270,6 +277,7 @@ def test_run_errors_when_no_agent_registered(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     _install_stub_client(monkeypatch, stub)
     import deepvista_cli.commands.agents as agents_module
     import deepvista_cli.commands.task_queue as tq_module
@@ -277,10 +285,10 @@ def test_run_errors_when_no_agent_registered(
     empty = isolated_home / ".config" / "deepvista" / "agents"
     monkeypatch.setattr(agents_module, "AGENTS_DIR", empty)
     monkeypatch.setattr(tq_module, "AGENTS_DIR", empty)
+    monkeypatch.setattr(tq_module, "RUN_LOCK_PATH", isolated_home / ".config" / "deepvista" / "task_queue.run.lock")
 
     result = CliRunner().invoke(cli, ["task_queue", "run"])
     assert result.exit_code == 3
-    assert stub.calls == []
 
 
 # ---------------------------------------------------------------------------
@@ -311,6 +319,7 @@ def test_run_headless_claims_command_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     stub.queue("/agents/agent-uuid-1/task-queue/claim", {"success": True, "tasks": []})
     _install_stub_client(monkeypatch, stub)
     _register_local_agent(monkeypatch, isolated_home)
@@ -321,7 +330,9 @@ def test_run_headless_claims_command_only(
 
     result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
-    method, path, body = stub.calls[0]
+    claim_calls = [(m, p, b) for m, p, b in stub.calls if p == "/agents/agent-uuid-1/task-queue/claim"]
+    assert len(claim_calls) == 1
+    method, path, body = claim_calls[0]
     assert (method, path) == ("POST", "/agents/agent-uuid-1/task-queue/claim")
     # Headless cron ticks must leave workflow tasks pending for a host run.
     assert body == {"command_only": True}
@@ -332,6 +343,7 @@ def test_run_host_emits_workflow_packet_and_leaves_task_running(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     stub.queue(
         "/agents/agent-uuid-1/task-queue/claim",
         {
@@ -381,6 +393,7 @@ def test_run_host_fails_unparseable_workflow_task(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     stub.queue(
         "/agents/agent-uuid-1/task-queue/claim",
         {
@@ -407,6 +420,7 @@ def test_run_headless_ignores_workflow_tasks_that_slip_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     stub.queue(
         "/agents/agent-uuid-1/task-queue/claim",
         {
@@ -443,6 +457,7 @@ def test_run_polls_until_total_time(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     for _ in range(3):
         stub.queue("/agents/agent-uuid-1/task-queue/claim", {"success": True, "tasks": []})
     _install_stub_client(monkeypatch, stub)
@@ -453,7 +468,8 @@ def test_run_polls_until_total_time(
     assert result.exit_code == 0, result.output
 
     # Passes at t=0, 10, 20; a fourth pass would start past the 25s budget.
-    assert [c[1] for c in stub.calls] == ["/agents/agent-uuid-1/task-queue/claim"] * 3
+    claim_calls = [c[1] for c in stub.calls if c[1] != "/projects"]
+    assert claim_calls == ["/agents/agent-uuid-1/task-queue/claim"] * 3
     assert clock.sleeps == [10, 10]
 
     # Empty passes are quiet; only the final summary is printed.
@@ -466,6 +482,7 @@ def test_run_polling_executes_tasks_across_passes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     stub.queue(
         "/agents/agent-uuid-1/task-queue/claim",
         {"success": True, "tasks": [{"id": "t-1", "command": "deepvista notes list", "status": "running"}]},
@@ -499,6 +516,7 @@ def test_run_host_polling_hands_back_after_workflow_packet(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     stub.queue(
         "/agents/agent-uuid-1/task-queue/claim",
         {
@@ -518,7 +536,7 @@ def test_run_host_polling_hands_back_after_workflow_packet(
     # the packet instead of sitting behind a blocked foreground poll.
     result = CliRunner().invoke(cli, ["task_queue", "run", "--host"])
     assert result.exit_code == 0, result.output
-    assert [c[1] for c in stub.calls] == ["/agents/agent-uuid-1/task-queue/claim"]
+    assert [c[1] for c in stub.calls if c[1] != "/projects"] == ["/agents/agent-uuid-1/task-queue/claim"]
     assert clock.sleeps == []
 
 
@@ -549,6 +567,7 @@ def test_run_reclaims_stale_lock_and_releases_on_exit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     stub = _StubCtxClient()
+    stub.queue("/projects", [])
     stub.queue("/agents/agent-uuid-1/task-queue/claim", {"success": True, "tasks": []})
     _install_stub_client(monkeypatch, stub)
     _register_local_agent(monkeypatch, isolated_home)
@@ -561,7 +580,7 @@ def test_run_reclaims_stale_lock_and_releases_on_exit(
 
     result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
     assert result.exit_code == 0, result.output
-    assert [c[1] for c in stub.calls] == ["/agents/agent-uuid-1/task-queue/claim"]
+    assert [c[1] for c in stub.calls if c[1] != "/projects"] == ["/agents/agent-uuid-1/task-queue/claim"]
     # Lock was reclaimed for the run and removed afterwards.
     assert not tq_module.RUN_LOCK_PATH.exists()
 
@@ -725,3 +744,160 @@ def test_cron_entry_runs_once_per_tick():
     # Cron provides the schedule; each tick must be a single pass, not a
     # second long-lived poller fighting the foreground one for the lock.
     assert "task_queue run --run-once" in _cron_entry(5, "default")
+
+
+# ---------------------------------------------------------------------------
+# multi-agent / all-projects polling
+# ---------------------------------------------------------------------------
+
+
+def _register_two_agents(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Write two agent registration files (different projects) and redirect state dirs."""
+    agents_dir = tmp_path / ".config" / "deepvista" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    (agents_dir / "claude-code__misc__proj-1.json").write_text(
+        json.dumps(
+            {"agent_id": "agent-proj-1", "agent_type": "claude-code", "agent_role": "misc", "project_id": "proj-1"}
+        )
+    )
+    (agents_dir / "claude-code__misc__proj-2.json").write_text(
+        json.dumps(
+            {"agent_id": "agent-proj-2", "agent_type": "claude-code", "agent_role": "misc", "project_id": "proj-2"}
+        )
+    )
+    import deepvista_cli.commands.agents as agents_module
+    import deepvista_cli.commands.task_queue as tq_module
+
+    monkeypatch.setattr(agents_module, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(tq_module, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(tq_module, "RUN_LOCK_PATH", tmp_path / ".config" / "deepvista" / "task_queue.run.lock")
+
+
+def test_run_once_polls_all_registered_agents(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without --type/--role/--project, run claims every locally registered agent's queue."""
+    stub = _StubCtxClient()
+    stub.queue("/agents/agent-proj-1/task-queue/claim", {"success": True, "tasks": []})
+    stub.queue("/agents/agent-proj-2/task-queue/claim", {"success": True, "tasks": []})
+    _install_stub_client(monkeypatch, stub)
+    _register_two_agents(monkeypatch, isolated_home)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    monkeypatch.setattr(
+        tq_module,
+        "_ensure_agents_for_all_projects",
+        lambda ctx: [("agent-proj-1", "proj-1"), ("agent-proj-2", "proj-2")],
+    )
+
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
+    assert result.exit_code == 0, result.output
+
+    claimed_paths = {c[1] for c in stub.calls}
+    assert "/agents/agent-proj-1/task-queue/claim" in claimed_paths
+    assert "/agents/agent-proj-2/task-queue/claim" in claimed_paths
+
+
+def test_ensure_agents_for_all_projects_registers_missing_and_reuses_existing(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Auto-registers for new projects and reuses existing local registrations."""
+    stub = _StubCtxClient()
+    stub.queue("/projects", [{"id": "proj-a"}, {"id": "proj-b"}])
+    stub.queue(
+        "/agents",
+        {"agent": {"id": "new-agent-b", "agent_type": "deepvista-cli", "agent_role": "misc"}},
+    )
+    # Initial sync posted after registration (mirrors `agents register` flow).
+    stub.queue("/agents/new-agent-b/sync", {"success": True, "agent": {"id": "new-agent-b"}})
+    _install_stub_client(monkeypatch, stub)
+
+    agents_dir = isolated_home / ".config" / "deepvista" / "agents"
+    agents_dir.mkdir(parents=True, exist_ok=True)
+    # proj-a already has a local registration.
+    (agents_dir / "deepvista-cli__misc__proj-a.json").write_text(
+        json.dumps(
+            {"agent_id": "existing-agent-a", "agent_type": "deepvista-cli", "agent_role": "misc", "project_id": "proj-a"}
+        )
+    )
+
+    import deepvista_cli.commands.agents as agents_module
+    import deepvista_cli.commands.task_queue as tq_module
+
+    monkeypatch.setattr(agents_module, "AGENTS_DIR", agents_dir)
+    monkeypatch.setattr(tq_module, "AGENTS_DIR", agents_dir)
+    # Patch detect_agent_tool in task_queue's namespace (it's imported directly).
+    monkeypatch.setattr(tq_module, "detect_agent_tool", lambda: ("deepvista-cli", {}))
+
+    import click
+    from click.testing import CliRunner as _CliRunner
+    from deepvista_cli.main import cli as _cli
+
+    captured: list = []
+
+    @_cli.command("_test_ensure")
+    @click.pass_context
+    def _test_cmd(ctx):  # type: ignore[no-untyped-def]
+        captured.extend(tq_module._ensure_agents_for_all_projects(ctx))
+
+    result = _CliRunner().invoke(_cli, ["_test_ensure"])
+    assert result.exit_code == 0, result.output
+
+    agent_ids = [a[0] for a in captured]
+    assert "existing-agent-a" in agent_ids
+    assert "new-agent-b" in agent_ids
+
+    # Verify the new registration was saved locally.
+    saved = json.loads((agents_dir / "deepvista-cli__misc__proj-b.json").read_text())
+    assert saved["agent_id"] == "new-agent-b"
+    assert saved["project_id"] == "proj-b"
+
+    # The POST for proj-b must have used the /agents endpoint (X-Project-Id goes in header, not path).
+    post_calls = [c for c in stub.calls if c[0] == "POST" and c[1] == "/agents"]
+    assert len(post_calls) == 1
+
+
+def test_run_type_filter_restricts_to_single_agent(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--type restricts polling to that agent only (backward-compat single-agent mode)."""
+    stub = _StubCtxClient()
+    stub.queue("/agents/agent-proj-1/task-queue/claim", {"success": True, "tasks": []})
+    _install_stub_client(monkeypatch, stub)
+    _register_two_agents(monkeypatch, isolated_home)
+
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once", "--type", "claude-code", "--project", "proj-1"])
+    assert result.exit_code == 0, result.output
+
+    claimed_paths = [c[1] for c in stub.calls]
+    assert claimed_paths == ["/agents/agent-proj-1/task-queue/claim"]
+
+
+def test_run_skips_stale_agent_and_continues(
+    isolated_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A claim failure on one agent logs a warning and services the remaining agents."""
+    stub = _StubCtxClient()
+    # agent-proj-1 claim fails (stale backend row)
+    stub.queue("/agents/agent-proj-1/task-queue/claim", {"success": False, "error": "AGENT_NOT_FOUND"})
+    # agent-proj-2 claim succeeds
+    stub.queue("/agents/agent-proj-2/task-queue/claim", {"success": True, "tasks": []})
+    _install_stub_client(monkeypatch, stub)
+    _register_two_agents(monkeypatch, isolated_home)
+
+    import deepvista_cli.commands.task_queue as tq_module
+
+    monkeypatch.setattr(
+        tq_module,
+        "_ensure_agents_for_all_projects",
+        lambda ctx: [("agent-proj-1", "proj-1"), ("agent-proj-2", "proj-2")],
+    )
+
+    result = CliRunner().invoke(cli, ["task_queue", "run", "--run-once"])
+    assert result.exit_code == 0, result.output
+    assert "/agents/agent-proj-2/task-queue/claim" in {c[1] for c in stub.calls}

--- a/tests/test_workflow_doc_phases.py
+++ b/tests/test_workflow_doc_phases.py
@@ -1,0 +1,84 @@
+"""Tests for WorkflowDocument phase parsing across accordion spellings.
+
+Regression guard (DV-955): the backend normalizes phase accordions to the
+chevron-only ``<accordion-plain>`` shortcode (DV-1084). The phase regex must
+accept that spelling — otherwise ``phases()`` returns empty and
+``task_queue run --host`` fails to emit a run packet ("Skill has no
+<accordion> phases") for any normalized workflow skill, silently breaking
+webhook-queued local runs.
+"""
+
+from __future__ import annotations
+
+from deepvista_cli.workflow_doc import WorkflowDocument
+
+_PLAIN = """---
+name: workflow-demo
+type: workflow
+---
+
+## Workflow
+
+```mermaid
+flowchart TD
+  A --> B
+```
+
+## Node Description
+
+<accordion-plain>
+Phase 1: Capture & Log
+
+Do the capture.
+</accordion-plain>
+
+<accordion-plain open="true">
+Phase 2: Enrich
+
+Do the enrichment.
+</accordion-plain>
+"""
+
+_CHECKBOX = """---
+name: workflow-demo
+type: workflow
+---
+
+## Node Description
+
+<accordion checked="true">
+Phase 1: Capture & Log
+
+Done.
+</accordion>
+
+<accordion checked="false">
+Phase 2: Enrich
+
+Pending.
+</accordion>
+"""
+
+
+def test_phases_parsed_from_accordion_plain():
+    phases = WorkflowDocument(_PLAIN).phases()
+    assert [p.title for p in phases] == ["Phase 1: Capture & Log", "Phase 2: Enrich"]
+    # `open="true"` on a plain accordion marks the active phase.
+    assert phases[0].state == "pending"
+    assert phases[1].state == "active"
+
+
+def test_phases_parsed_from_legacy_checkbox_accordion():
+    phases = WorkflowDocument(_CHECKBOX).phases()
+    assert [p.title for p in phases] == ["Phase 1: Capture & Log", "Phase 2: Enrich"]
+    assert phases[0].state == "done"
+    assert phases[1].state == "pending"
+
+
+def test_mixed_spellings_do_not_swallow_across_blocks():
+    # A plain open tag must not pair with a legacy close tag (and vice versa),
+    # which would merge two phases into one over-greedy match.
+    body = _PLAIN + _CHECKBOX
+    titles = [p.title for p in WorkflowDocument(body).phases()]
+    assert titles.count("Phase 1: Capture & Log") == 2
+    assert titles.count("Phase 2: Enrich") == 2


### PR DESCRIPTION
## Summary

Renames the `task_queue` command group to **`tasks`** and teaches `tasks run` to execute **task cards** — plain prompts the web chat delegates to this **Machine** (DV-1247). Also folds in **#164** (parse `<accordion-plain>` phases) and the existing verbose-run-output / multi-project registration work.

Pairs with deepvista **#2448**.

## What's in this PR

**`tasks` group (was `task_queue`)**
- Registered as `tasks`; `task_queue` stays as a **deprecated alias** so existing cron jobs keep working. The `setup` cron entry now emits `tasks run --run-once`.

**`tasks run` — runs web-chat task cards headless**
- On each poll pass, per accessible project, claims this Machine's pending **task cards** (`POST /agents/{id}/tasks/claim`, scoped via `X-Project-Id`) and runs each with `claude -p "/deepvista <prompt>"`, capturing stdout as the output and reporting the result (the backend creates a linked output card). The legacy CLI-command / host-workflow queue path runs in the same pass, unchanged.
- Binary / permission posture / cwd are overridable: `DEEPVISTA_CLAUDE_BIN` (also the test seam), `DEEPVISTA_TASK_PERMISSION_MODE` (default `bypassPermissions`), `DEEPVISTA_TASK_CWD`.
- Keeps the single-instance PID lock, `--run-once`, `--poll-interval`, `--total-time`, and **all-projects** auto-registration (DV-1242: a Machine registers on every project the user can Own/Edit).

**`tasks list`** — lists task cards for this Machine (`--status` filter).

**Project scope in the HTTP client** — `get()` now accepts `extra_headers`, so reads can carry `X-Project-Id` (the backend is project-scoped via that header; the CLI now sends it).

**Skill** — new `skills/deepvista/reference/tasks.md` documents the Machine/task model and the `tasks run` / `list` flow (DV-1247 noted there was no skill describing this), with an index row in `SKILL.md`.

**Folded in from #164** — `WorkflowDocument` now parses `<accordion-plain>` phases so host-mode workflow runs emit packets for normalized skills.

## Test plan

- `pytest tests/` — **82 pass**, including a new case that drives `claim → claude -p "/deepvista …" → result` (asserts the `/deepvista`-prefixed prompt, permission flag, and the reported output) and the `<accordion-plain>` phase tests from #164.
- Verified the `tasks` group + `task_queue` alias both resolve with `run` / `list` / `complete` / `setup`.

## Notes

- Closes #164 (cherry-picked here).
- The headless executor shells out to `claude`; on a Machine without Claude Code installed it reports a clear "binary not found — set DEEPVISTA_CLAUDE_BIN" failure rather than hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
