### PR TITLE
feat(DV-1277): clean session-card title + link task runs to their chat

### DIFF
--- a/deepvista_cli/commands/tasks.py
+++ b/deepvista_cli/commands/tasks.py
@@ -433,6 +433,15 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
     cwd = os.environ.get("DEEPVISTA_TASK_CWD") or os.getcwd()
     argv = [_claude_binary(), "-p", f"/deepvista {prompt}", "--permission-mode", permission_mode]
 
+    # DV-1277: expose the originating chat + this task to the headless run so the
+    # session card the Claude Code plugin writes (`deepvista session init`) can
+    # cross-reference them. The run record shares the same task_id, so a run and
+    # its session both resolve back to the web chat that triggered the task.
+    run_env = {**os.environ, "DEEPVISTA_TASK_ID": task_id}
+    source_chat_id = str(task.get("source_chat_id") or "").strip()
+    if source_chat_id:
+        run_env["DEEPVISTA_SOURCE_CHAT_ID"] = source_chat_id
+
     short_id = task_id[:8]
     title = task.get("title") or ""
     prompt_preview = (prompt[:120] + "…") if len(prompt) > 120 else prompt
@@ -473,6 +482,7 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
             text=True,
             timeout=TASK_RUN_TIMEOUT_SECONDS,
             cwd=cwd,
+            env=run_env,
         )
         exit_code = proc.returncode
         status = "completed" if exit_code == 0 else "failed"

--- a/deepvista_cli/session_note.py
+++ b/deepvista_cli/session_note.py
@@ -444,7 +444,9 @@ def seed_frontmatter(
     # a run and its session both resolve back to the chat that triggered them.
     source_chat_id = os.environ.get("DEEPVISTA_SOURCE_CHAT_ID", "").strip()
     if source_chat_id:
-        fm["source_chat_id"] = source_chat_id
+        # DV-1316: the chat reference is named `chat_id` across session/email/
+        # run_log cards.
+        fm["chat_id"] = source_chat_id
     task_id = os.environ.get("DEEPVISTA_TASK_ID", "").strip()
     if task_id:
         fm["task_id"] = task_id

--- a/deepvista_cli/session_note.py
+++ b/deepvista_cli/session_note.py
@@ -289,15 +289,44 @@ def _truncate(text: str, limit: int) -> str:
     return text[: limit - 1].rstrip() + "…"
 
 
+# Claude Code expands a `/command` invocation into the first user turn as
+# `<command-message>…</command-message><command-name>…</command-name>
+# <command-args>…</command-args>` (plus occasional `<local-command-*>` blocks).
+# The message/name are plumbing — noise in a human-facing title (DV-1277, the
+# card was titled literally "<command-message>"). The args are the real prompt,
+# so we drop the wrappers but keep their inner text.
+_COMMAND_NOISE_RE = re.compile(
+    r"<(command-message|command-name|local-command-stdout|local-command-stderr)>.*?</\1>",
+    re.DOTALL | re.IGNORECASE,
+)
+_TAG_RE = re.compile(r"</?[a-zA-Z][^>]*>")
+
+
+def strip_command_markup(text: str) -> str:
+    """Remove Claude Code slash-command plumbing from a transcript user turn.
+
+    Drops `<command-message>` / `<command-name>` / `<local-command-*>` blocks
+    (content included) and unwraps any remaining tags (e.g. `<command-args>`),
+    keeping their inner text. Returns the collapsed, stripped remainder.
+    """
+    if not text:
+        return ""
+    cleaned = _COMMAND_NOISE_RE.sub(" ", text)
+    cleaned = _TAG_RE.sub(" ", cleaned)
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
 def title_from_first_user_turn(text: str) -> str:
     """Heuristic placeholder title derived from a session's first user turn.
 
     Applied at ticks 1–``TITLE_REWRITE_TICK_THRESHOLD`` to give the card a
     meaningful name before the `deepvista-summarize-session` skill writes
-    an AI title at finalize. Empty input returns an empty string so callers
-    can skip the field.
+    an AI title at finalize. Slash-command plumbing is stripped first (DV-1277)
+    so the title is the real prompt, not `<command-message>`. Empty input (or a
+    turn that was only command plumbing) returns an empty string so callers can
+    skip the field and leave the prior/default title in place.
     """
-    return _truncate(text, TITLE_CHAR_LIMIT)
+    return _truncate(strip_command_markup(text), TITLE_CHAR_LIMIT)
 
 
 # ---------------------------------------------------------------------------
@@ -409,6 +438,16 @@ def seed_frontmatter(
         fm["agent_id"] = agent_id
     if agent_version:
         fm["agent_version"] = agent_version
+    # DV-1277: when this session is a task run dispatched from the web chat,
+    # `deepvista task_queue run` exports the originating chat + task so the
+    # session card cross-references them — the run record shares the task_id, so
+    # a run and its session both resolve back to the chat that triggered them.
+    source_chat_id = os.environ.get("DEEPVISTA_SOURCE_CHAT_ID", "").strip()
+    if source_chat_id:
+        fm["source_chat_id"] = source_chat_id
+    task_id = os.environ.get("DEEPVISTA_TASK_ID", "").strip()
+    if task_id:
+        fm["task_id"] = task_id
     fm.update(probe_git(cwd))
     return fm
 

--- a/tests/test_session_note_format.py
+++ b/tests/test_session_note_format.py
@@ -133,7 +133,7 @@ def test_seed_frontmatter_links_task_run_to_chat(monkeypatch) -> None:
     monkeypatch.setenv("DEEPVISTA_SOURCE_CHAT_ID", "chat-42")
     monkeypatch.setenv("DEEPVISTA_TASK_ID", "task-7")
     fm = sn.seed_frontmatter("sess-1", "/tmp/proj", "/tmp/t.jsonl")
-    assert fm["source_chat_id"] == "chat-42"
+    assert fm["chat_id"] == "chat-42"
     assert fm["task_id"] == "task-7"
 
 
@@ -141,7 +141,7 @@ def test_seed_frontmatter_omits_link_keys_for_interactive_session(monkeypatch) -
     monkeypatch.delenv("DEEPVISTA_SOURCE_CHAT_ID", raising=False)
     monkeypatch.delenv("DEEPVISTA_TASK_ID", raising=False)
     fm = sn.seed_frontmatter("sess-1", "/tmp/proj", "/tmp/t.jsonl")
-    assert "source_chat_id" not in fm
+    assert "chat_id" not in fm
     assert "task_id" not in fm
 
 

--- a/tests/test_session_note_format.py
+++ b/tests/test_session_note_format.py
@@ -102,6 +102,49 @@ def test_title_from_first_user_turn_returns_empty_for_blank_input() -> None:
     assert sn.title_from_first_user_turn("   \n  ") == ""
 
 
+def test_title_strips_command_message_and_name_markup() -> None:
+    # DV-1277: a /deepvista slash-command turn must not title the card
+    # "<command-message>"; the args (the real prompt) survive.
+    raw = (
+        "<command-message>deepvista is running…</command-message>\n"
+        "<command-name>deepvista</command-name>\n"
+        "<command-args>research Jane Doe</command-args>"
+    )
+    assert sn.title_from_first_user_turn(raw) == "research Jane Doe"
+
+
+def test_title_drops_turn_that_is_only_command_plumbing() -> None:
+    raw = "<command-message>deepvista is running…</command-message><command-name>deepvista</command-name>"
+    assert sn.title_from_first_user_turn(raw) == ""
+
+
+def test_strip_command_markup_keeps_plain_text() -> None:
+    assert sn.strip_command_markup("just a normal prompt") == "just a normal prompt"
+    # local-command output blocks are dropped wholesale
+    assert (
+        sn.strip_command_markup("do the thing <local-command-stdout>noisy output</local-command-stdout>")
+        == "do the thing"
+    )
+
+
+def test_seed_frontmatter_links_task_run_to_chat(monkeypatch) -> None:
+    # DV-1277: a task run exports the originating chat + task; the session card
+    # picks them up so it cross-references the chat that triggered it.
+    monkeypatch.setenv("DEEPVISTA_SOURCE_CHAT_ID", "chat-42")
+    monkeypatch.setenv("DEEPVISTA_TASK_ID", "task-7")
+    fm = sn.seed_frontmatter("sess-1", "/tmp/proj", "/tmp/t.jsonl")
+    assert fm["source_chat_id"] == "chat-42"
+    assert fm["task_id"] == "task-7"
+
+
+def test_seed_frontmatter_omits_link_keys_for_interactive_session(monkeypatch) -> None:
+    monkeypatch.delenv("DEEPVISTA_SOURCE_CHAT_ID", raising=False)
+    monkeypatch.delenv("DEEPVISTA_TASK_ID", raising=False)
+    fm = sn.seed_frontmatter("sess-1", "/tmp/proj", "/tmp/t.jsonl")
+    assert "source_chat_id" not in fm
+    assert "task_id" not in fm
+
+
 def test_append_turn_prepends_accordion_blocks() -> None:
     fm = sn.seed_frontmatter("sess-1", "/tmp/proj", "/tmp/t.jsonl")
     body = sn.build_initial_body(fm)


### PR DESCRIPTION
## DV-1277 — clean session-card title + link task runs to their chat

Companion to the deepvista PR for [DV-1277](https://linear.app/deepvista/issue/DV-1277). Two CLI-side changes:

### Session-card title no longer leaks `<command-message>`
`strip_command_markup` drops Claude Code slash-command plumbing from the first user turn: `<command-message>` / `<command-name>` / `<local-command-*>` blocks are removed (content included), `<command-args>` inner text is kept. A `/deepvista <prompt>` turn now titles the card with the real prompt instead of `<command-message>`. A turn that was *only* plumbing yields an empty title, so the prior/default title stands.

### Task runs cross-reference their originating chat
`task_queue run` exports `DEEPVISTA_SOURCE_CHAT_ID` + `DEEPVISTA_TASK_ID` into the headless `claude -p` environment; `session init` stamps them onto the session card frontmatter. A run record (created backend-side on task completion) shares the same `task_id`, so a run and its session both resolve back to the web chat that triggered the task — the DV-1277 "associate the session with the chat" item.

### Tests
16 session-note tests (title sanitize, fan-out-free linkage), 87 total pass; ruff + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
