### PR TITLE
feat(DV-1324): add dv CLI alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ deepvista card +search "founder mindset"
 deepvista chat +send "What did I learn last week?"
 ```
 
+> **Tip:** `dv` is a short alias for `deepvista` — `dv <args>` and `deepvista <args>`
+> are fully interchangeable (e.g. `dv notes +quick "..."`).
+
 That's it. Your knowledge base is now accessible from any terminal.
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ Issues = "https://github.com/DeepVista-AI/deepvista-cli/issues"
 
 [project.scripts]
 deepvista = "deepvista_cli.main:cli"
+dv = "deepvista_cli.main:cli"        # short alias for `deepvista` (DV-1324)
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_entry_points.py
+++ b/tests/test_entry_points.py
@@ -1,0 +1,35 @@
+"""Regression tests for the CLI console-script entry points.
+
+`deepvista` is the canonical command; `dv` is a short alias (DV-1324). Both must
+stay mapped to the same callable so the two commands remain interchangeable.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+TARGET = "deepvista_cli.main:cli"
+PROJECT = "project"
+SCRIPTS = "scripts"
+DEEPVISTA = "deepvista"
+DV = "dv"
+
+
+def _scripts() -> dict:
+    data = tomllib.loads(PYPROJECT.read_text())
+    return data[PROJECT][SCRIPTS]
+
+
+def test_both_entry_points_registered() -> None:
+    scripts = _scripts()
+    assert DEEPVISTA in scripts, "canonical `deepvista` entry point is missing"
+    assert DV in scripts, "`dv` alias entry point is missing"
+
+
+def test_alias_points_to_same_target() -> None:
+    scripts = _scripts()
+    assert scripts[DEEPVISTA] == TARGET
+    assert scripts[DV] == scripts[DEEPVISTA], "`dv` must alias the same callable as `deepvista`"


### PR DESCRIPTION
Closes DV-1324

## Summary

Adds a short `dv` alias for the `deepvista` CLI so both commands invoke the same entry point and are fully interchangeable.

- **pyproject.toml** — register a second console script `dv = "deepvista_cli.main:cli"` alongside `deepvista`, pointing at the same Click group. Installers (`install.sh` / `install.ps1`) install the package via `uv tool` / `pipx` / `pip`, all of which materialise every `[project.scripts]` entry — so `dv` is created automatically on install with no installer change.
- **README** — document `dv` as the short form in the quick-start.
- **tests/test_entry_points.py** — regression test asserting both entry points stay mapped to the same callable.

Note: `--version` keeps `prog_name="deepvista"` (canonical), so `dv --version` prints `deepvista, version X`; `dv --help` shows the `dv` program name.

## Test plan

- [x] `uv run pytest` — 108 passed (incl. new `tests/test_entry_points.py`)
- [x] `uv run deepvista --version` -> `deepvista, version 1.1.0`
- [x] `uv run dv --version` -> `deepvista, version 1.1.0`
- [x] `uv run dv --help` -> `Usage: dv [OPTIONS] COMMAND [ARGS]...`
- [x] `uv run ruff check` / `ruff format` clean
