### PR TITLE
feat: task improvements — timeout, phase notes, workflow resume, and web-agent polling

### DIFF
--- a/deepvista_cli/commands/skill.py
+++ b/deepvista_cli/commands/skill.py
@@ -542,6 +542,45 @@ def skill_phase_reset(ctx: click.Context, skill_id: str, phase_label: str, dry_r
     )
 
 
+@skill_phase_group.command("note")
+@click.argument("skill_id")
+@click.argument("phase_label")
+@click.argument("note_text")
+@click.option("--dry-run", is_flag=True, default=False, help="Preview without writing.")
+@click.pass_context
+def skill_phase_note(ctx: click.Context, skill_id: str, phase_label: str, note_text: str, dry_run: bool) -> None:
+    """Set or update the dvNote annotation bubble next to a phase node.
+
+    The annotation appears as a side bubble in the workflow mermaid diagram —
+    useful for recording task dispatch status, short summaries, or interim results.
+    Calling this command again with different text replaces the previous note.
+    """
+    if dry_run:
+        format_output(
+            {
+                "dry_run": True,
+                "would": "set phase note",
+                "skill_id": skill_id,
+                "phase": phase_label,
+                "note_text": note_text,
+            },
+            ctx.obj.output_format,
+            entity_type="skill",
+            base_url=ctx.obj.auth_url,
+            project_id=ctx.obj.project_id,
+        )
+        return
+
+    result = _phase(ctx, skill_id, phase_label=phase_label, action="note", note_text=note_text)
+    format_output(
+        {"ok": True, "skill_id": skill_id, "phase": phase_label, "note": note_text, "title": result.get("title", "")},
+        ctx.obj.output_format,
+        entity_type="skill",
+        base_url=ctx.obj.auth_url,
+        project_id=ctx.obj.project_id,
+    )
+
+
 @skill_phase_group.command("pause")
 @click.argument("skill_id")
 @click.option("--reason", required=True, help="Short sentence explaining what's blocking the run.")

--- a/deepvista_cli/commands/tasks.py
+++ b/deepvista_cli/commands/tasks.py
@@ -507,7 +507,35 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
         result["created_at"] = created_at_raw
     if workflow_name:
         result["workflow"] = workflow_name
+
+    # Resume the triggering workflow run so the server can continue from where
+    # it dispatched this task. ``skill_id`` is stamped on the task at enqueue
+    # time; without it the parent run stays paused and never completes.
+    skill_id = str(task.get("skill_id") or "").strip()
+    if skill_id:
+        click.echo(f"  ↩ resuming workflow {skill_id[:8]}… via deepvista skill run", err=True)
+        _resume_workflow(ctx, skill_id)
+
     return result
+
+
+def _resume_workflow(ctx: click.Context, skill_id: str) -> None:
+    """Run ``deepvista skill run --mode host <skill_id>`` to resume the parent workflow."""
+    profile_flag = []
+    profile = getattr(ctx.obj, "profile", None)
+    if profile and profile != "default":
+        profile_flag = ["--profile", profile]
+    argv = [_deepvista_binary(), *profile_flag, "skill", "run", "--mode", "host", skill_id]
+    try:
+        subprocess.run(  # noqa: S603 — argv built from validated binary + literal args
+            argv,
+            timeout=TASK_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        click.echo(f"  [warn] skill resume timed out for {skill_id[:8]}…", err=True)
+    except OSError as exc:
+        click.echo(f"  [warn] skill resume failed: {exc}", err=True)
 
 
 def _claim_and_run_task_cards(ctx: click.Context, agent_id: str, project_id: str | None) -> list[dict]:

--- a/deepvista_cli/commands/tasks.py
+++ b/deepvista_cli/commands/tasks.py
@@ -387,9 +387,9 @@ def _execute_task(ctx: click.Context, agent_id: str, task: dict) -> dict:
 # headlessly via `claude -p "/deepvista <prompt>"`.
 # ---------------------------------------------------------------------------
 
-# A task prompt may legitimately drive a long Claude Code session (research,
-# multi-tool work), so it gets a more generous budget than a queued CLI command.
-TASK_RUN_TIMEOUT_SECONDS = 1800
+# Default cap for a task-card run. 3 minutes covers most local CLI operations;
+# callers can override per-task via the ``timeout_seconds`` frontmatter field.
+TASK_RUN_TIMEOUT_SECONDS = 180
 
 # Headless permission posture for unattended task runs. ``bypassPermissions``
 # skips every approval prompt — appropriate for a Machine the user has
@@ -456,6 +456,10 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
         click.echo(f"    {' · '.join(meta_parts)}", err=True)
     click.echo(f"    prompt: {task_label}", err=True)
 
+    # Per-task timeout: the enqueuing agent can override the default via
+    # the ``timeout_seconds`` frontmatter field (e.g. for long research tasks).
+    task_timeout = int(task.get("timeout_seconds") or 0) or TASK_RUN_TIMEOUT_SECONDS
+
     _done = threading.Event()
     _start = time.monotonic()
 
@@ -471,7 +475,7 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
             argv,
             capture_output=True,
             text=True,
-            timeout=TASK_RUN_TIMEOUT_SECONDS,
+            timeout=task_timeout,
             cwd=cwd,
         )
         exit_code = proc.returncode
@@ -480,7 +484,7 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
         if not output and proc.stderr:
             output = proc.stderr.strip()
     except subprocess.TimeoutExpired:
-        status, exit_code, output = "failed", None, f"claude run timed out after {TASK_RUN_TIMEOUT_SECONDS}s"
+        status, exit_code, output = "failed", None, f"claude run timed out after {task_timeout}s"
     except FileNotFoundError:
         status, exit_code, output = (
             "failed",
@@ -508,15 +512,40 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
     if workflow_name:
         result["workflow"] = workflow_name
 
+    skill_id = str(task.get("skill_id") or "").strip()
+    phase_label = str(task.get("phase_label") or "").strip()
+
+    # Update the workflow phase dvNote annotation so the diagram reflects the
+    # task result before resuming — the annotation is visible immediately in the UI.
+    if skill_id and phase_label:
+        status_icon = "✅" if status == "completed" else "❌"
+        short_output = (output or "")[:120]
+        if len(output or "") > 120:
+            short_output += "…"
+        note = f"{status_icon} Task {short_id} {status}."
+        if short_output:
+            note += f" {short_output}"
+        _update_phase_note(ctx, skill_id, phase_label, note)
+
     # Resume the triggering workflow run so the server can continue from where
     # it dispatched this task. ``skill_id`` is stamped on the task at enqueue
     # time; without it the parent run stays paused and never completes.
-    skill_id = str(task.get("skill_id") or "").strip()
     if skill_id:
         click.echo(f"  ↩ resuming workflow {skill_id[:8]}… via deepvista skill run", err=True)
         _resume_workflow(ctx, skill_id)
 
     return result
+
+
+def _update_phase_note(ctx: click.Context, skill_id: str, phase_label: str, note_text: str) -> None:
+    """Call ``POST /workflow_phase`` with action='note' to update the dvNote annotation."""
+    try:
+        _client(ctx).post(
+            "/workflow_phase",
+            {"card_id": skill_id, "phase_label": phase_label, "action": "note", "note_text": note_text},
+        )
+    except Exception as exc:
+        click.echo(f"  [warn] phase note update failed: {exc}", err=True)
 
 
 def _resume_workflow(ctx: click.Context, skill_id: str) -> None:

--- a/deepvista_cli/commands/tasks.py
+++ b/deepvista_cli/commands/tasks.py
@@ -431,7 +431,16 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
 
     permission_mode = os.environ.get("DEEPVISTA_TASK_PERMISSION_MODE", DEFAULT_TASK_PERMISSION_MODE)
     cwd = os.environ.get("DEEPVISTA_TASK_CWD") or os.getcwd()
-    argv = [_claude_binary(), "-p", f"/deepvista {prompt}", "--permission-mode", permission_mode]
+    # Inject task_id into the prompt so the local Claude Code agent can call
+    # `deepvista tasks note <task_id> "<note>"` to write intermediate progress
+    # notes that the web agent polling the card can see in real-time.
+    task_context = (
+        f"[Task ID: {task_id}. "
+        f"After completing each significant step — or if you need human input to continue — "
+        f"run: deepvista tasks note {task_id} \"<brief note>\" "
+        f"so the delegating agent can track your progress.]\n\n"
+    )
+    argv = [_claude_binary(), "-p", f"/deepvista {task_context}{prompt}", "--permission-mode", permission_mode]
 
     short_id = task_id[:8]
     title = task.get("title") or ""
@@ -1200,6 +1209,44 @@ def tasks_list(
         columns=TASK_CARD_COLUMNS,
         title="Tasks",
     )
+
+
+@tasks_group.command("note")
+@click.argument("task_id")
+@click.argument("note")
+@click.option("--type", "agent_type", default=None, help="Resolve agent by type from local storage.")
+@click.option("--role", "agent_role", default=None, help="Resolve agent by role (with --type).")
+@click.option("--project", "project_id", default=None, help="Restrict to the agent registered for this project ID.")
+@click.pass_context
+def tasks_note(
+    ctx: click.Context,
+    task_id: str,
+    note: str,
+    agent_type: str | None,
+    agent_role: str | None,
+    project_id: str | None,
+) -> None:
+    """Append a progress note to a running task card's run log (DV-1247).
+
+    Called by the local Claude Code agent after completing a step or when human
+    input is required. The web agent polling the task card sees these notes in
+    the description and can relay them to the user in real-time.
+
+    Example (from inside a headless claude -p run):
+        deepvista tasks note <task-id> "Step 1 done: found 3 failing tests"
+        deepvista tasks note <task-id> "Needs human: please approve the PR at github.com/…"
+    """
+    agent_id, resolved_project_id = _require_machine_agent_id(agent_type, agent_role, project_id)
+    headers = {"X-Project-Id": resolved_project_id} if resolved_project_id else None
+    data = _client(ctx).post(
+        f"/agents/{agent_id}/tasks/{task_id}/note",
+        {"note": note},
+        extra_headers=headers,
+    )
+    if not data.get("success"):
+        output_error(1, "Failed to append task note", data.get("error", "Unknown error"))
+        raise SystemExit(1)
+    click.echo(f"  ✎ note appended to task {task_id[:8]}…", err=True)
 
 
 @tasks_group.command("complete")

--- a/deepvista_cli/commands/tasks.py
+++ b/deepvista_cli/commands/tasks.py
@@ -387,9 +387,9 @@ def _execute_task(ctx: click.Context, agent_id: str, task: dict) -> dict:
 # headlessly via `claude -p "/deepvista <prompt>"`.
 # ---------------------------------------------------------------------------
 
-# Default cap for a task-card run. 3 minutes covers most local CLI operations;
+# Default cap for a task-card run. 10 minutes covers most local CLI operations;
 # callers can override per-task via the ``timeout_seconds`` frontmatter field.
-TASK_RUN_TIMEOUT_SECONDS = 180
+TASK_RUN_TIMEOUT_SECONDS = 600
 
 # Headless permission posture for unattended task runs. ``bypassPermissions``
 # skips every approval prompt — appropriate for a Machine the user has


### PR DESCRIPTION
## Summary

- **Auto-resume parent workflow**: after a task card with `skill_id` completes, calls `deepvista skill run --mode host <skill_id>` so the parent run resumes automatically.
- **Per-task timeout**: enqueuing agent can set `timeout_seconds` in the task frontmatter; CLI respects it (default 10 min).
- **dvNote phase annotation**: after a task completes, stamps the dispatching phase's dvNote bubble with ✅/❌ + short output excerpt — visible in the workflow diagram before resuming.
- **`deepvista skill phase note`**: new CLI command to set/update a dvNote annotation on any workflow phase node.
- **Web-agent polling support**: `_run_task_card` injects the `task_id` into the headless Claude prompt so the local agent can call `deepvista tasks note <task_id> "<note>"` at each step (or when human input is needed). Notes appear in the task card's run log and are read by the web agent's `wait_for_task` polling loop.
- **New `tasks note` command**: `deepvista tasks note <task_id> <note>` posts an intermediate progress note to the backend, closing the feedback loop between local execution and the cloud agent.

## Test plan

- [ ] Run a task with `skill_id` + `phase_label` — confirm the dvNote updates and the workflow resumes after completion.
- [ ] Run a task with `timeout_seconds: 30` — confirm the CLI enforces the shorter timeout.
- [ ] From inside a headless `claude -p` run, call `deepvista tasks note <id> "step done"` — confirm the note appears in the task card's run log.
- [ ] Run `deepvista tasks note --help` to confirm the new subcommand is registered.
- [ ] Run `deepvista skill phase note <id> "Phase Label" "text"` — confirm the diagram gains/updates a dvNote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T9UTDpFyf1f2hKwhS4ghpj