### PR TITLE
fix(tasks): use single-quoted f-string to avoid escaped double quotes in task note hint

### DIFF
--- a/deepvista_cli/commands/tasks.py
+++ b/deepvista_cli/commands/tasks.py
@@ -438,7 +438,7 @@ def _run_task_card(ctx: click.Context, agent_id: str, project_id: str | None, ta
     task_context = (
         f"[Task ID: {task_id}. "
         f"After completing each significant step — or if you need human input to continue — "
-        f"run: deepvista tasks note {task_id} \"<brief note>\" "
+        f'run: deepvista tasks note {task_id} "<brief note>" '
         f"so the delegating agent can track your progress.]\n\n"
     )
     argv = [_claude_binary(), "-p", f"/deepvista {task_context}{prompt}", "--permission-mode", permission_mode]


### PR DESCRIPTION
## Summary

- Replace escaped double quotes (`\"`) with a single-quoted f-string in the task context string inside `_run_task_card`
- The `<brief note>` placeholder now renders as literal double quotes without backslash escapes, which is cleaner and avoids potential shell-quoting issues when the string is passed to Claude

## Test plan

- [ ] Run a task via `deepvista tasks run` and confirm the injected prompt displays `"<brief note>"` (not `\"<brief note>\"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Ynt67rXMqnmYdicNE7dPb