### PR TITLE
feat(skill): add phase need-input for :::dvNeedIntervention mermaid state

### DIFF
--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -528,14 +528,17 @@ def skill_phase_reset(ctx: click.Context, skill_id: str, phase_label: str, dry_r
 @click.option("--reason", required=True, help="Short sentence explaining what's blocking the run.")
 @click.pass_context
 def skill_phase_pause(ctx: click.Context, skill_id: str, reason: str) -> None:
-    """Pause the run (lock held). Exits non-zero so wrapping scripts notice.
+    """Pause the run (lock held), marking the active phase ``:::dvNeedIntervention``.
 
-    Does NOT change the card's ``status`` — the run lock stays held so a
-    re-run resumes the same phase. The user resumes by re-invoking
-    ``deepvista skill run --mode host <skill_id>``.
+    Sets the active phase's mermaid node to ``:::dvNeedIntervention`` so the
+    DeepVista UI shows the workflow is waiting for human action. Does NOT change
+    the card's ``status`` — the run lock stays held so a re-run resumes the same
+    phase. Exits non-zero so wrapping scripts notice.
     """
     card, doc = _load_skill_doc(ctx, skill_id)
     active = doc.active_phase()
+    if active:
+        _phase(ctx, skill_id, phase_label=active.title, action="need_input", reason=reason)
     out = {
         "ok": False,
         "paused": True,

--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -549,6 +549,37 @@ def skill_phase_pause(ctx: click.Context, skill_id: str, reason: str) -> None:
     sys.exit(2)
 
 
+@skill_phase_group.command("need-input")
+@click.argument("skill_id")
+@click.argument("phase_label")
+@click.option("--reason", required=True, help="Short sentence describing what input is needed from the user.")
+@click.pass_context
+def skill_phase_need_input(ctx: click.Context, skill_id: str, phase_label: str, reason: str) -> None:
+    """Signal that a phase is blocked waiting for user input (mermaid ``:::dvNeedIntervention``).
+
+    Marks the accordion open and sets the mermaid node to
+    ``:::dvNeedIntervention`` so the DeepVista UI shows the phase as
+    waiting for the user — distinct from a technical blocker (``phase pause``)
+    or an error. Exits non-zero so wrapping scripts notice.
+
+    The user provides the required information and then resumes with:
+
+        deepvista skill run --mode host <skill_id>
+    """
+    result = _phase(ctx, skill_id, phase_label=phase_label, action="need_input", reason=reason)
+    out = {
+        "ok": False,
+        "need_input": True,
+        "skill_id": skill_id,
+        "phase": phase_label,
+        "title": result.get("title", ""),
+        "reason": reason,
+        "resume_with": f"deepvista skill run --mode host {skill_id}",
+    }
+    format_output(out, ctx.obj.output_format, entity_type="skill", base_url=ctx.obj.auth_url)
+    sys.exit(2)
+
+
 @skill_phase_group.command("run-on-deepvista")
 @click.argument("skill_id")
 @click.argument("phase_label")

--- a/deepvista_cli/resources/workflow_host_runtime.md
+++ b/deepvista_cli/resources/workflow_host_runtime.md
@@ -110,8 +110,25 @@ follow steps 1–3.
 
 ### 5. Graceful exit when you can't continue
 
-If the current phase requires a tool you don't have (the user is offline,
-an MCP is unavailable, credentials are missing, …):
+Two distinct cases:
+
+**User input required** — the phase needs information, a decision, or
+approval from the user before it can proceed:
+
+1. Save whatever partial output you produced as a note card via
+   `deepvista notes create` so DeepVista keeps the artifact.
+2. Run:
+   ```
+   deepvista skill phase need-input <skill_id> "<Phase N: title>" \
+       --reason "<one short sentence describing what's needed>"
+   ```
+   This sets the mermaid node to `:::dvNeedIntervention`, **keeps the
+   run lock held** (`status` stays `in_progress`), and exits non-zero.
+3. Tell the user in plain language what you need and how to resume
+   once they've provided it (e.g. "Please confirm the target audience
+   and re-run `deepvista skill run` to continue Phase 2").
+
+**Technical blocker** — a tool, MCP, or credential is unavailable:
 
 1. Save whatever partial output you produced as a note card via
    `deepvista notes create` so DeepVista keeps the artifact.
@@ -148,8 +165,9 @@ be run again), and emits `<json>{"done": true}</json>`.
 | Open a phase | `deepvista skill phase open <skill_id> "Phase N: …"` |
 | Mark a phase done | `deepvista skill phase done <skill_id> "Phase N: …" [--artifact-card-id ID]…` |
 | Reset phase to pending | `deepvista skill phase reset <skill_id> "Phase N: …"` |
-| Pause (lock held) | `deepvista skill phase pause <skill_id> --reason "…"` |
-| Resume from pause | re-run `deepvista skill run --mode host <skill_id>` |
+| Needs user input (:::dvNeedIntervention) | `deepvista skill phase need-input <skill_id> "Phase N: …" --reason "…"` |
+| Pause — technical blocker (lock held) | `deepvista skill phase pause <skill_id> --reason "…"` |
+| Resume from pause / need-input | re-run `deepvista skill run --mode host <skill_id>` |
 | One-phase fallback to DeepVista | `deepvista skill phase run-on-deepvista <skill_id> "Phase N: …"` |
 | Finalize the run | `deepvista skill complete <skill_id> --review "…"` |
 | Save an artifact (note) | `deepvista notes create --title "…" --content "…"` |

--- a/deepvista_cli/resources/workflow_host_runtime.md
+++ b/deepvista_cli/resources/workflow_host_runtime.md
@@ -136,8 +136,8 @@ approval from the user before it can proceed:
    ```
    deepvista skill phase pause <skill_id> --reason "<one short sentence>"
    ```
-   This **keeps the run lock held** (`status` stays `in_progress`),
-   prints the reason for the user, and exits non-zero.
+   This also sets the active phase's mermaid node to `:::dvNeedIntervention`,
+   **keeps the run lock held** (`status` stays `in_progress`), and exits non-zero.
 3. Tell the user in plain language what's missing and how to resume
    (e.g. "Reconnect Gmail MCP and re-run `deepvista skill run` to
    continue Phase 3"). Do not pretend the phase succeeded.
@@ -166,7 +166,7 @@ be run again), and emits `<json>{"done": true}</json>`.
 | Mark a phase done | `deepvista skill phase done <skill_id> "Phase N: …" [--artifact-card-id ID]…` |
 | Reset phase to pending | `deepvista skill phase reset <skill_id> "Phase N: …"` |
 | Needs user input (:::dvNeedIntervention) | `deepvista skill phase need-input <skill_id> "Phase N: …" --reason "…"` |
-| Pause — technical blocker (lock held) | `deepvista skill phase pause <skill_id> --reason "…"` |
+| Pause — technical blocker (:::dvNeedIntervention, lock held) | `deepvista skill phase pause <skill_id> --reason "…"` |
 | Resume from pause / need-input | re-run `deepvista skill run --mode host <skill_id>` |
 | One-phase fallback to DeepVista | `deepvista skill phase run-on-deepvista <skill_id> "Phase N: …"` |
 | Finalize the run | `deepvista skill complete <skill_id> --review "…"` |

--- a/skills/deepvista/reference/skill.md
+++ b/skills/deepvista/reference/skill.md
@@ -61,7 +61,7 @@ deepvista skill phase open       <skill_id> "Phase N: <title>"
 deepvista skill phase done       <skill_id> "Phase N: <title>" [--artifact-card-id ID] [--next-phase "…"]
 deepvista skill phase reset      <skill_id> "Phase N: <title>"   # revert a done/active phase to pending
 deepvista skill phase need-input <skill_id> "Phase N: <title>" --reason "<what's needed>"  # :::dvNeedIntervention
-deepvista skill phase pause      <skill_id> --reason "<sentence>"  # technical blocker, no mermaid change
+deepvista skill phase pause      <skill_id> --reason "<sentence>"  # technical blocker → :::dvNeedIntervention
 deepvista skill complete         <skill_id> --review "<3–6 retrospective bullets>"
 ```
 

--- a/skills/deepvista/reference/skill.md
+++ b/skills/deepvista/reference/skill.md
@@ -57,11 +57,12 @@ If you called `skill get` and are already mid-workflow without a lock, call `ski
 After `skill run --mode host`, drive the run with:
 
 ```bash
-deepvista skill phase open  <skill_id> "Phase N: <title>"
-deepvista skill phase done  <skill_id> "Phase N: <title>" [--artifact-card-id ID] [--next-phase "…"]
-deepvista skill phase reset <skill_id> "Phase N: <title>"   # revert a done/active phase to pending
-deepvista skill phase pause <skill_id> --reason "<sentence>"
-deepvista skill complete    <skill_id> --review "<3–6 retrospective bullets>"
+deepvista skill phase open       <skill_id> "Phase N: <title>"
+deepvista skill phase done       <skill_id> "Phase N: <title>" [--artifact-card-id ID] [--next-phase "…"]
+deepvista skill phase reset      <skill_id> "Phase N: <title>"   # revert a done/active phase to pending
+deepvista skill phase need-input <skill_id> "Phase N: <title>" --reason "<what's needed>"  # :::dvNeedIntervention
+deepvista skill phase pause      <skill_id> --reason "<sentence>"  # technical blocker, no mermaid change
+deepvista skill complete         <skill_id> --review "<3–6 retrospective bullets>"
 ```
 
 `complete` appends `## Review`, releases the run lock, and emits `{"done": true}`.


### PR DESCRIPTION
## Summary

- Adds `deepvista skill phase need-input <skill_id> "<phase>" --reason "…"` command that calls `/workflow_phase` with `action="need_input"`, setting the mermaid node to `:::dvNeedIntervention` instead of falling back to `:::dvError`
- Updates `workflow_host_runtime.md` section 5 to distinguish two blocker types: *user input required* (`phase need-input`) vs *technical blocker* (`phase pause`)
- Updates `skills/deepvista/reference/skill.md` host-mode shims reference with the new command

## Test plan

- [ ] `deepvista skill phase need-input --help` shows the new command with `--reason` flag
- [ ] Running `phase need-input` on a valid skill/phase calls `/workflow_phase` with `action="need_input"` and exits 2
- [ ] Server marks the mermaid node `:::dvNeedIntervention` (not `:::dvError`)
- [ ] Runtime doc section 5 correctly splits user-input vs technical-blocker flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2wuR8JPgRB9bbZxx4iFVh