### PR TITLE
feat(DV-1294): make the CLI a project-scoped client

### DIFF
--- a/deepvista_cli/client/http.py
+++ b/deepvista_cli/client/http.py
@@ -55,6 +55,13 @@ class DeepVistaClient:
             "X-DeepVista-Origin": json.dumps(build_origin(), separators=(",", ":")),
         }
 
+        # Scope every authenticated request to the CLI's working project.
+        # When unset, the header is omitted and the backend resolves the
+        # caller's default project (unchanged legacy behavior). Resolved from
+        # --project / DEEPVISTA_PROJECT_ID / profile project_id (see config).
+        if self.config.project_id:
+            headers["X-Project-Id"] = self.config.project_id
+
         # JWT auth (from per-profile credentials file)
         tokens = get_valid_token(credentials_path(self.config.profile))
         if tokens is not None and tokens.access_token:

--- a/deepvista_cli/commands/__init__.py
+++ b/deepvista_cli/commands/__init__.py
@@ -3,8 +3,38 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
+
+import click
 
 from deepvista_cli.output.formatter import output_error
+
+
+def project_option[F: Callable](func: F) -> F:
+    """Add a per-command ``--project <id>`` override.
+
+    Use together with :func:`apply_project_override` at the top of the command
+    body. The override takes precedence over the persisted working project /
+    global ``--project`` flag for this single invocation only.
+    """
+    return click.option(
+        "--project",
+        "project_override",
+        default=None,
+        help="Scope this command to a project id (overrides the working project for this call only).",
+    )(func)
+
+
+def apply_project_override(ctx: click.Context, project_override: str | None) -> None:
+    """Apply a per-command ``--project`` value to the resolved config.
+
+    Mutating ``ctx.obj.project_id`` is sufficient because the HTTP client holds
+    the *same* ``CLIConfig`` object and reads ``project_id`` lazily when it
+    builds request headers, so the override flows through to ``X-Project-Id``
+    and to emitted web links without touching every callsite.
+    """
+    if project_override:
+        ctx.obj.project_id = project_override
 
 
 def resolve_content(content: str | None, content_file: str | None) -> str | None:

--- a/deepvista_cli/commands/agents.py
+++ b/deepvista_cli/commands/agents.py
@@ -713,6 +713,7 @@ def _output(ctx: click.Context, data: object, **kwargs: object) -> None:
         ctx.obj.output_format,
         entity_type="agent",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
         **kwargs,  # type: ignore[arg-type]
     )
 

--- a/deepvista_cli/commands/card.py
+++ b/deepvista_cli/commands/card.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import click
 
 from deepvista_cli.client.http import DeepVistaClient
-from deepvista_cli.commands import resolve_content
+from deepvista_cli.commands import apply_project_override, project_option, resolve_content
 from deepvista_cli.output.formatter import format_output, output_error
 
 CARD_TYPES = [
@@ -81,6 +81,7 @@ def card_group() -> None:
 @click.option("--page", "page_number", default=1, help="Page number (default 1).")
 @click.option("--order-by", type=click.Choice(["created_at", "updated_at"]), default=None)
 @click.option("--order", "order_direction", type=click.Choice(["asc", "desc"]), default=None)
+@project_option
 @click.pass_context
 def card_list(
     ctx: click.Context,
@@ -90,8 +91,10 @@ def card_list(
     page_number: int,
     order_by: str | None,
     order_direction: str | None,
+    project_override: str | None,
 ) -> None:
     """List context cards with optional filtering."""
+    apply_project_override(ctx, project_override)
     body: dict = {"limit": limit, "page_number": page_number}
     if card_type:
         body["card_type"] = card_type
@@ -117,16 +120,26 @@ def card_list(
         title="Cards",
         entity_type="card",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
 @card_group.command("get")
 @click.argument("card_id")
+@project_option
 @click.pass_context
-def card_get(ctx: click.Context, card_id: str) -> None:
+def card_get(ctx: click.Context, card_id: str, project_override: str | None) -> None:
     """Get a context card by ID."""
+    apply_project_override(ctx, project_override)
     data = _client(ctx).post("/get_context_card", {"card_id": card_id})
-    format_output(data, ctx.obj.output_format, title=f"Card: {card_id}", entity_type="card", base_url=ctx.obj.auth_url)
+    format_output(
+        data,
+        ctx.obj.output_format,
+        title=f"Card: {card_id}",
+        entity_type="card",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
+    )
 
 
 @card_group.command("create")
@@ -143,6 +156,7 @@ def card_get(ctx: click.Context, card_id: str) -> None:
 @click.option("--tags", default=None, help='Tags as JSON array: \'["tag1","tag2"]\'.')
 @click.option("--no-enrich", is_flag=True, default=False, help="Skip entity enrichment.")
 @click.option("--dry-run", is_flag=True, default=False, help="Preview what would happen without making any changes.")
+@project_option
 @click.pass_context
 def card_create(
     ctx: click.Context,
@@ -153,6 +167,7 @@ def card_create(
     tags: str | None,
     no_enrich: bool,
     dry_run: bool,
+    project_override: str | None,
 ) -> None:
     """Create a new context card.
 
@@ -160,6 +175,7 @@ def card_create(
     """
     import json as _json
 
+    apply_project_override(ctx, project_override)
     description = resolve_content(description, content_file)
     body: dict = {
         "card_type": card_type,
@@ -180,11 +196,19 @@ def card_create(
             ctx.obj.output_format,
             entity_type="card",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Created Card", entity_type="card", base_url=ctx.obj.auth_url)
+    format_output(
+        data,
+        ctx.obj.output_format,
+        title="Created Card",
+        entity_type="card",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
+    )
 
 
 @card_group.command("update")
@@ -240,12 +264,18 @@ def card_update(
             ctx.obj.output_format,
             entity_type="card",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
     data = _client(ctx).post("/update_context_card", body)
     format_output(
-        data, ctx.obj.output_format, title=f"Updated Card: {card_id}", entity_type="card", base_url=ctx.obj.auth_url
+        data,
+        ctx.obj.output_format,
+        title=f"Updated Card: {card_id}",
+        entity_type="card",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -287,12 +317,18 @@ def card_edit(
             ctx.obj.output_format,
             entity_type="card",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
     data = _client(ctx).post("/edit_context_card", body)
     format_output(
-        data, ctx.obj.output_format, title=f"Edited Card: {card_id}", entity_type="card", base_url=ctx.obj.auth_url
+        data,
+        ctx.obj.output_format,
+        title=f"Edited Card: {card_id}",
+        entity_type="card",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -315,6 +351,7 @@ def card_delete(ctx: click.Context, card_id: str, card_type: str | None, dry_run
             ctx.obj.output_format,
             entity_type="card",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -322,7 +359,9 @@ def card_delete(ctx: click.Context, card_id: str, card_type: str | None, dry_run
     if card_type:
         params["card_type"] = card_type
     data = _client(ctx).delete(f"/context_cards/{card_id}", params=params)
-    format_output(data, ctx.obj.output_format, entity_type="card", base_url=ctx.obj.auth_url)
+    format_output(
+        data, ctx.obj.output_format, entity_type="card", base_url=ctx.obj.auth_url, project_id=ctx.obj.project_id
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -354,6 +393,7 @@ def card_search(ctx: click.Context, query: str, card_type: str | None, limit: in
         title=f"Search: {query}",
         entity_type="card",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -385,6 +425,7 @@ def card_similar(ctx: click.Context, card_id: str, limit: int) -> None:
         title=f"Similar to: {card_id}",
         entity_type="card",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -403,11 +444,14 @@ def card_pin(ctx: click.Context, card_id: str, dry_run: bool) -> None:
             ctx.obj.output_format,
             entity_type="card",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "pinned"})
-    format_output(data, ctx.obj.output_format, entity_type="card", base_url=ctx.obj.auth_url)
+    format_output(
+        data, ctx.obj.output_format, entity_type="card", base_url=ctx.obj.auth_url, project_id=ctx.obj.project_id
+    )
 
 
 @card_group.command("+archive")
@@ -425,11 +469,14 @@ def card_archive(ctx: click.Context, card_id: str, dry_run: bool) -> None:
             ctx.obj.output_format,
             entity_type="card",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
     data = _client(ctx).post("/update_context_card", {"card_id": card_id, "display_status": "archived"})
-    format_output(data, ctx.obj.output_format, entity_type="card", base_url=ctx.obj.auth_url)
+    format_output(
+        data, ctx.obj.output_format, entity_type="card", base_url=ctx.obj.auth_url, project_id=ctx.obj.project_id
+    )
 
 
 @card_group.command("+grep")
@@ -464,4 +511,11 @@ def card_grep(
         body["card_type"] = card_type
 
     data = _client(ctx).post("/grep_context_cards", body)
-    format_output(data, ctx.obj.output_format, title=f"Grep: {pattern}", entity_type="card", base_url=ctx.obj.auth_url)
+    format_output(
+        data,
+        ctx.obj.output_format,
+        title=f"Grep: {pattern}",
+        entity_type="card",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
+    )

--- a/deepvista_cli/commands/chat.py
+++ b/deepvista_cli/commands/chat.py
@@ -10,6 +10,7 @@ import json
 import click
 
 from deepvista_cli.client.http import DeepVistaClient
+from deepvista_cli.commands import apply_project_override, project_option
 from deepvista_cli.output.formatter import format_output
 
 
@@ -26,12 +27,16 @@ def chat_group() -> None:
 @click.option("--limit", default=10, help="Max results (default 10).")
 @click.option("--offset", default=0, help="Offset for pagination.")
 @click.option("--search", default=None, help="Search chat summaries.")
+@project_option
 @click.pass_context
-def chat_sessions(ctx: click.Context, limit: int, offset: int, search: str | None) -> None:
+def chat_sessions(
+    ctx: click.Context, limit: int, offset: int, search: str | None, project_override: str | None
+) -> None:
     """List chat sessions.
 
     Read-only — never modifies chat sessions.
     """
+    apply_project_override(ctx, project_override)
     body: dict = {"limit": limit, "offset": offset}
     if search:
         body["search"] = search
@@ -46,19 +51,29 @@ def chat_sessions(ctx: click.Context, limit: int, offset: int, search: str | Non
         title="Chat Sessions",
         entity_type="chat",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
 @chat_group.command("get")
 @click.argument("chat_id")
+@project_option
 @click.pass_context
-def chat_get(ctx: click.Context, chat_id: str) -> None:
+def chat_get(ctx: click.Context, chat_id: str, project_override: str | None) -> None:
     """Get a chat session with all pages.
 
     Read-only.
     """
+    apply_project_override(ctx, project_override)
     data = _client(ctx).get(f"/chat_sessions/{chat_id}")
-    format_output(data, ctx.obj.output_format, title=f"Chat: {chat_id}", entity_type="chat", base_url=ctx.obj.auth_url)
+    format_output(
+        data,
+        ctx.obj.output_format,
+        title=f"Chat: {chat_id}",
+        entity_type="chat",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
+    )
 
 
 @chat_group.command("delete")
@@ -76,11 +91,14 @@ def chat_delete(ctx: click.Context, chat_id: str, dry_run: bool) -> None:
             ctx.obj.output_format,
             entity_type="chat",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
     data = _client(ctx).delete(f"/chat_sessions/{chat_id}")
-    format_output(data, ctx.obj.output_format, entity_type="chat", base_url=ctx.obj.auth_url)
+    format_output(
+        data, ctx.obj.output_format, entity_type="chat", base_url=ctx.obj.auth_url, project_id=ctx.obj.project_id
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -93,8 +111,11 @@ def chat_delete(ctx: click.Context, chat_id: str, dry_run: bool) -> None:
 @click.option("--chat-id", default=None, help="Send to existing chat session.")
 @click.option("--new", "new_chat", is_flag=True, default=False, help="Force start a new conversation.")
 @click.option("--dry-run", is_flag=True, default=False, help="Preview what would happen without making any changes.")
+@project_option
 @click.pass_context
-def chat_send(ctx: click.Context, message: str, chat_id: str | None, new_chat: bool, dry_run: bool) -> None:
+def chat_send(
+    ctx: click.Context, message: str, chat_id: str | None, new_chat: bool, dry_run: bool, project_override: str | None
+) -> None:
     """Send a message to the DeepVista AI agent and stream the response.
 
     Output is NDJSON (one JSON object per line) — each line is an SSE event
@@ -103,6 +124,7 @@ def chat_send(ctx: click.Context, message: str, chat_id: str | None, new_chat: b
     > [!CAUTION] This is a write command — it creates/updates a chat session
     > and may trigger agent actions (creating cards, searching, etc.).
     """
+    apply_project_override(ctx, project_override)
     body: dict = {"user_instruction": message}
     if chat_id and not new_chat:
         body["chat_id"] = chat_id
@@ -113,6 +135,7 @@ def chat_send(ctx: click.Context, message: str, chat_id: str | None, new_chat: b
             ctx.obj.output_format,
             entity_type="chat",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 

--- a/deepvista_cli/commands/lint.py
+++ b/deepvista_cli/commands/lint.py
@@ -273,6 +273,7 @@ def lint_command(
             ctx.obj.output_format,
             entity_type="chat",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 

--- a/deepvista_cli/commands/notes.py
+++ b/deepvista_cli/commands/notes.py
@@ -19,7 +19,7 @@ import click
 from deepvista_cli import session_note as sn
 from deepvista_cli.client.http import DeepVistaClient
 from deepvista_cli.client.origin import detect_agent_tool
-from deepvista_cli.commands import resolve_content
+from deepvista_cli.commands import apply_project_override, project_option, resolve_content
 from deepvista_cli.commands.session import session_finalize, session_init, session_tick
 from deepvista_cli.output.formatter import format_output, output_error
 
@@ -44,12 +44,14 @@ def notes_group() -> None:
 @notes_group.command("list")
 @click.option("--limit", default=20, help="Max results (default 20).")
 @click.option("--page", "page_number", default=1, help="Page number.")
+@project_option
 @click.pass_context
-def notes_list(ctx: click.Context, limit: int, page_number: int) -> None:
+def notes_list(ctx: click.Context, limit: int, page_number: int, project_override: str | None) -> None:
     """List all notes.
 
     Read-only — never modifies your notes.
     """
+    apply_project_override(ctx, project_override)
     data = _client(ctx).post(
         "/get_context_cards",
         {
@@ -67,19 +69,29 @@ def notes_list(ctx: click.Context, limit: int, page_number: int) -> None:
         title="Notes",
         entity_type="note",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
 @notes_group.command("get")
 @click.argument("note_id")
+@project_option
 @click.pass_context
-def notes_get(ctx: click.Context, note_id: str) -> None:
+def notes_get(ctx: click.Context, note_id: str, project_override: str | None) -> None:
     """Get a note by ID.
 
     Read-only.
     """
+    apply_project_override(ctx, project_override)
     data = _client(ctx).post("/get_context_card", {"card_id": note_id, "card_type": "note"})
-    format_output(data, ctx.obj.output_format, title=f"Note: {note_id}", entity_type="note", base_url=ctx.obj.auth_url)
+    format_output(
+        data,
+        ctx.obj.output_format,
+        title=f"Note: {note_id}",
+        entity_type="note",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
+    )
 
 
 @notes_group.command("create")
@@ -92,14 +104,22 @@ def notes_get(ctx: click.Context, note_id: str) -> None:
 )
 @click.option("--tags", default=None, help='Tags as JSON array: \'["tag1","tag2"]\'.')
 @click.option("--dry-run", is_flag=True, default=False, help="Preview what would happen without making any changes.")
+@project_option
 @click.pass_context
 def notes_create(
-    ctx: click.Context, title: str, description: str | None, content_file: str | None, tags: str | None, dry_run: bool
+    ctx: click.Context,
+    title: str,
+    description: str | None,
+    content_file: str | None,
+    tags: str | None,
+    dry_run: bool,
+    project_override: str | None,
 ) -> None:
     """Create a new note.
 
     > [!CAUTION] This is a write command — confirm with the user before executing.
     """
+    apply_project_override(ctx, project_override)
     description = resolve_content(description, content_file)
 
     from deepvista_cli.commands.agents import load_agent_id_for_active_agent
@@ -130,11 +150,19 @@ def notes_create(
             ctx.obj.output_format,
             entity_type="note",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Created Note", entity_type="note", base_url=ctx.obj.auth_url)
+    format_output(
+        data,
+        ctx.obj.output_format,
+        title="Created Note",
+        entity_type="note",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
+    )
 
 
 @notes_group.command("update")
@@ -180,12 +208,18 @@ def notes_update(
             ctx.obj.output_format,
             entity_type="note",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
     data = _client(ctx).post("/update_context_card", body)
     format_output(
-        data, ctx.obj.output_format, title=f"Updated Note: {note_id}", entity_type="note", base_url=ctx.obj.auth_url
+        data,
+        ctx.obj.output_format,
+        title=f"Updated Note: {note_id}",
+        entity_type="note",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -204,11 +238,14 @@ def notes_delete(ctx: click.Context, note_id: str, dry_run: bool) -> None:
             ctx.obj.output_format,
             entity_type="note",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
     data = _client(ctx).delete(f"/context_cards/{note_id}", params={"card_type": "note"})
-    format_output(data, ctx.obj.output_format, entity_type="note", base_url=ctx.obj.auth_url)
+    format_output(
+        data, ctx.obj.output_format, entity_type="note", base_url=ctx.obj.auth_url, project_id=ctx.obj.project_id
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -270,6 +307,7 @@ def notes_index(
             ctx.obj.output_format,
             entity_type="note",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -280,6 +318,7 @@ def notes_index(
         title="Indexed Notes",
         entity_type="note",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -386,6 +425,7 @@ def notes_history(ctx: click.Context, note_id: str, limit: int) -> None:
         title=f"History: {note_id}",
         entity_type="note",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -412,6 +452,7 @@ def notes_diff(ctx: click.Context, note_id: str, version_a: int, version_b: int)
             ctx.obj.output_format,
             entity_type="note",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
     else:
         click.echo(diff or "(no differences)")
@@ -436,6 +477,7 @@ def notes_restore(ctx: click.Context, note_id: str, version: int, yes: bool, dry
             ctx.obj.output_format,
             entity_type="note",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -450,6 +492,7 @@ def notes_restore(ctx: click.Context, note_id: str, version: int, yes: bool, dry
         title=f"Restored: {note_id} → v{version}",
         entity_type="note",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -507,8 +550,16 @@ def notes_quick(ctx: click.Context, text: str, dry_run: bool) -> None:
             ctx.obj.output_format,
             entity_type="note",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
     data = _client(ctx).post("/create_context_card", body)
-    format_output(data, ctx.obj.output_format, title="Quick Note", entity_type="note", base_url=ctx.obj.auth_url)
+    format_output(
+        data,
+        ctx.obj.output_format,
+        title="Quick Note",
+        entity_type="note",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
+    )

--- a/deepvista_cli/commands/project.py
+++ b/deepvista_cli/commands/project.py
@@ -53,6 +53,43 @@ def _projects(ctx: click.Context) -> list[dict]:
     return []
 
 
+def _project_role(project: dict) -> str | None:
+    """Best-effort role for a project: explicit permission, else owner/shared."""
+    permission = project.get("permission")
+    if permission:
+        return permission
+    if project.get("is_shared"):
+        return None
+    return "owner"
+
+
+# Metadata fields worth surfacing in the slim view; the raw Project model also
+# carries large `tags` / `conversation_starters` arrays that drown the output.
+_SLIM_OPTIONAL_FIELDS = (
+    "is_shared",
+    "is_active",
+    "icon_url",
+    "timezone",
+    "backend_api_endpoint",
+    "owner_name",
+    "owner_email",
+    "created_at",
+    "updated_at",
+)
+
+
+def _slim_project(project: dict) -> dict:
+    """Project down to the useful metadata (id, name, role, …).
+
+    Keeps the ``id`` so the formatter still attaches a ``/project/{id}`` link.
+    """
+    slim: dict = {"id": project.get("id"), "name": project.get("name"), "role": _project_role(project)}
+    for key in _SLIM_OPTIONAL_FIELDS:
+        if project.get(key) is not None:
+            slim[key] = project[key]
+    return slim
+
+
 @click.group("project")
 def project_group() -> None:
     """Inspect and switch the CLI's working project.
@@ -66,10 +103,13 @@ def project_group() -> None:
 
 
 @project_group.command("list")
+@click.option("--full", is_flag=True, default=False, help="Show the raw project objects (tags, starters, …).")
 @click.pass_context
-def project_list(ctx: click.Context) -> None:
+def project_list(ctx: click.Context, full: bool) -> None:
     """List projects you own or that are shared with you."""
     projects = _projects(ctx)
+    if not full:
+        projects = [_slim_project(p) for p in projects]
     result = {"projects": projects, "count": len(projects), "current": ctx.obj.project_id}
     format_output(
         result,
@@ -81,26 +121,32 @@ def project_list(ctx: click.Context) -> None:
 
 
 @project_group.command("current")
+@click.option("--full", is_flag=True, default=False, help="Show the raw project object (tags, starters, …).")
 @click.pass_context
-def project_current(ctx: click.Context) -> None:
+def project_current(ctx: click.Context, full: bool) -> None:
     """Show the project the backend resolves for this CLI right now.
 
     Reflects the working project (`X-Project-Id`) when one is set, else the
     user's backend default project.
     """
     data = _client(ctx).get("/projects/me")
+    if not full and isinstance(data, dict):
+        data = _slim_project(data)
     format_output(data, ctx.obj.output_format, title="Current project", entity_type="project")
 
 
 @project_group.command("show")
 @click.argument("project_id", required=False)
+@click.option("--full", is_flag=True, default=False, help="Show the raw project object (tags, starters, …).")
 @click.pass_context
-def project_show(ctx: click.Context, project_id: str | None) -> None:
+def project_show(ctx: click.Context, project_id: str | None, full: bool) -> None:
     """Show metadata for a project (defaults to the resolved current project)."""
     if project_id:
         data = _client(ctx).get(f"/projects/{project_id}")
     else:
         data = _client(ctx).get("/projects/me")
+    if not full and isinstance(data, dict):
+        data = _slim_project(data)
     format_output(data, ctx.obj.output_format, title="Project", entity_type="project")
 
 

--- a/deepvista_cli/commands/project.py
+++ b/deepvista_cli/commands/project.py
@@ -1,0 +1,145 @@
+"""deepvista project — inspect and switch the CLI's working project.
+
+Every DeepVista entity is scoped to a **project** (DV-1164 and follow-ups).
+The backend resolves each request to a project via the ``X-Project-Id`` header,
+falling back to the caller's default project when the header is absent.
+
+This group lets a user pick a **working project** once and have every other
+subcommand (card, notes, chat, skill, …) operate inside it. The working
+project is persisted in the active profile and is *distinct* from the
+backend's per-user default project: ``project use`` only changes which project
+the CLI scopes to — it never calls ``set_default`` / ``activate``.
+
+Resolution order for the working project (highest wins):
+  --project flag  →  DEEPVISTA_PROJECT_ID env  →  profile project_id  →  none
+
+Endpoints:
+  GET /projects        -> list owned + shared projects
+  GET /projects/me     -> the resolved/default project
+  GET /projects/{id}   -> a single project's metadata
+"""
+
+from __future__ import annotations
+
+import click
+
+from deepvista_cli.client.http import DeepVistaClient
+from deepvista_cli.config import (
+    EXIT_VALIDATION_ERROR,
+    clear_working_project,
+    set_working_project,
+)
+from deepvista_cli.output.formatter import format_output, output_error
+
+PROJECT_COLUMNS = ["id", "name", "role"]
+
+
+def _client(ctx: click.Context) -> DeepVistaClient:
+    return ctx.obj._client
+
+
+def _projects(ctx: click.Context) -> list[dict]:
+    """Return the list of accessible projects from ``GET /projects``.
+
+    The backend returns a bare JSON array; tolerate a ``{"projects": [...]}``
+    envelope too for forward-compatibility.
+    """
+    raw = _client(ctx).get("/projects")
+    if isinstance(raw, list):
+        return raw
+    if isinstance(raw, dict):
+        projects = raw.get("projects", [])
+        return projects if isinstance(projects, list) else []
+    return []
+
+
+@click.group("project")
+def project_group() -> None:
+    """Inspect and switch the CLI's working project.
+
+    Pick a working project once with `project use <id>`; every subcommand then
+    scopes to it (sends `X-Project-Id` and emits `/project/{id}/...` links).
+    Override per-invocation with the global `--project <id>` flag or the
+    `DEEPVISTA_PROJECT_ID` env var. `project clear` falls back to the backend
+    default.
+    """
+
+
+@project_group.command("list")
+@click.pass_context
+def project_list(ctx: click.Context) -> None:
+    """List projects you own or that are shared with you."""
+    projects = _projects(ctx)
+    result = {"projects": projects, "count": len(projects), "current": ctx.obj.project_id}
+    format_output(
+        result,
+        ctx.obj.output_format,
+        columns=PROJECT_COLUMNS,
+        title="Projects",
+        entity_type="project",
+    )
+
+
+@project_group.command("current")
+@click.pass_context
+def project_current(ctx: click.Context) -> None:
+    """Show the project the backend resolves for this CLI right now.
+
+    Reflects the working project (`X-Project-Id`) when one is set, else the
+    user's backend default project.
+    """
+    data = _client(ctx).get("/projects/me")
+    format_output(data, ctx.obj.output_format, title="Current project", entity_type="project")
+
+
+@project_group.command("show")
+@click.argument("project_id", required=False)
+@click.pass_context
+def project_show(ctx: click.Context, project_id: str | None) -> None:
+    """Show metadata for a project (defaults to the resolved current project)."""
+    if project_id:
+        data = _client(ctx).get(f"/projects/{project_id}")
+    else:
+        data = _client(ctx).get("/projects/me")
+    format_output(data, ctx.obj.output_format, title="Project", entity_type="project")
+
+
+@project_group.command("use")
+@click.argument("project_id")
+@click.pass_context
+def project_use(ctx: click.Context, project_id: str) -> None:
+    """Set the working project for this profile after validating membership.
+
+    Persists ``project_id`` in the active profile. This is client-side scoping
+    only — it does not change the backend's per-user default project.
+    """
+    projects = _projects(ctx)
+    match = next((p for p in projects if p.get("id") == project_id), None)
+    if match is None:
+        output_error(
+            EXIT_VALIDATION_ERROR,
+            f"Project {project_id} not found or not accessible",
+            detail="Run `deepvista project list` to see available projects.",
+        )
+
+    set_working_project(ctx.obj.profile, project_id)
+    ctx.obj.project_id = project_id
+    result = {
+        "working_project": project_id,
+        "name": match.get("name"),
+        "profile": ctx.obj.profile,
+    }
+    format_output(result, ctx.obj.output_format, title="Working project set")
+
+
+@project_group.command("clear")
+@click.pass_context
+def project_clear(ctx: click.Context) -> None:
+    """Unset the working project; fall back to the backend default."""
+    cleared = clear_working_project(ctx.obj.profile)
+    ctx.obj.project_id = None
+    format_output(
+        {"cleared": cleared, "profile": ctx.obj.profile},
+        ctx.obj.output_format,
+        title="Working project cleared",
+    )

--- a/deepvista_cli/commands/session.py
+++ b/deepvista_cli/commands/session.py
@@ -137,6 +137,7 @@ def session_init(
             title="Session init (skipped)",
             entity_type=SESSION_ENTITY_TYPE,
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -162,6 +163,7 @@ def session_init(
             title="Session card (existing)",
             entity_type=SESSION_ENTITY_TYPE,
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -189,6 +191,7 @@ def session_init(
             ctx.obj.output_format,
             entity_type=SESSION_ENTITY_TYPE,
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -204,6 +207,7 @@ def session_init(
         title="Session card (created)",
         entity_type=SESSION_ENTITY_TYPE,
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -236,6 +240,7 @@ def session_tick(ctx: click.Context, session_id: str, transcript: str, dry_run: 
             title="Session tick (no-op)",
             entity_type=SESSION_ENTITY_TYPE,
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -286,6 +291,7 @@ def session_tick(ctx: click.Context, session_id: str, transcript: str, dry_run: 
             ctx.obj.output_format,
             entity_type=SESSION_ENTITY_TYPE,
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -304,6 +310,7 @@ def session_tick(ctx: click.Context, session_id: str, transcript: str, dry_run: 
         title="Session tick",
         entity_type=SESSION_ENTITY_TYPE,
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -345,6 +352,7 @@ def session_finalize(
             ctx.obj.output_format,
             entity_type=SESSION_ENTITY_TYPE,
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -362,4 +370,5 @@ def session_finalize(
         title="Session finalized",
         entity_type=SESSION_ENTITY_TYPE,
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )

--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -19,6 +19,7 @@ import click
 
 from deepvista_cli import skill_catalog
 from deepvista_cli.client.http import DeepVistaClient
+from deepvista_cli.commands import apply_project_override, project_option
 from deepvista_cli.output.formatter import format_output, output_error
 from deepvista_cli.workflow_doc import (
     WorkflowDocument,
@@ -64,12 +65,14 @@ def skill_group() -> None:
 @skill_group.command("list")
 @click.option("--limit", default=20, help="Max results (default 20).")
 @click.option("--page", "page_number", default=1, help="Page number.")
+@project_option
 @click.pass_context
-def skill_list(ctx: click.Context, limit: int, page_number: int) -> None:
+def skill_list(ctx: click.Context, limit: int, page_number: int, project_override: str | None) -> None:
     """List all Skills.
 
     Read-only — never modifies your Skills.
     """
+    apply_project_override(ctx, project_override)
     data = _client(ctx).post(
         "/get_context_cards",
         {
@@ -87,17 +90,20 @@ def skill_list(ctx: click.Context, limit: int, page_number: int) -> None:
         title="Skills",
         entity_type="skill",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
 @skill_group.command("get")
 @click.argument("skill_id")
+@project_option
 @click.pass_context
-def skill_get(ctx: click.Context, skill_id: str) -> None:
+def skill_get(ctx: click.Context, skill_id: str, project_override: str | None) -> None:
     """Get a Skill by ID.
 
     Read-only — never modifies the Skill.
     """
+    apply_project_override(ctx, project_override)
     data = _client(ctx).post("/get_context_card", {"card_id": skill_id, "card_type": "skill"})
     # Remind host agents that workflow skills must be executed via `skill run`,
     # not by reading the body with `skill get` and driving phases manually.
@@ -107,7 +113,12 @@ def skill_get(ctx: click.Context, skill_id: str) -> None:
             f"workflow skill — to execute with phase tracking run: deepvista skill run --mode host {skill_id}"
         )
     format_output(
-        data, ctx.obj.output_format, title=f"Skill: {skill_id}", entity_type="skill", base_url=ctx.obj.auth_url
+        data,
+        ctx.obj.output_format,
+        title=f"Skill: {skill_id}",
+        entity_type="skill",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -266,6 +277,7 @@ def emit_host_run_packet(
             ctx.obj.output_format,
             entity_type="skill",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -314,6 +326,7 @@ def _skill_run_deepvista(
             ctx.obj.output_format,
             entity_type="skill",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -413,6 +426,7 @@ def skill_phase_open(ctx: click.Context, skill_id: str, phase_label: str, dry_ru
             ctx.obj.output_format,
             entity_type="skill",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -422,6 +436,7 @@ def skill_phase_open(ctx: click.Context, skill_id: str, phase_label: str, dry_ru
         ctx.obj.output_format,
         entity_type="skill",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -468,6 +483,7 @@ def skill_phase_done(
             ctx.obj.output_format,
             entity_type="skill",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -491,6 +507,7 @@ def skill_phase_done(
         ctx.obj.output_format,
         entity_type="skill",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -511,6 +528,7 @@ def skill_phase_reset(ctx: click.Context, skill_id: str, phase_label: str, dry_r
             ctx.obj.output_format,
             entity_type="skill",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -520,6 +538,7 @@ def skill_phase_reset(ctx: click.Context, skill_id: str, phase_label: str, dry_r
         ctx.obj.output_format,
         entity_type="skill",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -545,7 +564,9 @@ def skill_phase_pause(ctx: click.Context, skill_id: str, reason: str) -> None:
         "reason": reason,
         "resume_with": f"deepvista skill run --mode host {skill_id}",
     }
-    format_output(out, ctx.obj.output_format, entity_type="skill", base_url=ctx.obj.auth_url)
+    format_output(
+        out, ctx.obj.output_format, entity_type="skill", base_url=ctx.obj.auth_url, project_id=ctx.obj.project_id
+    )
     sys.exit(2)
 
 
@@ -599,6 +620,7 @@ def skill_phase_run_on_deepvista(
             ctx.obj.output_format,
             entity_type="skill",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -631,6 +653,7 @@ def skill_complete(ctx: click.Context, skill_id: str, review: str, dry_run: bool
             ctx.obj.output_format,
             entity_type="skill",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -659,7 +682,14 @@ def skill_status(ctx: click.Context, run_id: str) -> None:
         "visibility": session.get("visibility", ""),
         "created_at": session.get("created_at", ""),
     }
-    format_output(result, ctx.obj.output_format, title=f"Run: {run_id}", entity_type="chat", base_url=ctx.obj.auth_url)
+    format_output(
+        result,
+        ctx.obj.output_format,
+        title=f"Run: {run_id}",
+        entity_type="chat",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -833,6 +863,7 @@ def skill_discover(ctx: click.Context, search: str | None, category: str | None,
         title="Marketplace Skills",
         entity_type="skill",
         base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
     )
 
 
@@ -855,6 +886,7 @@ def skill_install(ctx: click.Context, skill_id: str, dry_run: bool) -> None:
             ctx.obj.output_format,
             entity_type="skill",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 
@@ -1192,6 +1224,7 @@ def skill_create_from_note(
             ctx.obj.output_format,
             entity_type="skill",
             base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
         )
         return
 

--- a/deepvista_cli/config.py
+++ b/deepvista_cli/config.py
@@ -119,6 +119,32 @@ def delete_profile(name: str) -> bool:
     return False
 
 
+def set_working_project(profile_name: str, project_id: str) -> None:
+    """Persist the CLI's working ``project_id`` inside a profile.
+
+    Merges into the existing profile dict so other settings (``api_url``,
+    ``auth_url``, …) are preserved. This is purely client-side scoping; it
+    does not touch the backend's per-user default project.
+    """
+    profile = dict(get_profile(profile_name))
+    profile["project_id"] = project_id
+    set_profile(profile_name, profile)
+
+
+def clear_working_project(profile_name: str) -> bool:
+    """Unset the working ``project_id`` in a profile.
+
+    Returns True if a working project was set (and is now removed). After
+    clearing, the CLI falls back to the backend's default project.
+    """
+    profile = dict(get_profile(profile_name))
+    if "project_id" not in profile:
+        return False
+    del profile["project_id"]
+    set_profile(profile_name, profile)
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Session CWD skip patterns (DV-862)
 # ---------------------------------------------------------------------------
@@ -168,17 +194,35 @@ class CLIConfig:
     verbose: bool = False
     dry_run: bool = False
     profile: str = "default"
+    # The CLI's **working project** — scopes every request via the
+    # ``X-Project-Id`` header and prefixes web links with ``/project/{id}``.
+    # Distinct from the backend's per-user *default project*: setting it here
+    # does NOT call ``set_default``/``activate``, it only tells the CLI which
+    # project to scope to. ``None`` → backend resolves the user's default.
+    # Resolution order (highest wins): ``--project`` flag → ``DEEPVISTA_PROJECT_ID``
+    # env → profile ``project_id`` → ``None``.
+    project_id: str | None = None
 
     def apply_profile(self, profile_name: str) -> None:
-        """Apply settings from a named profile."""
-        profile = get_profile(profile_name)
-        if not profile:
-            return
+        """Apply settings from a named profile.
 
-        if "api_url" in profile:
-            self.api_url = profile["api_url"]
-        if "auth_url" in profile:
-            self.auth_url = profile["auth_url"]
+        Resolution order for ``project_id`` (lowest precedence first; callers
+        layer ``--project`` / ``DEEPVISTA_PROJECT_ID`` on top afterward):
+        profile ``project_id`` → ``DEEPVISTA_PROJECT_ID`` env.
+        """
+        profile = get_profile(profile_name)
+        if profile:
+            if "api_url" in profile:
+                self.api_url = profile["api_url"]
+            if "auth_url" in profile:
+                self.auth_url = profile["auth_url"]
+            if profile.get("project_id"):
+                self.project_id = profile["project_id"]
+
+        # Env var overrides the persisted working project.
+        env_project = os.environ.get("DEEPVISTA_PROJECT_ID")
+        if env_project:
+            self.project_id = env_project
 
     def ensure_config_dir(self) -> Path:
         CONFIG_DIR.mkdir(parents=True, exist_ok=True)

--- a/deepvista_cli/main.py
+++ b/deepvista_cli/main.py
@@ -30,6 +30,7 @@ from deepvista_cli.commands.chat import chat_group
 from deepvista_cli.commands.config import config_group
 from deepvista_cli.commands.lint import lint_command
 from deepvista_cli.commands.notes import notes_group
+from deepvista_cli.commands.project import project_group
 from deepvista_cli.commands.schedule import schedule_group
 from deepvista_cli.commands.session import session_group
 from deepvista_cli.commands.skill import skill_group
@@ -59,13 +60,29 @@ class _RootGroup(click.Group):
 @click.option("--dry-run", is_flag=True, default=False, help="Show what would be sent without executing.")
 @click.option("--api-url", default=None, help=f"Override backend URL (default: {DEFAULT_API_URL}).")
 @click.option("--profile", default="default", help="Use a named config profile (e.g. local, staging).")
+@click.option(
+    "--project",
+    "project_id",
+    default=None,
+    help="Scope this invocation to a project id (overrides the profile working project / DEEPVISTA_PROJECT_ID).",
+)
 @click.pass_context
 def cli(
-    ctx: click.Context, output_format: str, verbose: bool, dry_run: bool, api_url: str | None, profile: str
+    ctx: click.Context,
+    output_format: str,
+    verbose: bool,
+    dry_run: bool,
+    api_url: str | None,
+    profile: str,
+    project_id: str | None,
 ) -> None:
     """DeepVista CLI — chat, notes, skills, and knowledge cards from your terminal.
 
-    Resources: card · skill · chat
+    Resources: project · card · skill · chat
+
+    Requests are scoped to a project: pick one with `deepvista project use <id>`
+    (persisted per profile), or override per call with `--project <id>` /
+    `DEEPVISTA_PROJECT_ID`. When none is set the backend uses your default project.
     """
     config = CLIConfig(
         output_format=output_format,
@@ -74,18 +91,24 @@ def cli(
         profile=profile,
     )
 
-    # Apply profile settings (env vars and CLI flags still take precedence)
+    # Apply profile settings (resolves project_id from profile + DEEPVISTA_PROJECT_ID).
+    # CLI flags still take precedence below.
     config.apply_profile(profile)
 
-    # CLI flag overrides everything
+    # CLI flags override everything
     if api_url:
         config.api_url = api_url
+    if project_id:
+        config.project_id = project_id
 
     # Attach config + lazy client to context
     ctx.ensure_object(CLIConfig)
     ctx.obj = config
     ctx.obj._client = DeepVistaClient(config)
 
+
+# Project scoping — pick a working project that scopes every other command.
+cli.add_command(project_group)
 
 # Primary resources
 # `card` is the canonical knowledge-base command; `vistabase` is a

--- a/deepvista_cli/output/formatter.py
+++ b/deepvista_cli/output/formatter.py
@@ -26,6 +26,7 @@ from deepvista_cli.config import DEFAULT_AUTH_URL
 URL_PATTERNS = {
     "vistabase": "/vistabase/{id}",
     "card": "/vistabase/{id}",
+    "project": "/project/{id}",
     "note": "/notes/{id}",
     "skill": "/skills/{id}",
     "chat": "/chat/{id}",
@@ -37,27 +38,40 @@ URL_PATTERNS = {
 
 # Known entity keys in API responses (singular for wrapped, plural for lists).
 # Entity type matches the key name except where overridden below.
-ENTITY_KEYS = ("card", "note", "skill", "session")
+ENTITY_KEYS = ("card", "note", "skill", "session", "project")
 _KEY_TYPE_OVERRIDES = {"session": "chat"}
 GENERIC_LIST_KEYS = ("results", "similar")
 
 
-def generate_url(entity_id: str, entity_type: str = "card", base_url: str = DEFAULT_AUTH_URL) -> str:
+def generate_url(
+    entity_id: str,
+    entity_type: str = "card",
+    base_url: str = DEFAULT_AUTH_URL,
+    project_id: str | None = None,
+) -> str:
     """Generate a web app URL for an entity.
 
     Args:
         entity_id: The UUID of the entity
         entity_type: Type of entity (card, note, skill, chat, person, organization, topic, keypoint)
         base_url: Base URL of the web app (defaults to https://app.deepvista.ai)
+        project_id: Working project id. When set, the path is prefixed with
+            ``/project/{project_id}`` to match the project-scoped frontend
+            routes (mirrors the web app's ``withProjectPrefix()``).
 
     Returns:
         Full URL to the entity in the web app
     """
     pattern = URL_PATTERNS.get(entity_type, URL_PATTERNS["card"])
-    return f"{base_url.rstrip('/')}{pattern.format(id=entity_id)}"
+    path = pattern.format(id=entity_id)
+    if project_id:
+        path = f"/project/{project_id}{path}"
+    return f"{base_url.rstrip('/')}{path}"
 
 
-def add_url_to_entity(entity: dict, entity_type: str = "card", base_url: str = DEFAULT_AUTH_URL) -> dict:
+def add_url_to_entity(
+    entity: dict, entity_type: str = "card", base_url: str = DEFAULT_AUTH_URL, project_id: str | None = None
+) -> dict:
     """Add a 'url' field to an entity dict if it has an 'id' field.
 
     Args:
@@ -78,12 +92,16 @@ def add_url_to_entity(entity: dict, entity_type: str = "card", base_url: str = D
     # Map known entity types; fall back to the passed entity_type for unknown types
     if effective_type not in URL_PATTERNS:
         effective_type = entity_type
-    result["url"] = generate_url(entity["id"], effective_type, base_url)
+    result["url"] = generate_url(entity["id"], effective_type, base_url, project_id=project_id)
     return result
 
 
 def add_urls_to_data(
-    data: Any, entity_type: str = "card", base_url: str = DEFAULT_AUTH_URL, list_key: str | None = None
+    data: Any,
+    entity_type: str = "card",
+    base_url: str = DEFAULT_AUTH_URL,
+    list_key: str | None = None,
+    project_id: str | None = None,
 ) -> Any:
     """Add URLs to entities in various data structures.
 
@@ -102,19 +120,21 @@ def add_urls_to_data(
         Data with URLs added to entities
     """
     if isinstance(data, list):
-        return [add_url_to_entity(item, entity_type, base_url) for item in data]
+        return [add_url_to_entity(item, entity_type, base_url, project_id=project_id) for item in data]
 
     if isinstance(data, dict):
         # If it's a single entity with an 'id', add URL directly
         if "id" in data and list_key is None:
-            return add_url_to_entity(data, entity_type, base_url)
+            return add_url_to_entity(data, entity_type, base_url, project_id=project_id)
 
         result = dict(data)
 
         # Wrapped single-entity responses (e.g. {"card": {..., "id": "..."}, "created": true})
         for key in ENTITY_KEYS:
             if key in result and isinstance(result[key], dict) and "id" in result[key]:
-                result[key] = add_url_to_entity(result[key], _KEY_TYPE_OVERRIDES.get(key, key), base_url)
+                result[key] = add_url_to_entity(
+                    result[key], _KEY_TYPE_OVERRIDES.get(key, key), base_url, project_id=project_id
+                )
 
         # List responses (e.g. {"cards": [...], "total": 10})
         plural_key_to_type = {f"{k}s": _KEY_TYPE_OVERRIDES.get(k, k) for k in ENTITY_KEYS}
@@ -124,7 +144,9 @@ def add_urls_to_data(
         for key in keys_to_check:
             if key in result and isinstance(result[key], list):
                 item_type = plural_key_to_type.get(key, entity_type)
-                result[key] = [add_url_to_entity(item, item_type, base_url) for item in result[key]]
+                result[key] = [
+                    add_url_to_entity(item, item_type, base_url, project_id=project_id) for item in result[key]
+                ]
 
         return result
 
@@ -186,6 +208,7 @@ def format_output(
     title: str | None = None,
     entity_type: str = "card",
     base_url: str = DEFAULT_AUTH_URL,
+    project_id: str | None = None,
 ) -> None:
     """Route output to the correct formatter based on --format flag.
 
@@ -198,9 +221,11 @@ def format_output(
         title: Title for table output
         entity_type: Type of entity for URL generation (card, note, skill, chat)
         base_url: Base URL for the web app
+        project_id: Working project id; prefixes emitted links with
+            ``/project/{project_id}`` to match project-scoped frontend routes.
     """
     # Add URLs to entities
-    data_with_urls = add_urls_to_data(data, entity_type=entity_type, base_url=base_url)
+    data_with_urls = add_urls_to_data(data, entity_type=entity_type, base_url=base_url, project_id=project_id)
 
     # Update columns to include 'url' if 'id' was in the original columns
     if columns and "id" in columns:

--- a/skills/deepvista/SKILL.md
+++ b/skills/deepvista/SKILL.md
@@ -44,6 +44,7 @@ other reference file assumes you know it.
 | Subcommand | Use when | Reference |
 |---|---|---|
 | `deepvista auth` / `agents` / `config` / `upgrade` | authenticating, registering an agent, switching profiles, checking for updates | [shared.md](reference/shared.md) |
+| `deepvista project` | listing projects, picking / switching the **working project** that scopes every other command (`X-Project-Id` + `/project/{id}/…` links) | [project.md](reference/project.md) |
 | `deepvista notes` | taking a note the user **explicitly asked to record**, listing / updating / deleting notes, quick-capture of a single-line fact, re-indexing notes for entity extraction | [notes.md](reference/notes.md) |
 | `deepvista session` | recording an agent conversation transcript as a rolling `type=session` card via the `init` / `tick` / `finalize` hook lifecycle | [session.md](reference/session.md) |
 | `deepvista lint` | periodic LLM health check over the vistabase — duplicates, contradictions, stale claims, orphans, missing cross-references, data gaps | [lint.md](reference/lint.md) |

--- a/skills/deepvista/reference/project.md
+++ b/skills/deepvista/reference/project.md
@@ -1,0 +1,53 @@
+# project — scope the CLI to a project
+
+Every DeepVista entity is scoped to a **project**. The CLI resolves each request
+to a *working project* and sends it as the `X-Project-Id` header; emitted web
+links are prefixed with `/project/{id}/…` so they resolve in the app. When no
+working project is set the backend falls back to your default project (unchanged
+legacy behavior).
+
+The working project is **client-side scoping only** — `project use` does not
+touch your server-side default project (no `set_default`/`activate`).
+
+## Commands
+
+```bash
+deepvista project list           # list owned + shared projects (id, name, role)
+deepvista project current        # the project the backend resolves right now
+deepvista project show [<id>]    # metadata for a project (defaults to current)
+deepvista project use <id>       # set the working project for this profile
+deepvista project clear          # unset the working project
+```
+
+`project use <id>` validates that `<id>` is accessible (it must appear in
+`project list`); an unknown/inaccessible id exits with code 3.
+
+## Resolution order
+
+Highest precedence wins:
+
+1. `--project <id>` — global flag (before the resource) **or** the per-command
+   override on `card`/`notes`/`chat`/`skill` `list`/`get`/`create`/`send`.
+2. `DEEPVISTA_PROJECT_ID` environment variable.
+3. The profile's persisted working project (`project use`).
+4. None → the backend resolves your default project.
+
+```bash
+# one-off override for a single call (per-command flag)
+deepvista card list --project 1234-…
+
+# one-off override for the whole invocation (global flag, before the resource)
+deepvista --project 1234-… card list
+
+# scope an entire shell session
+export DEEPVISTA_PROJECT_ID=1234-…
+```
+
+The working project is stored in the active profile in
+`~/.config/deepvista/config.json`, alongside `api_url`/`auth_url`. Switching
+profiles (`--profile`) switches working project too.
+
+## Out of scope
+
+Creating, deleting, or sharing projects from the CLI is not supported yet — use
+the web app. `project use` only selects an existing project.

--- a/skills/deepvista/reference/shared.md
+++ b/skills/deepvista/reference/shared.md
@@ -23,9 +23,27 @@ deepvista [GLOBAL FLAGS] <resource> <command> [options]
 **Wrong:** `deepvista card list --profile staging`
 **Right:** `deepvista --profile staging card list`
 
-Key global flags: `--profile NAME`, `--format json|table`, `--verbose`, `--dry-run`, `--api-url URL`.
+Key global flags: `--profile NAME`, `--project ID`, `--format json|table`, `--verbose`, `--dry-run`, `--api-url URL`.
 
 `--dry-run` is supported on every stateful command — use it to preview before writing.
+
+## Project scoping
+
+Every entity (card, note, chat, skill, …) lives inside a **project**. The CLI
+scopes requests to a *working project* and sends it as the `X-Project-Id`
+header; web links it emits are prefixed `/project/{id}/…` to match the app.
+
+```bash
+deepvista project list            # projects you own or that are shared with you
+deepvista project current         # the project the backend resolves right now
+deepvista project use <id>        # set the working project for this profile
+deepvista project clear           # unset → fall back to the backend default
+```
+
+Resolution order (highest wins): `--project <id>` flag → `DEEPVISTA_PROJECT_ID`
+env → profile working project (`project use`) → none (backend default). The
+working project is client-side scoping only — it does **not** change your
+server-side default project. See [reference/project.md](project.md).
 
 ## Profiles
 

--- a/tests/test_agent_id_tagging.py
+++ b/tests/test_agent_id_tagging.py
@@ -180,6 +180,7 @@ def _invoke_quick(monkeypatch: pytest.MonkeyPatch, agent_id: str | None) -> _Rec
     class _Obj:
         output_format = "json"
         auth_url = "http://localhost"
+        project_id = None
 
     @click.group()
     @click.pass_context

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -1,0 +1,267 @@
+"""Tests for project scoping (DV-1294):
+
+- X-Project-Id header injection in the HTTP client
+- working-project config persistence + resolution order
+- project-prefixed web-link generation
+- the `deepvista project` command group + `--project` override
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+import deepvista_cli.config as cfg
+from deepvista_cli.client.http import DeepVistaClient
+from deepvista_cli.config import CLIConfig
+from deepvista_cli.main import cli
+from deepvista_cli.output.formatter import add_urls_to_data, generate_url
+
+# ---------------------------------------------------------------------------
+# Fixtures / stubs
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def isolated_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point the (already-imported) config module at a temp dir.
+
+    Functions in ``deepvista_cli.config`` reference ``CONFIG_DIR`` /
+    ``PROFILES_PATH`` as module globals at call time, so patching the attributes
+    redirects reads and writes without reloading the module (which would
+    desync the class ``main.cli`` already imported).
+    """
+    config_dir = tmp_path / ".config" / "deepvista"
+    monkeypatch.setattr(cfg, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(cfg, "PROFILES_PATH", config_dir / "config.json")
+    monkeypatch.delenv("DEEPVISTA_PROJECT_ID", raising=False)
+    return config_dir
+
+
+class _StubCtxClient:
+    """Minimal stand-in for the real client attached to ctx.obj._client."""
+
+    def __init__(self) -> None:
+        self.responses: dict[str, list[Any]] = {}
+        # Records (method, path, resolved project_id) so tests can assert the
+        # working project that *would* have been sent as X-Project-Id.
+        self.calls: list[tuple[str, str, str | None]] = []
+
+    def queue(self, path: str, response: Any) -> None:
+        self.responses.setdefault(path, []).append(response)
+
+    def _pop(self, path: str) -> Any:
+        q = self.responses.get(path)
+        if not q:
+            raise AssertionError(f"no response queued for {path}")
+        return q.pop(0)
+
+
+def _install_stub_client(monkeypatch: pytest.MonkeyPatch, stub: _StubCtxClient) -> None:
+    """Swap the real client's __init__/get/post so tests can drive responses
+    and observe the resolved project id (``self.config.project_id``)."""
+
+    def fake_init(self, config):  # type: ignore[no-untyped-def]
+        self.config = config
+
+    def fake_get(self, path, params=None, extra_headers=None):  # type: ignore[no-untyped-def]
+        stub.calls.append(("GET", path, self.config.project_id))
+        return stub._pop(path)
+
+    def fake_post(self, path, body=None, extra_headers=None):  # type: ignore[no-untyped-def]
+        stub.calls.append(("POST", path, self.config.project_id))
+        return stub._pop(path)
+
+    monkeypatch.setattr(DeepVistaClient, "__init__", fake_init)
+    monkeypatch.setattr(DeepVistaClient, "get", fake_get)
+    monkeypatch.setattr(DeepVistaClient, "post", fake_post)
+
+
+# ---------------------------------------------------------------------------
+# 1. X-Project-Id header injection
+# ---------------------------------------------------------------------------
+
+
+def _patch_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    import deepvista_cli.client.http as http_mod
+    import deepvista_cli.client.origin as origin_mod
+
+    monkeypatch.setattr(http_mod, "get_valid_token", lambda _path: types.SimpleNamespace(access_token="tok-123"))
+    monkeypatch.setattr(origin_mod, "build_origin", lambda: {})
+
+
+def test_auth_headers_include_project_id_when_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_auth(monkeypatch)
+    client = DeepVistaClient(CLIConfig(project_id="proj-1"))
+    headers = client._auth_headers()
+    assert headers["X-Project-Id"] == "proj-1"
+    assert headers["Authorization"] == "Bearer tok-123"
+
+
+def test_auth_headers_omit_project_id_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_auth(monkeypatch)
+    client = DeepVistaClient(CLIConfig(project_id=None))
+    headers = client._auth_headers()
+    assert "X-Project-Id" not in headers
+
+
+# ---------------------------------------------------------------------------
+# 2. Config persistence + resolution order
+# ---------------------------------------------------------------------------
+
+
+def test_set_and_clear_working_project_preserves_other_keys(isolated_config: Path) -> None:
+    cfg.set_profile("default", {"api_url": "https://api.example.com"})
+    cfg.set_working_project("default", "proj-abc")
+
+    profile = cfg.get_profile("default")
+    assert profile["project_id"] == "proj-abc"
+    assert profile["api_url"] == "https://api.example.com"  # untouched
+
+    assert cfg.clear_working_project("default") is True
+    profile = cfg.get_profile("default")
+    assert "project_id" not in profile
+    assert profile["api_url"] == "https://api.example.com"
+    # Clearing again is a no-op.
+    assert cfg.clear_working_project("default") is False
+
+
+def test_apply_profile_resolves_project_id(isolated_config: Path) -> None:
+    cfg.set_working_project("default", "proj-from-profile")
+    config = CLIConfig(profile="default")
+    config.apply_profile("default")
+    assert config.project_id == "proj-from-profile"
+
+
+def test_env_var_overrides_profile(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg.set_working_project("default", "proj-from-profile")
+    monkeypatch.setenv("DEEPVISTA_PROJECT_ID", "proj-from-env")
+    config = CLIConfig(profile="default")
+    config.apply_profile("default")
+    assert config.project_id == "proj-from-env"
+
+
+# ---------------------------------------------------------------------------
+# 3. Project-prefixed web links
+# ---------------------------------------------------------------------------
+
+
+def test_generate_url_with_project_prefix() -> None:
+    url = generate_url("card-1", "card", "https://app.deepvista.ai", project_id="proj-9")
+    assert url == "https://app.deepvista.ai/project/proj-9/vistabase/card-1"
+
+
+def test_generate_url_without_project_prefix() -> None:
+    url = generate_url("card-1", "card", "https://app.deepvista.ai")
+    assert url == "https://app.deepvista.ai/vistabase/card-1"
+
+
+def test_format_output_links_are_project_scoped() -> None:
+    data = {"cards": [{"id": "c1", "type": "note"}]}
+    out = add_urls_to_data(data, entity_type="card", base_url="https://app.deepvista.ai", project_id="p1")
+    assert out["cards"][0]["url"] == "https://app.deepvista.ai/project/p1/notes/c1"
+
+
+# ---------------------------------------------------------------------------
+# 4. `deepvista project` command group
+# ---------------------------------------------------------------------------
+
+
+def test_project_list_returns_projects(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubCtxClient()
+    stub.queue("/projects", [{"id": "p1", "name": "Alpha", "role": "owner"}])
+    _install_stub_client(monkeypatch, stub)
+
+    result = CliRunner().invoke(cli, ["project", "list"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["count"] == 1
+    assert payload["projects"][0]["id"] == "p1"
+    # project links point at /project/{id}, not /vistabase/{id}.
+    assert payload["projects"][0]["url"].endswith("/project/p1")
+
+
+def test_project_use_persists_and_validates(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubCtxClient()
+    stub.queue("/projects", [{"id": "p1", "name": "Alpha"}, {"id": "p2", "name": "Beta"}])
+    _install_stub_client(monkeypatch, stub)
+
+    result = CliRunner().invoke(cli, ["project", "use", "p2"])
+    assert result.exit_code == 0, result.output
+    assert cfg.get_profile("default")["project_id"] == "p2"
+
+
+def test_project_use_rejects_inaccessible_id(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubCtxClient()
+    stub.queue("/projects", [{"id": "p1", "name": "Alpha"}])
+    _install_stub_client(monkeypatch, stub)
+
+    result = CliRunner().invoke(cli, ["project", "use", "nope"])
+    assert result.exit_code == cfg.EXIT_VALIDATION_ERROR
+    assert "project_id" not in cfg.get_profile("default")
+
+
+def test_project_current_hits_projects_me(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubCtxClient()
+    stub.queue("/projects/me", {"id": "p1", "name": "Alpha"})
+    _install_stub_client(monkeypatch, stub)
+
+    result = CliRunner().invoke(cli, ["project", "current"])
+    assert result.exit_code == 0, result.output
+    assert stub.calls == [("GET", "/projects/me", None)]
+
+
+def test_project_clear_unsets_working_project(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg.set_working_project("default", "p1")
+    stub = _StubCtxClient()
+    _install_stub_client(monkeypatch, stub)
+
+    result = CliRunner().invoke(cli, ["project", "clear"])
+    assert result.exit_code == 0, result.output
+    assert "project_id" not in cfg.get_profile("default")
+
+
+# ---------------------------------------------------------------------------
+# 5. --project resolution order through a real command
+# ---------------------------------------------------------------------------
+
+
+def _run_card_list(monkeypatch: pytest.MonkeyPatch, argv: list[str]) -> tuple[Any, _StubCtxClient]:
+    stub = _StubCtxClient()
+    stub.queue("/get_context_cards", {"cards": [], "has_more": False})
+    _install_stub_client(monkeypatch, stub)
+    result = CliRunner().invoke(cli, argv)
+    return result, stub
+
+
+def test_profile_working_project_scopes_commands(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg.set_working_project("default", "proj-profile")
+    result, stub = _run_card_list(monkeypatch, ["card", "list"])
+    assert result.exit_code == 0, result.output
+    assert stub.calls[0] == ("POST", "/get_context_cards", "proj-profile")
+
+
+def test_global_project_flag_overrides_profile(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg.set_working_project("default", "proj-profile")
+    result, stub = _run_card_list(monkeypatch, ["--project", "proj-flag", "card", "list"])
+    assert result.exit_code == 0, result.output
+    assert stub.calls[0] == ("POST", "/get_context_cards", "proj-flag")
+
+
+def test_per_command_project_override(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg.set_working_project("default", "proj-profile")
+    result, stub = _run_card_list(monkeypatch, ["card", "list", "--project", "proj-cmd"])
+    assert result.exit_code == 0, result.output
+    assert stub.calls[0] == ("POST", "/get_context_cards", "proj-cmd")
+
+
+def test_env_var_scopes_commands(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEEPVISTA_PROJECT_ID", "proj-env")
+    result, stub = _run_card_list(monkeypatch, ["card", "list"])
+    assert result.exit_code == 0, result.output
+    assert stub.calls[0] == ("POST", "/get_context_cards", "proj-env")

--- a/tests/test_project_commands.py
+++ b/tests/test_project_commands.py
@@ -186,6 +186,38 @@ def test_project_list_returns_projects(isolated_config: Path, monkeypatch: pytes
     assert payload["projects"][0]["url"].endswith("/project/p1")
 
 
+def test_project_list_slims_output_and_derives_role(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubCtxClient()
+    stub.queue(
+        "/projects",
+        [
+            {"id": "p1", "name": "Owned", "tags": ["a", "b"], "conversation_starters": [{}], "is_shared": False},
+            {"id": "p2", "name": "Shared", "permission": "editor", "is_shared": True},
+        ],
+    )
+    _install_stub_client(monkeypatch, stub)
+
+    result = CliRunner().invoke(cli, ["project", "list"])
+    assert result.exit_code == 0, result.output
+    projects = json.loads(result.output)["projects"]
+    # The noisy fat-model fields are dropped by default.
+    assert "tags" not in projects[0]
+    assert "conversation_starters" not in projects[0]
+    # Role is derived: owner when not shared, the explicit permission when shared.
+    assert projects[0]["role"] == "owner"
+    assert projects[1]["role"] == "editor"
+
+
+def test_project_list_full_keeps_raw_fields(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    stub = _StubCtxClient()
+    stub.queue("/projects", [{"id": "p1", "name": "Owned", "tags": ["a", "b"]}])
+    _install_stub_client(monkeypatch, stub)
+
+    result = CliRunner().invoke(cli, ["project", "list", "--full"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["projects"][0]["tags"] == ["a", "b"]
+
+
 def test_project_use_persists_and_validates(isolated_config: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     stub = _StubCtxClient()
     stub.queue("/projects", [{"id": "p1", "name": "Alpha"}, {"id": "p2", "name": "Beta"}])


### PR DESCRIPTION
Closes DV-1294

## Summary

Makes `deepvista-cli` a first-class **project-scoped** client, matching the web app (which routes under `/project/{id}/…` and sends `X-Project-Id` on every call). Previously the CLI sent no project header, had no notion of a working project, and emitted bare links (`/vistabase/{id}`) that 404/mis-route in the project-scoped app shell.

- **`project` command group** (`commands/project.py`): `list` · `current` · `show [<id>]` · `use <id>` · `clear`.
- **Working project config**: `CLIConfig.project_id`, persisted per-profile in `~/.config/deepvista/config.json` (`set_working_project`/`clear_working_project`). This is *client-side scoping only* — distinct from the backend's per-user default project; `use` never calls `set_default`/`activate`.
- **Resolution order** (highest wins): `--project` flag → `DEEPVISTA_PROJECT_ID` env → profile `project_id` → none (backend default).
- **`X-Project-Id` header**: injected in `DeepVistaClient._auth_headers()` when a working project is set, so it automatically covers `get/post/patch/delete/stream_sse`. Omitted when unset (unchanged legacy behavior).
- **Global `--project` flag** + per-command override on `card`/`notes`/`chat`/`skill` `list`/`get`/`create`/`send`. The override mutates `ctx.obj.project_id`, which the client reads lazily at request time — no need to thread `extra_headers` through every callsite.
- **Project-prefixed web links**: `generate_url()`/`format_output()` prefix `/project/{id}` when a project is known (mirrors the frontend's `withProjectPrefix()`), e.g. `https://app.deepvista.ai/project/{pid}/vistabase/{id}`. Links use `auth_url`.
- **Docs**: `reference/project.md` + project-scoping sections in `shared.md`/`SKILL.md`.

### Open questions (resolved per the issue's "lean" recommendations)
1. **Working project vs. backend default** — kept separate; no `--set-default` added (defer until asked).
2. **Link base** — confirmed links use `auth_url` + project id consistently.
3. **No project + multiple projects** — stay silent (unchanged behavior); no warning added.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pyright deepvista_cli/` clean (pre-commit scope)
- [x] `pytest` — 99 passed (17 new in `tests/test_project_commands.py`)
- [x] `gh skill publish --dry-run` passes with the new reference file
- [x] Manual: `deepvista --help`, `deepvista project --help` show the group + `--project` flag
- New tests cover: `X-Project-Id` injection (set/unset), config persistence + resolution order, `DEEPVISTA_PROJECT_ID` env, project-prefixed URL generation, `project use` membership validation (exit 3 on inaccessible id), and `--project` flag/env/per-command precedence.

CLI-only change (no `frontend/`), so no browser testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)